### PR TITLE
Draft: fix: update 'mode' flag to optional

### DIFF
--- a/cmd/caib/main.go
+++ b/cmd/caib/main.go
@@ -341,7 +341,6 @@ Examples:
 	buildDevCmd.Flags().IntVar(&timeout, "timeout", 60, "timeout in minutes")
 	buildDevCmd.Flags().BoolVarP(&waitForBuild, "wait", "w", false, "wait for build to complete")
 	buildDevCmd.Flags().BoolVarP(&followLogs, "follow", "f", true, "follow build logs")
-	_ = buildDevCmd.MarkFlagRequired("mode")
 
 	// Add all commands
 	rootCmd.AddCommand(buildCmd, diskCmd, buildDevCmd, listCmd, catalog.NewCatalogCmd())


### PR DESCRIPTION


Update build command-line 'mode' flag from required to optional in `caib`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * The `--mode` flag for the build-dev command is now optional and defaults to image mode when not specified.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->