### PR TITLE
fix: update build-dev 'mode' flag usage

### DIFF
--- a/cmd/caib/main.go
+++ b/cmd/caib/main.go
@@ -749,9 +749,14 @@ func runBuildDev(_ *cobra.Command, args []string) {
 	}
 
 	// Validate mode
-	parsedMode := buildapitypes.ModePackage
-	if mode == "image" {
+	var parsedMode buildapitypes.Mode
+	switch mode {
+	case "image":
 		parsedMode = buildapitypes.ModeImage
+	case "package":
+		parsedMode = buildapitypes.ModePackage
+	default:
+		handleError(fmt.Errorf("invalid --mode %q (expected: %q or %q)", mode, buildapitypes.ModeImage, buildapitypes.ModePackage))
 	}
 
 	// Extract registry URL and credentials


### PR DESCRIPTION
https://github.com/centos-automotive-suite/automotive-dev-operator/issues/29

update build-dev `--mode` flag usage text 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Default packaging mode for the development build command now defaults to "package"; help text lists "image" and "package".
  * Mode handling is stricter: "image" and "package" are recognized explicitly and unknown values now produce a clear error.
  * Registry credential lookup for development builds was adjusted, and the build request now uses the explicitly selected mode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->