### PR TITLE
fix: update 'mode' flag to optional

### DIFF
--- a/cmd/caib/main.go
+++ b/cmd/caib/main.go
@@ -341,7 +341,6 @@ Examples:
 	buildDevCmd.Flags().IntVar(&timeout, "timeout", 60, "timeout in minutes")
 	buildDevCmd.Flags().BoolVarP(&waitForBuild, "wait", "w", false, "wait for build to complete")
 	buildDevCmd.Flags().BoolVarP(&followLogs, "follow", "f", true, "follow build logs")
-	_ = buildDevCmd.MarkFlagRequired("mode")
 
 	// Add all commands
 	rootCmd.AddCommand(buildCmd, diskCmd, buildDevCmd, listCmd, catalog.NewCatalogCmd())


### PR DESCRIPTION
https://github.com/centos-automotive-suite/automotive-dev-operator/issues/29

Update build command-line 'mode' flag from required to optional in `caib`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Made the `--mode` flag optional for the build-dev command, which now defaults to image mode when omitted. This simplifies command usage by removing an unnecessary required parameter.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->