### PR TITLE
remove artifact serving feature

### DIFF
--- a/api/v1alpha1/imagebuild_types.go
+++ b/api/v1alpha1/imagebuild_types.go
@@ -56,17 +56,8 @@ type ImageBuildSpec struct {
 	// RuntimeClassName specifies the runtime class to use for the build pod
 	RuntimeClassName string `json:"runtimeClassName,omitempty"`
 
-	// ServeArtifact determines whether to make the built artifact available for download
-	ServeArtifact bool `json:"serveArtifact,omitempty"`
-
-	// ServeExpiryHours specifies how long to serve the artifact before cleanup (default: 24)
-	ServeExpiryHours int32 `json:"serveExpiryHours,omitempty"`
-
 	// InputFilesServer indicates if there's a server for files referenced locally in the manifest
 	InputFilesServer bool `json:"inputFilesServer,omitempty"`
-
-	// ExposeRoute indicates whether to expose the a route for the artifacts
-	ExposeRoute bool `json:"exposeRoute,omitempty"`
 
 	// EnvSecretRef is the name of the secret containing environment variables for the build
 	// These environment variables will be available during the build process and can be used
@@ -132,20 +123,11 @@ type ImageBuildStatus struct {
 	// PVCName is the name of the PVC where the artifact is stored
 	PVCName string `json:"pvcName,omitempty"`
 
-	// ArtifactPath is the path inside the PVC where the artifact is stored
-	ArtifactPath string `json:"artifactPath,omitempty"`
-
-	// ArtifactFileName is the name of the artifact file inside the PVC
-	ArtifactFileName string `json:"artifactFileName,omitempty"`
-
 	// PipelineRunName is the name of the active PipelineRun for this build
 	PipelineRunName string `json:"pipelineRunName,omitempty"`
 
 	// PushTaskRunName is the name of the TaskRun for pushing artifacts to registry
 	PushTaskRunName string `json:"pushTaskRunName,omitempty"`
-
-	// ArtifactURL is the route URL created to expose the artifacts
-	ArtifactURL string `json:"artifactURL,omitempty"`
 
 	// Conditions represent the latest available observations of the ImageBuild's state
 	// +optional

--- a/api/v1alpha1/operatorconfig_types.go
+++ b/api/v1alpha1/operatorconfig_types.go
@@ -40,11 +40,6 @@ type BuildConfig struct {
 	// More info: https://kubernetes.io/docs/concepts/containers/runtime-class/
 	// +optional
 	RuntimeClassName string `json:"runtimeClassName,omitempty"`
-
-	// ServeExpiryHours specifies how long to serve build artifacts before automatic cleanup
-	// Default: 24
-	// +optional
-	ServeExpiryHours int32 `json:"serveExpiryHours,omitempty"`
 }
 
 // JumpstarterTargetMapping defines the Jumpstarter configuration for a specific build target
@@ -128,11 +123,6 @@ type OSBuildsConfig struct {
 	// More info: https://kubernetes.io/docs/concepts/containers/runtime-class/
 	// +optional
 	RuntimeClassName string `json:"runtimeClassName,omitempty"`
-
-	// ServeExpiryHours specifies how long to serve build artifacts before automatic cleanup
-	// Default: 24
-	// +optional
-	ServeExpiryHours int32 `json:"serveExpiryHours,omitempty"`
 
 	// ClusterRegistryRoute is the external route for the cluster's internal image registry
 	// Required for bootc builds to allow nested containers to pull builder images

--- a/bundle/manifests/automotive.sdv.cloud.redhat.com_imagebuilds.yaml
+++ b/bundle/manifests/automotive.sdv.cloud.redhat.com_imagebuilds.yaml
@@ -87,10 +87,6 @@ spec:
                 description: ExportOCI is the registry URL to push the disk image
                   as an OCI artifact
                 type: string
-              exposeRoute:
-                description: ExposeRoute indicates whether to expose the a route for
-                  the artifacts
-                type: boolean
               inputFilesServer:
                 description: InputFilesServer indicates if there's a server for files
                   referenced locally in the manifest
@@ -125,15 +121,6 @@ spec:
                 description: RuntimeClassName specifies the runtime class to use for
                   the build pod
                 type: string
-              serveArtifact:
-                description: ServeArtifact determines whether to make the built artifact
-                  available for download
-                type: boolean
-              serveExpiryHours:
-                description: 'ServeExpiryHours specifies how long to serve the artifact
-                  before cleanup (default: 24)'
-                format: int32
-                type: integer
               storageClass:
                 description: StorageClass is the name of the storage class to use
                   for the build PVC
@@ -145,17 +132,6 @@ spec:
           status:
             description: ImageBuildStatus defines the observed state of ImageBuild
             properties:
-              artifactFileName:
-                description: ArtifactFileName is the name of the artifact file inside
-                  the PVC
-                type: string
-              artifactPath:
-                description: ArtifactPath is the path inside the PVC where the artifact
-                  is stored
-                type: string
-              artifactURL:
-                description: ArtifactURL is the route URL created to expose the artifacts
-                type: string
               completionTime:
                 description: CompletionTime is when the build finished
                 format: date-time

--- a/bundle/manifests/automotive.sdv.cloud.redhat.com_operatorconfigs.yaml
+++ b/bundle/manifests/automotive.sdv.cloud.redhat.com_operatorconfigs.yaml
@@ -140,17 +140,12 @@ spec:
                       RuntimeClassName specifies the runtime class to use for the build pod
                       More info: https://kubernetes.io/docs/concepts/containers/runtime-class/
                     type: string
-                  serveExpiryHours:
-                    description: |-
-                      ServeExpiryHours specifies how long to serve build artifacts before automatic cleanup
-                      Default: 24
-                    format: int32
-                    type: integer
                   tolerations:
                     description: |-
                       Tolerations specifies tolerations to be added to build pods
                       Enables scheduling on tainted nodes for dedicated/exclusive access
-                      Example: [{"key": "automotive.sdv.cloud.redhat.com/dedicated", "operator": "Equal", "value": "builds", "effect": "NoSchedule"}]
+                      Example: [{"key": "automotive.sdv.cloud.redhat.com/dedicated", "operator": "Equal",
+                                "value": "builds", "effect": "NoSchedule"}]
                     items:
                       description: |-
                         The pod this Toleration is attached to tolerates any taint that matches

--- a/config/crd/bases/automotive.sdv.cloud.redhat.com_imagebuilds.yaml
+++ b/config/crd/bases/automotive.sdv.cloud.redhat.com_imagebuilds.yaml
@@ -87,10 +87,6 @@ spec:
                 description: ExportOCI is the registry URL to push the disk image
                   as an OCI artifact
                 type: string
-              exposeRoute:
-                description: ExposeRoute indicates whether to expose the a route for
-                  the artifacts
-                type: boolean
               inputFilesServer:
                 description: InputFilesServer indicates if there's a server for files
                   referenced locally in the manifest
@@ -125,15 +121,6 @@ spec:
                 description: RuntimeClassName specifies the runtime class to use for
                   the build pod
                 type: string
-              serveArtifact:
-                description: ServeArtifact determines whether to make the built artifact
-                  available for download
-                type: boolean
-              serveExpiryHours:
-                description: 'ServeExpiryHours specifies how long to serve the artifact
-                  before cleanup (default: 24)'
-                format: int32
-                type: integer
               storageClass:
                 description: StorageClass is the name of the storage class to use
                   for the build PVC
@@ -145,17 +132,6 @@ spec:
           status:
             description: ImageBuildStatus defines the observed state of ImageBuild
             properties:
-              artifactFileName:
-                description: ArtifactFileName is the name of the artifact file inside
-                  the PVC
-                type: string
-              artifactPath:
-                description: ArtifactPath is the path inside the PVC where the artifact
-                  is stored
-                type: string
-              artifactURL:
-                description: ArtifactURL is the route URL created to expose the artifacts
-                type: string
               completionTime:
                 description: CompletionTime is when the build finished
                 format: date-time

--- a/config/crd/bases/automotive.sdv.cloud.redhat.com_operatorconfigs.yaml
+++ b/config/crd/bases/automotive.sdv.cloud.redhat.com_operatorconfigs.yaml
@@ -140,12 +140,6 @@ spec:
                       RuntimeClassName specifies the runtime class to use for the build pod
                       More info: https://kubernetes.io/docs/concepts/containers/runtime-class/
                     type: string
-                  serveExpiryHours:
-                    description: |-
-                      ServeExpiryHours specifies how long to serve build artifacts before automatic cleanup
-                      Default: 24
-                    format: int32
-                    type: integer
                   tolerations:
                     description: |-
                       Tolerations specifies tolerations to be added to build pods

--- a/config/samples/automotive_v1_imagebuild.yaml
+++ b/config/samples/automotive_v1_imagebuild.yaml
@@ -19,8 +19,6 @@ spec:
   #storageClass: "lvms-vg1"  # use cluster default if not specified
   automotiveImageBuilder: "quay.io/centos-sig-automotive/automotive-image-builder:1.0.0"
   manifestConfigMap: mpp
-  serveArtifact: false
-  serveExpiryHours: 24
   #runtimeClassName: "kata"
 # publishers:
 #     registry:

--- a/config/samples/automotive_v1_operatorconfig.yaml
+++ b/config/samples/automotive_v1_operatorconfig.yaml
@@ -16,10 +16,6 @@ spec:
     # Default: "8Gi"
     pvcSize: "8Gi"
 
-    # How long to serve build artifacts before automatic cleanup (in hours)
-    # Default: 24
-    serveExpiryHours: 24
-
     # Optional: Use memory-backed volumes for faster builds
     # Requires memoryVolumeSize to be set if enabled
     # useMemoryVolumes: false

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -131,45 +131,6 @@ paths:
             text/plain:
               schema:
                 type: string
-  /v1/builds/{name}/artifact:
-    parameters:
-      - in: path
-        name: name
-        schema:
-          type: string
-        required: true
-    get:
-      summary: Download built artifact
-      operationId: downloadArtifact
-      responses:
-        '200':
-          description: Artifact stream
-          headers:
-            Content-Disposition:
-              description: Suggested filename for download
-              schema:
-                type: string
-            Content-Length:
-              description: Artifact size in bytes (when known)
-              schema:
-                type: string
-          content:
-            application/octet-stream:
-              schema:
-                type: string
-                format: binary
-        '409':
-          description: Build not completed
-          content:
-            text/plain:
-              schema:
-                type: string
-        '503':
-          description: Artifact pod not ready
-          content:
-            text/plain:
-              schema:
-                type: string
 components:
   schemas:
     BuildRequest:
@@ -209,12 +170,6 @@ components:
           type: array
           items:
             type: string
-        serveArtifact:
-          type: boolean
-          description: Create artifact serving pod on completion
-        exposeRoute:
-          type: boolean
-          description: Create external route/URL (OpenShift)
     BuildResponse:
       type: object
       properties:
@@ -224,12 +179,6 @@ components:
           type: string
         message:
           type: string
-        artifactURL:
-          type: string
-          nullable: true
-        artifactFileName:
-          type: string
-          nullable: true
     BuildListItem:
       type: object
       properties:

--- a/internal/buildapi/openapi.yaml
+++ b/internal/buildapi/openapi.yaml
@@ -150,44 +150,6 @@ paths:
                 $ref: '#/components/schemas/BuildTemplateResponse'
         '404':
           description: Not found
-    parameters:
-      - in: path
-        name: name
-        schema:
-          type: string
-        required: true
-    get:
-      summary: Download built artifact
-      operationId: downloadArtifact
-      responses:
-        '200':
-          description: Artifact stream
-          headers:
-            Content-Disposition:
-              description: Suggested filename for download
-              schema:
-                type: string
-            Content-Length:
-              description: Artifact size in bytes (when known)
-              schema:
-                type: string
-          content:
-            application/octet-stream:
-              schema:
-                type: string
-                format: binary
-        '409':
-          description: Build not completed
-          content:
-            text/plain:
-              schema:
-                type: string
-        '503':
-          description: Artifact pod not ready
-          content:
-            text/plain:
-              schema:
-                type: string
 components:
   schemas:
     BuildRequest:
@@ -227,12 +189,6 @@ components:
           type: array
           items:
             type: string
-        serveArtifact:
-          type: boolean
-          description: Create artifact serving pod on completion
-        exposeRoute:
-          type: boolean
-          description: Create external route/URL (OpenShift)
     BuildResponse:
       type: object
       properties:
@@ -243,12 +199,6 @@ components:
         message:
           type: string
         requestedBy:
-          type: string
-          nullable: true
-        artifactURL:
-          type: string
-          nullable: true
-        artifactFileName:
           type: string
           nullable: true
     BuildListItem:

--- a/internal/buildapi/server_test.go
+++ b/internal/buildapi/server_test.go
@@ -76,7 +76,6 @@ var _ = Describe("APIServer", func() {
 			{"POST", "/v1/builds"},
 			{"GET", "/v1/builds/test-build"},
 			{"GET", "/v1/builds/test-build/logs"},
-			{"GET", "/v1/builds/test-build/artifacts"},
 			{"GET", "/v1/builds/test-build/template"},
 			{"POST", "/v1/builds/test-build/uploads"},
 		}

--- a/internal/buildapi/types.go
+++ b/internal/buildapi/types.go
@@ -123,7 +123,6 @@ type BuildRequest struct {
 	StorageClass           string               `json:"storageClass"`
 	CustomDefs             []string             `json:"customDefs"`
 	AIBExtraArgs           []string             `json:"aibExtraArgs"`
-	ServeArtifact          bool                 `json:"serveArtifact"`
 	Compression            string               `json:"compression,omitempty"`
 	RegistryCredentials    *RegistryCredentials `json:"registryCredentials,omitempty"`
 	PushRepository         string               `json:"pushRepository,omitempty"`
@@ -157,15 +156,13 @@ type JumpstarterInfo struct {
 
 // BuildResponse is returned by POST and GET build operations
 type BuildResponse struct {
-	Name             string           `json:"name"`
-	Phase            string           `json:"phase"`
-	Message          string           `json:"message"`
-	RequestedBy      string           `json:"requestedBy,omitempty"`
-	ArtifactURL      string           `json:"artifactURL,omitempty"`
-	ArtifactFileName string           `json:"artifactFileName,omitempty"`
-	StartTime        string           `json:"startTime,omitempty"`
-	CompletionTime   string           `json:"completionTime,omitempty"`
-	Jumpstarter      *JumpstarterInfo `json:"jumpstarter,omitempty"`
+	Name           string           `json:"name"`
+	Phase          string           `json:"phase"`
+	Message        string           `json:"message"`
+	RequestedBy    string           `json:"requestedBy,omitempty"`
+	StartTime      string           `json:"startTime,omitempty"`
+	CompletionTime string           `json:"completionTime,omitempty"`
+	Jumpstarter    *JumpstarterInfo `json:"jumpstarter,omitempty"`
 }
 
 // BuildListItem represents a build in the list API

--- a/internal/common/tasks/tasks.go
+++ b/internal/common/tasks/tasks.go
@@ -18,7 +18,6 @@ type BuildConfig struct {
 	MemoryVolumeSize string
 	PVCSize          string
 	RuntimeClassName string
-	ServeExpiryHours int32
 }
 
 // AutomotiveImageBuilder is the default container image for the automotive image builder.

--- a/internal/controller/operatorconfig/controller.go
+++ b/internal/controller/operatorconfig/controller.go
@@ -409,7 +409,6 @@ func (r *OperatorConfigReconciler) deployOSBuilds(
 			MemoryVolumeSize: config.Spec.OSBuilds.MemoryVolumeSize,
 			PVCSize:          config.Spec.OSBuilds.PVCSize,
 			RuntimeClassName: config.Spec.OSBuilds.RuntimeClassName,
-			ServeExpiryHours: config.Spec.OSBuilds.ServeExpiryHours,
 		}
 	}
 


### PR DESCRIPTION
we will rely on OCI registry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed artifact-serving options and expiry configuration across APIs, operator config, controller and CLI; CLI no longer supports API-based artifact downloads and relies on registry pulls when output is requested.
* **Documentation**
  * Updated OpenAPI and CRD schemas and samples to remove artifact-related fields and the artifact download endpoint.
* **Tests**
  * Removed E2E and server tests that exercised API/CLI artifact download behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->