### PR TITLE
use multi layer push

### DIFF
--- a/internal/common/tasks/scripts/push_artifact.sh
+++ b/internal/common/tasks/scripts/push_artifact.sh
@@ -1,53 +1,242 @@
 #!/bin/sh
 set -e
 
-# Trim whitespace/newlines from the filename
+# Get media type based on file format and compression
+get_media_type() {
+  case "$1" in
+    *.tar.gz)         echo "application/vnd.oci.image.layer.v1.tar+gzip" ;;
+    *.tar.lz4)        echo "application/vnd.oci.image.layer.v1.tar+lz4" ;;
+    *.tar.xz)         echo "application/vnd.oci.image.layer.v1.tar+xz" ;;
+    *.tar)            echo "application/vnd.oci.image.layer.v1.tar" ;;
+
+    *.simg.gz)        echo "application/vnd.automotive.disk.simg+gzip" ;;
+    *.simg.lz4)       echo "application/vnd.automotive.disk.simg+lz4" ;;
+    *.simg.xz)        echo "application/vnd.automotive.disk.simg+xz" ;;
+    *.raw.gz|*.img.gz) echo "application/vnd.automotive.disk.raw+gzip" ;;
+    *.raw.lz4|*.img.lz4) echo "application/vnd.automotive.disk.raw+lz4" ;;
+    *.raw.xz|*.img.xz) echo "application/vnd.automotive.disk.raw+xz" ;;
+    *.qcow2.gz)       echo "application/vnd.automotive.disk.qcow2+gzip" ;;
+    *.qcow2.lz4)      echo "application/vnd.automotive.disk.qcow2+lz4" ;;
+    *.qcow2.xz)       echo "application/vnd.automotive.disk.qcow2+xz" ;;
+
+    *.simg)           echo "application/vnd.automotive.disk.simg" ;;
+    *.raw|*.img)      echo "application/vnd.automotive.disk.raw" ;;
+    *.qcow2)          echo "application/vnd.automotive.disk.qcow2" ;;
+
+    *.gz)             echo "application/gzip" ;;
+    *.lz4)            echo "application/x-lz4" ;;
+    *.xz)             echo "application/x-xz" ;;
+
+    # Default fallback
+    *)                echo "application/octet-stream" ;;
+  esac
+}
+
+# Safely escape string for JSON (escape quotes, backslashes, control chars)
+json_escape() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g; s/	/\\t/g; s/\n/\\n/g; s/\r/\\r/g'
+}
+
+get_artifact_type() {
+  case "$1" in
+    *.simg.gz|*.simg.lz4|*.simg) echo "application/vnd.automotive.disk.simg" ;;
+    *.qcow2.gz|*.qcow2.lz4|*.qcow2.xz|*.qcow2) echo "application/vnd.automotive.disk.qcow2" ;;
+    *.raw.gz|*.raw.lz4|*.raw.xz|*.raw|*.img.gz|*.img.lz4|*.img.xz|*.img) echo "application/vnd.automotive.disk.raw" ;;
+    *) echo "application/octet-stream" ;;
+  esac
+}
+
+get_partition_name() {
+  # Strip base extension (.simg/.raw/.img), optional .tar, and optional compression (.gz/.lz4/.xz)
+  # Examples: boot_a.simg.gz -> boot_a, foo.simg.tar.gz -> foo, system.raw.lz4 -> system
+  basename "$1" | sed -E 's/\.(simg|raw|img)(\.tar)?(\.(gz|lz4|xz))?$//'
+}
+
+# Get decompressed file size from sidecar .size file (created by build_image.sh)
+# Falls back to empty string if sidecar doesn't exist
+get_decompressed_size() {
+  file="$1"
+  size_file="${file}.size"
+  if [ -f "$size_file" ]; then
+    cat "$size_file"
+  else
+    echo ""
+  fi
+}
+
 exportFile=$(echo "$(params.artifact-filename)" | tr -d '[:space:]')
 
 if [ -z "$exportFile" ]; then
   echo "ERROR: artifact-filename param is empty"
-  echo "Available files in workspace:"
   ls -la /workspace/shared/
   exit 1
 fi
 
-if [ ! -f "$exportFile" ]; then
-  echo "ERROR: Artifact file not found: $exportFile"
-  echo "Available files in workspace:"
-  ls -la /workspace/shared/
-  exit 1
+repo_url="$(params.repository-url)"
+parts_dir="${exportFile}-parts"
+distro="$(params.distro)"
+target="$(params.target)"
+arch="$(params.arch)"
+
+cd /workspace/shared
+
+echo "=== Artifact Push Configuration ==="
+echo "  Working directory: $(pwd)"
+echo "  Artifact file:     ${exportFile}"
+echo "  Parts directory:   ${parts_dir}"
+echo "  Repository URL:    ${repo_url}"
+echo "  Distro: ${distro}, Target: ${target}, Arch: ${arch}"
+echo ""
+
+if [ -d "${parts_dir}" ] && [ -n "$(ls -A "${parts_dir}" 2>/dev/null)" ]; then
+  echo "Found parts directory: ${parts_dir}"
+  echo "Using multi-layer push for individual partition files"
+  ls -la "${parts_dir}/"
+
+  cd "${parts_dir}"
+
+  # Create annotations file in current directory (ORAS container may not have /tmp)
+  annotations_file="./oras-annotations.json"
+  trap 'rm -f "$annotations_file"' EXIT
+
+  layer_args=""
+  file_list=""
+
+  layer_annotations_json=""
+
+  for part_file in *; do
+    # Skip .size sidecar files
+    case "$part_file" in *.size) continue ;; esac
+
+    if [ -f "$part_file" ]; then
+      filename="$part_file"
+      part_media_type=$(get_media_type "$filename")
+      partition_name=$(get_partition_name "$filename")
+      decompressed_size=$(get_decompressed_size "$filename")
+
+      echo "  Layer: ${filename} (partition: ${partition_name}, type: ${part_media_type}, decompressed: ${decompressed_size:-unknown})"
+
+      # Build layer argument: file:media-type (no path prefix = flat extraction)
+      layer_args="${layer_args} ${filename}:${part_media_type}"
+
+      # Build comma-separated file list for parts annotation
+      if [ -z "$file_list" ]; then
+        file_list="${filename}"
+      else
+        file_list="${file_list},${filename}"
+      fi
+
+      # Build per-layer annotation JSON entry with safe escaping
+      # Include partition name, decompressed size, and standard OCI title
+      if [ -n "$layer_annotations_json" ]; then
+        layer_annotations_json="${layer_annotations_json},"
+      fi
+
+      # Safely escape values for JSON
+      escaped_filename=$(json_escape "$filename")
+      escaped_partition=$(json_escape "$partition_name")
+      escaped_decompressed_size=$(json_escape "$decompressed_size")
+
+      # Build JSON with properly escaped values
+      if [ -n "$decompressed_size" ]; then
+        layer_annotations_json="${layer_annotations_json}\"${escaped_filename}\":{\"automotive.sdv.cloud.redhat.com/partition\":\"${escaped_partition}\",\"org.opencontainers.image.title\":\"${escaped_filename}\",\"automotive.sdv.cloud.redhat.com/decompressed-size\":\"${escaped_decompressed_size}\"}"
+      else
+        layer_annotations_json="${layer_annotations_json}\"${escaped_filename}\":{\"automotive.sdv.cloud.redhat.com/partition\":\"${escaped_partition}\",\"org.opencontainers.image.title\":\"${escaped_filename}\"}"
+      fi
+    fi
+  done
+
+  # Guard: fail fast if no partition files were found
+  if [ -z "$file_list" ]; then
+    echo "ERROR: No partition files found in ${parts_dir}" >&2
+    echo "  Expected .simg, .raw, or .img files but directory appears empty or contains no regular files" >&2
+    ls -la . >&2 || true
+    exit 1
+  fi
+
+  # Get artifact type from first entry in filtered file_list (avoids sidecar .size files)
+  first_filename=$(echo "$file_list" | cut -d',' -f1)
+  artifact_type=$(get_artifact_type "$first_filename")
+
+  cat > "$annotations_file" <<EOF
+{
+  "\$manifest": {
+    "automotive.sdv.cloud.redhat.com/multi-layer": "true",
+    "automotive.sdv.cloud.redhat.com/parts": "${file_list}",
+    "automotive.sdv.cloud.redhat.com/distro": "${distro}",
+    "automotive.sdv.cloud.redhat.com/target": "${target}",
+    "automotive.sdv.cloud.redhat.com/arch": "${arch}"
+  },
+  ${layer_annotations_json}
+}
+EOF
+
+  echo ""
+  echo "Pushing multi-layer artifact to ${repo_url}"
+  echo "  Artifact type: ${artifact_type}"
+  echo "  Parts: ${file_list}"
+  echo "  Annotations file: ${annotations_file}"
+  cat "$annotations_file"
+
+  # Push with multi-layer manifest using annotation file
+  # Files are pushed from current directory (parts_dir) so they extract flat
+  # shellcheck disable=SC2086
+  oras push --disable-path-validation \
+    --artifact-type "${artifact_type}" \
+    --annotation-file "$annotations_file" \
+    "${repo_url}" \
+    ${layer_args}
+
+  # Clean up annotation file (also handled by trap)
+  rm -f "$annotations_file"
+
+  echo ""
+  echo "=== Multi-layer artifact pushed successfully ==="
+  echo ""
+  echo "Files are stored flat (no subdirectory). After pull, you get:"
+  echo "$file_list" | sed 's/,/\n/g' | while read -r f; do echo "  ./$f"; done
+  echo ""
+  echo "Pull commands:"
+  echo "  All files:      oras pull ${repo_url}"
+  echo "  Single file:    oras pull ${repo_url} --include \"boot_a.simg.gz\""
+  echo "  Inspect:        oras manifest fetch ${repo_url} | jq ."
+
+else
+  # Fallback to single-file push (original behavior)
+  if [ ! -f "${exportFile}" ]; then
+    echo "ERROR: Artifact file not found: ${exportFile}"
+    ls -la /workspace/shared/
+    exit 1
+  fi
+
+  media_type=$(get_media_type "${exportFile}")
+
+  annotation_args=""
+
+  if echo "${exportFile}" | grep -q '\.tar'; then
+    echo "Listing tar contents for annotation"
+    file_list=$(tar -tf "${exportFile}" 2>/dev/null | grep -v '/$' | xargs -I{} basename {} | sort | tr '\n' ',' | sed 's/,$//')
+    if [ -n "$file_list" ]; then
+      echo "  Contents: ${file_list}"
+      annotation_args="--annotation automotive.sdv.cloud.redhat.com/parts=${file_list}"
+    fi
+  fi
+
+  echo "Pushing single-file artifact to ${repo_url}"
+  echo "  File: ${exportFile}"
+  echo "  Media type: ${media_type}"
+  echo "  Annotations: distro=${distro}, target=${target}, arch=${arch}"
+
+  oras push --disable-path-validation \
+    --artifact-type "${media_type}" \
+    --annotation "automotive.sdv.cloud.redhat.com/distro=${distro}" \
+    --annotation "automotive.sdv.cloud.redhat.com/target=${target}" \
+    --annotation "automotive.sdv.cloud.redhat.com/arch=${arch}" \
+    ${annotation_args} \
+    "${repo_url}" \
+    "${exportFile}:${media_type}"
+
+  echo ""
+  echo "=== Artifact pushed successfully ==="
+  echo "Pull: oras pull ${repo_url}"
 fi
-
-case "$exportFile" in
-  *.tar.gz)
-    mediaType="application/gzip"
-    ;;
-  *.gz)
-    mediaType="application/gzip"
-    ;;
-  *.lz4)
-    mediaType="application/x-lz4"
-    ;;
-  *.xz)
-    mediaType="application/x-xz"
-    ;;
-  *.qcow2)
-    mediaType="application/x-qcow2"
-    ;;
-  *.raw|*.img)
-    mediaType="application/x-raw-disk-image"
-    ;;
-  *)
-    mediaType="application/octet-stream"
-    ;;
-esac
-
-echo "Pushing artifact to $(params.repository-url)"
-echo "File: ${exportFile}"
-echo "Media type: ${mediaType}"
-
-oras push --disable-path-validation \
-  $(params.repository-url) \
-  ${exportFile}:${mediaType}
-
-echo "Artifact pushed successfully to registry"

--- a/internal/common/tasks/tasks.go
+++ b/internal/common/tasks/tasks.go
@@ -52,6 +52,11 @@ func GeneratePushArtifactRegistryTask(namespace string) *tektonv1.Task {
 					Description: "Build target",
 				},
 				{
+					Name:        "arch",
+					Type:        tektonv1.ParamTypeString,
+					Description: "Target architecture",
+				},
+				{
 					Name:        "export-format",
 					Type:        tektonv1.ParamTypeString,
 					Description: "Export format for the build",
@@ -869,6 +874,13 @@ func GenerateTektonPipeline(name, namespace string) *tektonv1.Pipeline {
 							Value: tektonv1.ParamValue{
 								Type:      tektonv1.ParamTypeString,
 								StringVal: "$(params.target)",
+							},
+						},
+						{
+							Name: "arch",
+							Value: tektonv1.ParamValue{
+								Type:      tektonv1.ParamTypeString,
+								StringVal: "$(params.arch)",
 							},
 						},
 						{

--- a/internal/controller/imagebuild/controller.go
+++ b/internal/controller/imagebuild/controller.go
@@ -672,6 +672,13 @@ func (r *ImageBuildReconciler) createPushTaskRun(ctx context.Context, imageBuild
 
 	params := []tektonv1.Param{
 		{
+			Name: "arch",
+			Value: tektonv1.ParamValue{
+				Type:      tektonv1.ParamTypeString,
+				StringVal: imageBuild.Spec.Architecture,
+			},
+		},
+		{
 			Name: "distro",
 			Value: tektonv1.ParamValue{
 				Type:      tektonv1.ParamTypeString,


### PR DESCRIPTION
and add annotation to OCI image

```
❯ oras manifest fetch quay.io/bzlotnik/ridesx-image:latest | jq
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "artifactType": "application/vnd.automotive.disk.simg",
  "config": {
    "mediaType": "application/vnd.oci.empty.v1+json",
    "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
    "size": 2,
    "data": "e30="
  },
  "layers": [
    {
      "mediaType": "application/vnd.automotive.disk.simg+gzip",
      "digest": "sha256:541b1a1ca38369520275030390ead8bbb37fa5a692ad90281df3c5d08e743d4b",
      "size": 24479031,
      "annotations": {
        "automotive.sdv.cloud.redhat.com/decompressed-size": "26660904",
        "automotive.sdv.cloud.redhat.com/partition": "boot_a",
        "org.opencontainers.image.title": "boot_a.simg.gz"
      }
    },
    {
      "mediaType": "application/vnd.automotive.disk.simg+gzip",
      "digest": "sha256:27f199d21144c5f048edba14faec7a7e7ae65f9f8d70b9f002d501fd292fdba6",
      "size": 224219678,
      "annotations": {
        "automotive.sdv.cloud.redhat.com/decompressed-size": "593367844",
        "automotive.sdv.cloud.redhat.com/partition": "system_a",
        "org.opencontainers.image.title": "system_a.simg.gz"
      }
    }
  ],
  "annotations": {
    "automotive.sdv.cloud.redhat.com/arch": "arm64",
    "automotive.sdv.cloud.redhat.com/distro": "autosd",
    "automotive.sdv.cloud.redhat.com/multi-layer": "true",
    "automotive.sdv.cloud.redhat.com/parts": "boot_a.simg.gz,system_a.simg.gz",
    "automotive.sdv.cloud.redhat.com/target": "ridesx4",
    "org.opencontainers.image.created": "2026-02-02T07:50:21Z"
  }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-layer artifact support for push and pull, delivering/extracting per-layer files when present.
  * Per-layer and manifest-level annotations for parts, distro, target, arch and uncompressed-size metadata.
  * New push helpers to derive media type, artifact/partition names and decompressed sizes.
  * Exposed a new "arch" parameter for pipeline/task configuration.
* **Improvements**
  * Artifacts now include a sidecar storing uncompressed size for each packaged file.
  * Enhanced runtime output, logging and user guidance for multi-layer and single-file flows.
  * Filename sanitization, unified copy handling, and stronger error checks with clearer messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->