### PR TITLE
test: add e2e-test for build bootc image

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,11 +15,18 @@ env:
   GO_VERSION: '1.24'
   KIND_VERSION: v0.24.0
   KUBECTL_VERSION: v1.31.0
+  TEKTON_VERSION: v1.9.1
+  INGRESS_NGINX_VERSION: v1.14.3
+  CLUSTER_NAME: automotive-dev-e2e
+  REGISTRY_NAME: kind-registry
+  REGISTRY_PORT: '5001'
+  REGISTRY_HOST: image-registry.openshift-image-registry.svc
+  ARCH: arm64
 
 jobs:
   e2e-tests:
     runs-on: ubuntu-24.04-arm
-    timeout-minutes: 20
+    timeout-minutes: 90
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -32,64 +39,179 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgpgme-dev
+          sudo apt-get install -y libgpgme-dev jq
 
       - name: Install kubectl
         run: |
-          curl -LO "https://dl.k8s.io/release/${{ env.KUBECTL_VERSION }}/bin/linux/arm64/kubectl"
+          curl -LO "https://dl.k8s.io/release/${{ env.KUBECTL_VERSION }}/bin/linux/${{ env.ARCH }}/kubectl"
           chmod +x kubectl
           sudo mv kubectl /usr/local/bin/
           kubectl version --client
 
       - name: Install Kind
         run: |
-          curl -Lo ./kind "https://kind.sigs.k8s.io/dl/${{ env.KIND_VERSION }}/kind-linux-arm64"
+          curl -Lo ./kind "https://kind.sigs.k8s.io/dl/${{ env.KIND_VERSION }}/kind-linux-${{ env.ARCH }}"
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind
           kind version
 
+      # ---------------------------------------------------------------
+      # [1/7] Local Registry
+      # ---------------------------------------------------------------
+      - name: Set up local registry
+        run: |
+          docker run -d --restart=always \
+            -p "127.0.0.1:${REGISTRY_PORT}:5000" \
+            -p "127.0.0.1:5000:5000" \
+            --name "${REGISTRY_NAME}" \
+            registry:2
+
+          echo "127.0.0.1 ${REGISTRY_HOST}" | sudo tee -a /etc/hosts
+
+          mkdir -p "${HOME}/.config/containers/registries.conf.d"
+          tee "${HOME}/.config/containers/registries.conf.d/kind-e2e-registry.conf" <<EOF
+          [[registry]]
+          location = "${REGISTRY_HOST}:5000"
+          insecure = true
+          EOF
+
+      # ---------------------------------------------------------------
+      # [2/7] Kind Cluster
+      # ---------------------------------------------------------------
       - name: Create Kind cluster
         run: |
-          kind create cluster --name automotive-dev-e2e --wait 5m
-          kubectl cluster-info
-          kubectl get nodes
-          # Label node for OperatorConfig nodeSelector
+          kind create cluster --name "$CLUSTER_NAME" --wait 5m
+          kubectl cluster-info --context "kind-$CLUSTER_NAME"
           kubectl label nodes --all aib=true
+          kubectl get nodes --show-labels
 
+      - name: Connect registry to Kind network
+        run: |
+          docker network connect kind "${REGISTRY_NAME}"
+          for node in $(kind get nodes --name "${CLUSTER_NAME}"); do
+            kubectl annotate node "${node}" "kind.x-k8s.io/registry=localhost:${REGISTRY_PORT}" --overwrite
+          done
+          kubectl wait --for=condition=Ready nodes --all --timeout=60s
+
+      # ---------------------------------------------------------------
+      # [3/7] Internal DNS for Registry (OpenShift spoof)
+      # ---------------------------------------------------------------
+      - name: Set up registry DNS spoof
+        run: |
+          cat <<EOF | kubectl apply -f -
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: local-registry-hosting
+            namespace: kube-public
+          data:
+            localRegistryHosting.v1: |
+              host: "localhost:${REGISTRY_PORT}"
+              help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
+          EOF
+
+          kubectl create namespace openshift-image-registry --dry-run=client -o yaml | kubectl apply -f -
+
+          REGISTRY_IP=""
+          for i in $(seq 1 30); do
+            REGISTRY_IP=$(docker inspect -f '{{.NetworkSettings.Networks.kind.IPAddress}}' "${REGISTRY_NAME}" 2>/dev/null || true)
+            if [ -n "$REGISTRY_IP" ]; then
+              echo "Registry IP found: $REGISTRY_IP" 
+              break; 
+            fi
+            echo "Waiting for registry IP... (attempt $i/30)"
+            sleep 1
+          done
+          echo "Registry IP: $REGISTRY_IP"
+          if [ -z "$REGISTRY_IP" ]; then
+            echo "Failed to discover a Kind-network IP for ${REGISTRY_NAME}" >&2
+            exit 1
+          fi
+
+          cat <<EOF | kubectl apply -f -
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: image-registry
+            namespace: openshift-image-registry
+          spec:
+            ports:
+            - port: 5000
+              protocol: TCP
+              targetPort: 5000
+            clusterIP: None
+          ---
+          apiVersion: v1
+          kind: Endpoints
+          metadata:
+            name: image-registry
+            namespace: openshift-image-registry
+          subsets:
+          - addresses:
+            - ip: ${REGISTRY_IP}
+            ports:
+            - port: 5000
+              name: registry
+              protocol: TCP
+          EOF
+
+      # ---------------------------------------------------------------
+      # [4/7] Infrastructure (Tekton & Ingress)
+      # ---------------------------------------------------------------
       - name: Install Tekton Pipelines
         run: |
-          kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+          kubectl apply --filename https://infra.tekton.dev/tekton-releases/pipeline/previous/${{ env.TEKTON_VERSION }}/release.yaml
           echo "Waiting for Tekton Pipelines to be ready..."
           kubectl wait --for=condition=ready pod --all -n tekton-pipelines --timeout=5m
 
       - name: Install NGINX Ingress Controller
         run: |
-          kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+          kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-${{ env.INGRESS_NGINX_VERSION }}/deploy/static/provider/kind/deploy.yaml
           echo "Waiting for NGINX Ingress Controller to be ready..."
           kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=3m
+
+      # ---------------------------------------------------------------
+      # [5/7] Run E2E tests (self-contained: deploys operator, tests, tears down)
+      # ---------------------------------------------------------------
+      - name: Build caib CLI
+        run: make build-caib
 
       - name: Run E2E tests
         env:
           KIND_CLUSTER: automotive-dev-e2e
           CONTAINER_TOOL: docker
-        run: |
-          make test-e2e
+          BUILD_PLATFORM: linux/${{ env.ARCH }}
+          REGISTRY_HOST: ${{ env.REGISTRY_HOST }}
+          REGISTRY_USERNAME: kind
+          REGISTRY_PASSWORD: kind
+          CAIB_SERVER: http://localhost:8080
+        run: make test-e2e
 
       - name: Collect logs on failure
         if: failure()
         run: |
           echo "=== Operator Logs ==="
-          kubectl logs -n automotive-dev-operator-system -l control-plane=operator --tail=100
+          kubectl logs -n automotive-dev-operator-system -l control-plane=operator --tail=200 || true
           echo "=== All Pods in operator namespace ==="
-          kubectl get pods -n automotive-dev-operator-system -o wide
+          kubectl get pods -n automotive-dev-operator-system -o wide || true
+          echo "=== PipelineRuns ==="
+          kubectl get pipelinerun -n automotive-dev-operator-system -o yaml || true
           echo "=== Events ==="
-          kubectl get events -n automotive-dev-operator-system --sort-by='.lastTimestamp'
+          kubectl get events -n automotive-dev-operator-system --sort-by='.lastTimestamp' || true
           echo "=== OperatorConfig ==="
           kubectl get operatorconfig -n automotive-dev-operator-system -o yaml || true
           echo "=== ImageBuilds ==="
           kubectl get imagebuilds -n automotive-dev-operator-system -o yaml || true
+          echo "=== Build Image Pod Logs ==="
+          for pod in $(kubectl get pods -n automotive-dev-operator-system -o name | grep build-image-pod); do
+            echo "--- $pod ---"
+            kubectl logs -n automotive-dev-operator-system "$pod" -c step-build-image --tail=100 || true
+          done
 
       - name: Cleanup
         if: always()
         run: |
-          kind delete cluster --name automotive-dev-e2e || true
+          kind delete cluster --name "$CLUSTER_NAME" || true
+          docker rm -f "$REGISTRY_NAME" || true
+          sudo sed -i "/${REGISTRY_HOST}/d" /etc/hosts 2>/dev/null || true
+          rm -f "${HOME}/.config/containers/registries.conf.d/kind-e2e-registry.conf" || true

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
 test-e2e:
-	go test ./test/e2e/ -v -ginkgo.v -timeout 15m
+	go test ./test/e2e/ -v -ginkgo.v -timeout 85m
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter

--- a/hack/run-e2e-local.sh
+++ b/hack/run-e2e-local.sh
@@ -1,51 +1,290 @@
 #!/bin/bash
 set -e
 
+# Configuration
 CLUSTER_NAME="automotive-dev-e2e"
+REGISTRY_NAME="kind-registry"
+REGISTRY_PORT="5001"
+REGISTRY_HOST="image-registry.openshift-image-registry.svc"
+KIND_NETWORK="kind"
+TEKTON_VERSION="v1.9.1"
+INGRESS_NGINX_VERSION="v1.14.3"
 
+# Ownership flags: only tear down resources this invocation created
+CREATED_REGISTRY=false
+CREATED_HOSTS_ENTRY=false
+CREATED_REGISTRIES_CONF=false
+REGISTRIES_CONF_BACKUP=""
+
+# Diagnostics and Cleanup
 cleanup() {
-  echo ""
-  echo "Cleaning up..."
-  kind delete cluster --name "$CLUSTER_NAME" 2>/dev/null || true
+  local exit_code=$?
+  local CONF_FILE="${HOME}/.config/containers/registries.conf.d/kind-e2e-registry.conf"
+  if [ $exit_code -ne 0 ]; then
+    echo ""
+    echo "!!! Script exited/failed. Keeping cluster for debugging. !!!"
+    echo "To clean up, run:"
+    echo "  kind delete cluster --name $CLUSTER_NAME"
+    [ "$CREATED_REGISTRY" = "true" ] && echo "  docker rm -f $REGISTRY_NAME"
+    [ "$CREATED_HOSTS_ENTRY" = "true" ] && echo "  sudo sed -i '/${REGISTRY_HOST}/d' /etc/hosts"
+    [ "$CREATED_REGISTRIES_CONF" = "true" ] && echo "  rm -f $CONF_FILE"
+    [ -n "$REGISTRIES_CONF_BACKUP" ] && echo "  mv $REGISTRIES_CONF_BACKUP $CONF_FILE  # restore original"
+  else
+    echo ""
+    echo "Cleaning up..."
+    kind delete cluster --name "$CLUSTER_NAME"
+    [ "$CREATED_REGISTRY" = "true" ] && docker rm -f "$REGISTRY_NAME"
+    [ "$CREATED_HOSTS_ENTRY" = "true" ] && sudo sed -i "/${REGISTRY_HOST}/d" /etc/hosts 2>/dev/null || true
+    if [ "$CREATED_REGISTRIES_CONF" = "true" ]; then
+      rm -f "$CONF_FILE"
+    elif [ -n "$REGISTRIES_CONF_BACKUP" ]; then
+      mv "$REGISTRIES_CONF_BACKUP" "$CONF_FILE"
+    fi
+    echo "Cleanup complete."
+  fi
 }
-
 trap cleanup EXIT
 
+set_build_platform() {
+  local host_arch
+  host_arch=$(uname -m)
+  case "$host_arch" in
+    x86_64)
+      export BUILD_PLATFORM=linux/amd64
+      export ARCH=amd64
+      ;;
+    arm64|aarch64)
+      export BUILD_PLATFORM=linux/arm64
+      export ARCH=arm64
+      ;;
+    *)
+      echo "Unsupported architecture: $host_arch (supported: x86_64, arm64, aarch64)"
+      exit 1
+      ;;
+  esac
+}
+
 echo "========================================="
-echo "Running E2E Tests Locally"
+echo "   Initializing Local Dev Environment    "
 echo "========================================="
 
-echo ""
-echo "Checking for existing cluster..."
+for bin in docker kind kubectl jq make; do
+  command -v "$bin" >/dev/null 2>&1 || {
+    echo "Missing required dependency: $bin" >&2
+    exit 1
+  }
+done
+
+# ------------------------------------------------------------------
+# [1/5] Ensure Local Registry Exists (Docker Container)
+# ------------------------------------------------------------------
+echo "[1/5] Setting up local registry..."
+verify_registry_ports() {
+  docker inspect -f '{{json .NetworkSettings.Ports}}' "${REGISTRY_NAME}" 2>/dev/null |
+    jq -e --arg rp "${REGISTRY_PORT}" '
+      (."5000/tcp" // []) |
+      (any(.[]; .HostIp == "127.0.0.1" and .HostPort == $rp)) and
+      (any(.[]; .HostIp == "127.0.0.1" and .HostPort == "5000"))
+    ' >/dev/null 2>&1
+}
+
+create_registry() {
+  CREATED_REGISTRY=true
+  docker run \
+    -d --restart=always \
+    -p "127.0.0.1:${REGISTRY_PORT}:5000" \
+    -p "127.0.0.1:5000:5000" \
+    --name "${REGISTRY_NAME}" \
+    registry:2
+}
+
+REGISTRY_STATE="$(docker inspect -f '{{.State.Running}}' "${REGISTRY_NAME}" 2>/dev/null || echo "missing")"
+if [ "$REGISTRY_STATE" = "true" ]; then
+  if verify_registry_ports; then
+    echo "Registry container '${REGISTRY_NAME}' is already running with correct ports."
+  else
+    echo "Registry container '${REGISTRY_NAME}' has wrong port bindings. Recreating..."
+    docker rm -f "${REGISTRY_NAME}"
+    create_registry
+  fi
+elif [ "$REGISTRY_STATE" = "false" ]; then
+  if verify_registry_ports; then
+    echo "Registry container '${REGISTRY_NAME}' exists but is stopped. Starting..."
+    docker start "${REGISTRY_NAME}"
+  else
+    echo "Registry container '${REGISTRY_NAME}' has wrong port bindings. Recreating..."
+    docker rm -f "${REGISTRY_NAME}"
+    create_registry
+  fi
+else
+  create_registry
+fi
+
+# Make the in-cluster registry hostname resolvable from the host.
+# This allows caib (running on the host) to pull artifacts using the same
+# URL that the in-cluster builds push to.
+if ! grep -q "${REGISTRY_HOST}" /etc/hosts; then
+  echo "127.0.0.1 ${REGISTRY_HOST}" | sudo tee -a /etc/hosts >/dev/null
+  echo "Added ${REGISTRY_HOST} to /etc/hosts"
+  CREATED_HOSTS_ENTRY=true
+fi
+
+# Configure containers/image (used by caib) to use HTTP for the local registry.
+# Per-user config avoids requiring sudo for system-wide /etc/containers paths.
+REGISTRIES_CONF_DIR="${HOME}/.config/containers/registries.conf.d"
+REGISTRIES_CONF_FILE="${REGISTRIES_CONF_DIR}/kind-e2e-registry.conf"
+EXPECTED_CONF="[[registry]]
+location = \"${REGISTRY_HOST}:5000\"
+insecure = true"
+if [ -e "$REGISTRIES_CONF_FILE" ] && [ "$(cat "$REGISTRIES_CONF_FILE")" = "$EXPECTED_CONF" ]; then
+  echo "Registries config already matches, skipping write."
+else
+  if [ ! -e "$REGISTRIES_CONF_FILE" ]; then
+    CREATED_REGISTRIES_CONF=true
+  else
+    REGISTRIES_CONF_BACKUP="$(mktemp)"
+    cp "$REGISTRIES_CONF_FILE" "$REGISTRIES_CONF_BACKUP"
+    echo "Backed up existing registries config to $REGISTRIES_CONF_BACKUP"
+  fi
+  mkdir -p "$REGISTRIES_CONF_DIR"
+  tee "$REGISTRIES_CONF_FILE" >/dev/null <<EOF
+[[registry]]
+location = "${REGISTRY_HOST}:5000"
+insecure = true
+EOF
+fi
+
+# ------------------------------------------------------------------
+# [2/5] Create Kind Cluster with Registry Config
+# ------------------------------------------------------------------
+echo "[2/5] Creating Kind cluster..."
+
+# Check if cluster exists
 if kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
   echo "Found existing cluster, deleting..."
   kind delete cluster --name "$CLUSTER_NAME"
 fi
 
-echo ""
-echo "[1/5] Creating Kind cluster..."
 kind create cluster --name "$CLUSTER_NAME" --wait 5m
+echo "Verifying cluster is up..."
+kubectl cluster-info --context "kind-$CLUSTER_NAME"
+# Label node for OperatorConfig nodeSelector
+kubectl label nodes --all aib=true
+kubectl get nodes --show-labels
 
-echo ""
-echo "[2/5] Installing Tekton Pipelines..."
-kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
-echo "Waiting for Tekton Pipelines to be ready..."
+
+
+# Connect the registry to the cluster network if not already connected
+echo "Connecting registry to Kind network..."
+if [ "$(docker inspect -f='{{json .NetworkSettings.Networks.'"${KIND_NETWORK}"'}}' "${REGISTRY_NAME}")" = 'null' ]; then
+  docker network connect "${KIND_NETWORK}" "${REGISTRY_NAME}"
+fi
+
+# Map the registry in the nodes to the docker container
+for node in $(kind get nodes --name "${CLUSTER_NAME}"); do
+  kubectl annotate node "${node}" "kind.x-k8s.io/registry=localhost:${REGISTRY_PORT}" --overwrite
+done
+
+echo "Waiting for node ready..."
+kubectl wait --for=condition=Ready nodes --all --timeout=60s
+
+# ------------------------------------------------------------------
+# [3/5] Setup Internal DNS for Registry (The OpenShift spoof)
+# ------------------------------------------------------------------
+echo "[3/5] Configuring internal registry DNS..."
+
+# 1. Document the local registry (standard Kind practice)
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:${REGISTRY_PORT}"
+    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
+EOF
+
+# 2. Create the Namespace
+kubectl create namespace openshift-image-registry --dry-run=client -o yaml | kubectl apply -f -
+
+# 3. ROBUST IP FETCHING
+# Wait until the registry has an IP on the 'kind' network
+echo "Waiting for registry IP assignment..."
+REGISTRY_IP=""
+for i in $(seq 1 30); do
+  REGISTRY_IP=$(docker inspect -f '{{.NetworkSettings.Networks.'"${KIND_NETWORK}"'.IPAddress}}' "${REGISTRY_NAME}" 2>/dev/null || true)
+  if [ -n "$REGISTRY_IP" ]; then
+    echo "Registry Internal IP found: $REGISTRY_IP"
+    break
+  fi
+  echo "Waiting for IP... (attempt $i/30)"
+  sleep 1
+done
+if [ -z "$REGISTRY_IP" ]; then
+  echo "Failed to discover a Kind-network IP for '${REGISTRY_NAME}' after 30 attempts" >&2
+  exit 1
+fi
+
+# 4. Create Service and Endpoints manually
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Service
+metadata:
+  name: image-registry
+  namespace: openshift-image-registry
+spec:
+  ports:
+  - port: 5000
+    protocol: TCP
+    targetPort: 5000
+  clusterIP: None
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: image-registry
+  namespace: openshift-image-registry
+subsets:
+- addresses:
+  - ip: ${REGISTRY_IP}
+  ports:
+  - port: 5000
+    name: registry
+    protocol: TCP
+EOF
+
+# ------------------------------------------------------------------
+# [4/5] Install Infrastructure (Tekton & Ingress)
+# ------------------------------------------------------------------
+echo "[4/5] Installing Infrastructure..."
+
+# Tekton
+kubectl apply --filename "https://infra.tekton.dev/tekton-releases/pipeline/previous/${TEKTON_VERSION}/release.yaml"
+# Ingress NGINX
+kubectl apply -f "https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-${INGRESS_NGINX_VERSION}/deploy/static/provider/kind/deploy.yaml"
+
+echo "Waiting for Infrastructure..."
 kubectl wait --for=condition=ready pod --all -n tekton-pipelines --timeout=5m
-
-echo ""
-echo "[3/5] Installing NGINX Ingress Controller..."
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
-echo "Waiting for NGINX Ingress Controller to be ready..."
 kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=3m
-
-echo ""
-echo "[4/5] Running E2E tests..."
-export KIND_CLUSTER="$CLUSTER_NAME"
+make build-caib
+# ------------------------------------------------------------------
+# [5/5] Run E2E Tests (self-contained: deploys operator, tests, tears down)
+# ------------------------------------------------------------------
+echo "[5/5] Running E2E Tests..."
+set_build_platform
 export CONTAINER_TOOL=docker
+export KIND_CLUSTER="$CLUSTER_NAME"
+export CAIB_SERVER=http://localhost:8080
+export REGISTRY_USERNAME=kind
+export REGISTRY_PASSWORD=kind
+export REGISTRY_HOST
+export CLUSTER_NAME
 make test-e2e
 
+
 echo ""
 echo "========================================="
-echo "E2E Tests Complete!"
+echo "[5/5] All Tests Complete!"
 echo "========================================="
-

--- a/test/config/test-manifest.aib.yml
+++ b/test/config/test-manifest.aib.yml
@@ -1,0 +1,7 @@
+name: my-automotive-os
+
+# auth:
+#   root_password: $6$xoLqEUz0cGGJRx01$H3H/bFm0myJPULNMtbSsOFd/2BnHqHkMD92Sfxd.EKM9hXTWSmELG8cf205l6dktomuTcgKGGtGDgtvHVXSWU.
+#   sshd_config:
+#     PermitRootLogin: true
+#     PasswordAuthentication: true

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -17,13 +17,16 @@ limitations under the License.
 package e2e
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // Dot import is standard for Ginkgo
@@ -32,7 +35,11 @@ import (
 	utils "github.com/centos-automotive-suite/automotive-dev-operator/test/utils"
 )
 
-const namespace = "automotive-dev-operator-system"
+const (
+	namespace = "automotive-dev-operator-system"
+	archARM64 = "arm64"
+	aarch64   = "aarch64"
+)
 
 // hasOpenShiftRouteCRD returns true when the OpenShift Route CRD exists (OpenShift cluster).
 // On Kind there is no Route CRD, so OIDC suite can skip before creating any resources.
@@ -157,13 +164,13 @@ var _ = Describe("controller", Ordered, func() {
 					return err
 				}
 				tasks := string(output)
-				if !contains(tasks, "build-automotive-image") {
+				if !strings.Contains(tasks, "build-automotive-image") {
 					// Collect controller logs for debugging
 					logCmd := exec.Command("kubectl", "logs", "-n", namespace, "-l", "control-plane=operator", "--tail=50")
 					logs, _ := utils.Run(logCmd)
 					return fmt.Errorf("build-automotive-image task not found, got: %s\nController logs:\n%s", tasks, string(logs))
 				}
-				if !contains(tasks, "push-artifact-registry") {
+				if !strings.Contains(tasks, "push-artifact-registry") {
 					return fmt.Errorf("push-artifact-registry task not found, got: %s", tasks)
 				}
 				return nil
@@ -210,13 +217,13 @@ var _ = Describe("controller", Ordered, func() {
 			if strings.Contains(strings.ToLower(os.Getenv("RUNNER_ARCH")), "arm") ||
 				strings.Contains(strings.ToLower(os.Getenv("HOSTTYPE")), "arm") ||
 				strings.Contains(strings.ToLower(os.Getenv("PROCESSOR_ARCHITECTURE")), "arm") {
-				arch = "arm64"
+				arch = archARM64
 			}
 			// Also check uname for local development
 			unameCmd := exec.Command("uname", "-m")
 			unameOutput, _ := utils.Run(unameCmd)
-			if strings.Contains(string(unameOutput), "arm64") || strings.Contains(string(unameOutput), "aarch64") {
-				arch = "arm64"
+			if strings.Contains(string(unameOutput), archARM64) || strings.Contains(string(unameOutput), aarch64) {
+				arch = archARM64
 			}
 
 			imageBuildYAML := fmt.Sprintf(`
@@ -228,7 +235,7 @@ metadata:
 spec:
   # Common fields
   architecture: %s
-
+  
   # AIB configuration
   aib:
     distro: autosd
@@ -238,7 +245,7 @@ spec:
       name: e2e-test-image
     manifestFileName: "manifest.aib.yml"
     image: quay.io/centos-sig-automotive/automotive-image-builder:latest
-
+  
   # Export configuration
   export:
     format: qcow2
@@ -321,32 +328,294 @@ spec:
 			_, _ = utils.Run(cmd)
 		})
 	})
-})
 
-func contains(s, substr string) bool {
-	if len(s) == 0 || len(substr) == 0 {
-		return false
-	}
-	if s == substr {
-		return true
-	}
-	if len(s) < len(substr) {
-		return false
-	}
-	// Check prefix, suffix, or middle
-	return s[:len(substr)] == substr ||
-		s[len(s)-len(substr):] == substr ||
-		containsMiddle(s, substr)
-}
+	Context("caib image build", func() {
+		var portForwardCmd *exec.Cmd
+		var registryHost string
+		var arch string
+		var caibToken string
+		var projectimage = "automotive-dev-operator:test"
+		var caibBuildTimeout = 45 * time.Minute // max timeout for caib builds
 
-func containsMiddle(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
+		BeforeAll(func() {
+			registryHost = os.Getenv("REGISTRY_HOST")
+			if registryHost == "" {
+				Skip("REGISTRY_HOST not set; caib build tests require a local registry")
+			}
+
+			arch = os.Getenv("ARCH")
+			if arch == "" {
+				unameCmd := exec.Command("uname", "-m")
+				unameOutput, _ := utils.Run(unameCmd)
+				switch strings.TrimSpace(string(unameOutput)) {
+				case archARM64, aarch64:
+					arch = archARM64
+				default:
+					arch = "amd64"
+				}
+			}
+
+			By("ensuring namespace has privileged PSA labels")
+			cmd := exec.Command("kubectl", "label", "namespace", namespace,
+				"pod-security.kubernetes.io/enforce=privileged", "--overwrite")
+			_, err := utils.Run(cmd)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			cmd = exec.Command("kubectl", "label", "namespace", namespace,
+				"pod-security.kubernetes.io/audit=privileged", "--overwrite")
+			_, _ = utils.Run(cmd)
+			cmd = exec.Command("kubectl", "label", "namespace", namespace,
+				"pod-security.kubernetes.io/warn=privileged", "--overwrite")
+			_, _ = utils.Run(cmd)
+
+			By("building the manager(Operator) image")
+			cmd = exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectimage))
+			_, err = utils.Run(cmd)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+			By("loading the the manager(Operator) image on Kind")
+			err = utils.LoadImageToKindClusterWithName(projectimage)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+			By("installing CRDs")
+			cmd = exec.Command("make", "install")
+			_, err = utils.Run(cmd)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+			By("deploying the operator")
+			cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectimage))
+			_, err = utils.Run(cmd)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+			By("waiting for operator deployment to be available")
+			cmd = exec.Command("kubectl", "wait", "--for=condition=available",
+				"--timeout=10m", "deployment/ado-operator", "-n", namespace)
+			_, err = utils.Run(cmd)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+			By("waiting for Build API deployment to be available")
+			cmd = exec.Command("kubectl", "apply", "-f",
+				"config/samples/automotive_v1_operatorconfig.yaml")
+			_, err = utils.Run(cmd)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+			By("waiting for Build API deployment to be available")
+			cmd = exec.Command("kubectl", "wait", "--for=condition=available",
+				"--timeout=8m", "deployment/ado-build-api", "-n", namespace)
+			_, err = utils.Run(cmd)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+			By("patching OperatorConfig for Kind registry")
+			cmd = exec.Command("kubectl", "patch", "operatorconfig", "config",
+				"-n", namespace, "--type=merge",
+				"-p", fmt.Sprintf(`{"spec":{"osBuilds":{"clusterRegistryRoute":"%s:5000"}}}`, registryHost))
+			_, err = utils.Run(cmd)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+			By("waiting for push-artifact-registry Task to be created")
+			waitForPushTask := func() error {
+				taskCmd := exec.Command("kubectl", "get", "task", "push-artifact-registry", "-n", namespace)
+				_, taskErr := utils.Run(taskCmd)
+				return taskErr
+			}
+			EventuallyWithOffset(1, waitForPushTask, 2*time.Minute, 5*time.Second).Should(Succeed(),
+				"push-artifact-registry Task was not created in time")
+
+			// Kind-specific workaround: the local registry uses plain HTTP (no TLS),
+			// so oras push needs --plain-http. On OpenShift the internal registry has
+			// TLS and this flag is not required.
+			// runAsUser: 0 is needed because plain Kubernetes lacks OpenShift's SCC
+			// (Security Context Constraints) that would grant the push step access to
+			// root-owned build artifacts in the shared workspace.
+			By("patching push-artifact-registry Task for Kind (plain-http + runAsUser 0)")
+			cmd = exec.Command("kubectl", "annotate", "task", "push-artifact-registry",
+				"-n", namespace, "automotive.sdv.cloud.redhat.com/unmanaged=true", "--overwrite")
+			_, err = utils.Run(cmd)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+			cmd = exec.Command("bash", "-c",
+				`kubectl get task push-artifact-registry -n `+namespace+` -o json `+
+					`| jq '.spec.steps[0].script |= gsub("push --disable-path-validation"; "push --plain-http --disable-path-validation")' `+
+					`| jq '.spec.steps[0].securityContext = {"runAsUser": 0}' `+
+					`| kubectl replace -f -`)
+			_, err = utils.Run(cmd)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+			By("ensuring port 8080 is free before starting port-forward")
+			if conn, dialErr := net.DialTimeout("tcp", "localhost:8080", 500*time.Millisecond); dialErr == nil {
+				_ = conn.Close()
+				Fail("port 8080 is already in use; cannot set up port-forward to Build API")
+			}
+
+			By("setting up port-forward to Build API")
+			portForwardCmd = exec.Command("kubectl", "port-forward",
+				"-n", namespace, "svc/ado-build-api", "8080:8080")
+			err = portForwardCmd.Start()
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+			By("waiting for Build API to respond on port-forward")
+			httpClient := &http.Client{Timeout: 2 * time.Second}
+			waitForBuildAPI := func() error {
+				resp, httpErr := httpClient.Get("http://localhost:8080/v1/healthz")
+				if httpErr != nil {
+					return httpErr
+				}
+				_ = resp.Body.Close()
+				if resp.StatusCode == http.StatusOK {
+					return nil
+				}
+				return fmt.Errorf("unexpected status %d from Build API /v1/healthz", resp.StatusCode)
+			}
+			EventuallyWithOffset(1, waitForBuildAPI, 30*time.Second, 1*time.Second).Should(Succeed(),
+				"Build API on localhost:8080 did not become ready")
+
+			By("creating service account and token")
+			cmd = exec.Command("kubectl", "create", "serviceaccount", "caib",
+				"-n", namespace, "--dry-run=client", "-o", "yaml")
+			saYAML, saErr := utils.Run(cmd)
+			ExpectWithOffset(1, saErr).NotTo(HaveOccurred())
+			cmd = exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(string(saYAML))
+			_, saErr = utils.Run(cmd)
+			ExpectWithOffset(1, saErr).NotTo(HaveOccurred())
+
+			By("creating caib token")
+			cmd = exec.Command("kubectl", "create", "token", "caib",
+				"-n", namespace, "--duration=1h")
+			tokenOutput, tokenErr := utils.Run(cmd)
+			ExpectWithOffset(1, tokenErr).NotTo(HaveOccurred())
+			caibToken = strings.TrimSpace(string(tokenOutput))
+			ExpectWithOffset(1, caibToken).NotTo(BeEmpty(), "CAIB_TOKEN must not be empty")
+			prevToken, hadPrevToken := os.LookupEnv("CAIB_TOKEN")
+			prevServer, hadPrevServer := os.LookupEnv("CAIB_SERVER")
+			DeferCleanup(func() {
+				if hadPrevToken {
+					_ = os.Setenv("CAIB_TOKEN", prevToken)
+				} else {
+					_ = os.Unsetenv("CAIB_TOKEN")
+				}
+				if hadPrevServer {
+					_ = os.Setenv("CAIB_SERVER", prevServer)
+				} else {
+					_ = os.Unsetenv("CAIB_SERVER")
+				}
+			})
+			setErr := os.Setenv("CAIB_TOKEN", caibToken)
+			ExpectWithOffset(1, setErr).NotTo(HaveOccurred())
+			setErr = os.Setenv("CAIB_SERVER", "http://localhost:8080")
+			ExpectWithOffset(1, setErr).NotTo(HaveOccurred())
+		})
+
+		AfterAll(func() {
+			if portForwardCmd != nil {
+				if portForwardCmd.Process != nil {
+					_ = portForwardCmd.Process.Kill()
+				}
+				_ = portForwardCmd.Wait()
+			}
+		})
+
+		verifyCaibList := func(caibBuildName string) {
+			listCmd := exec.Command("bin/caib", "image", "list")
+			listOutput, listErr := utils.Run(listCmd)
+			ExpectWithOffset(2, listErr).NotTo(HaveOccurred())
+			lines := strings.Split(string(listOutput), "\n")
+			found := false
+			for _, line := range lines {
+				if strings.Contains(line, caibBuildName) {
+					ExpectWithOffset(2, line).To(ContainSubstring("Completed"))
+					found = true
+					break
+				}
+			}
+			ExpectWithOffset(2, found).To(BeTrue(),
+				fmt.Sprintf("build %q not found in caib list output:\n%s", caibBuildName, string(listOutput)))
 		}
-	}
-	return false
-}
+
+		It("should build container and disk images in parallel via caib", func() {
+			containerBuildName := "e2e-test-build-image"
+			diskBuildName := "e2e-test-build-disk-image"
+			diskDir, tmpErr := os.MkdirTemp("", "caib-disk-*")
+			ExpectWithOffset(1, tmpErr).NotTo(HaveOccurred())
+			DeferCleanup(func() { _ = os.RemoveAll(diskDir) })
+			diskImageOutput := diskDir + "/automotive-os-test2-latest.qcow2"
+
+			type buildResult struct {
+				output []byte
+				err    error
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), caibBuildTimeout)
+			defer cancel()
+
+			var wg sync.WaitGroup
+			containerCh := make(chan buildResult, 1)
+			diskCh := make(chan buildResult, 1)
+
+			By("launching container build and disk build in parallel")
+			wg.Add(2)
+
+			go func() {
+				defer wg.Done()
+				cmd := exec.CommandContext(ctx, "bin/caib", "image", "build", "test/config/test-manifest.aib.yml",
+					"--name", containerBuildName,
+					"--arch", arch,
+					"--push", fmt.Sprintf("%s:5000/myorg/automotive-os-test1:latest", registryHost))
+				out, err := utils.RunSafe(cmd)
+				containerCh <- buildResult{output: out, err: err}
+			}()
+
+			go func() {
+				defer wg.Done()
+				cmd := exec.CommandContext(ctx, "bin/caib", "image", "build", "test/config/test-manifest.aib.yml",
+					"--name", diskBuildName,
+					"--arch", arch,
+					"--push", fmt.Sprintf("%s:5000/myorg/automotive-os-test2:latest", registryHost),
+					"--target", "qemu",
+					"--disk",
+					"--format", "qcow2",
+					"--push-disk", fmt.Sprintf("%s:5000/myorg/automotive-os-test2:latest-disk", registryHost),
+					"--output", diskImageOutput)
+				out, err := utils.RunSafe(cmd)
+				diskCh <- buildResult{output: out, err: err}
+			}()
+
+			done := make(chan struct{})
+			go func() {
+				wg.Wait()
+				close(done)
+			}()
+			select {
+			case <-done:
+			case <-ctx.Done():
+				Fail(fmt.Sprintf("caib builds did not complete within %v", caibBuildTimeout))
+			}
+			By("verifying container build completed successfully")
+			cr := <-containerCh
+			ExpectWithOffset(1, cr.err).NotTo(HaveOccurred(),
+				fmt.Sprintf("container build failed:\n%sError: %v\n", string(cr.output), cr.err))
+			ExpectWithOffset(1, string(cr.output)).To(ContainSubstring("Completed"))
+
+			By("verifying disk build completed successfully")
+			dr := <-diskCh
+			ExpectWithOffset(1, dr.err).NotTo(HaveOccurred(),
+				fmt.Sprintf("disk build failed:\n%sError: %v\n", string(dr.output), dr.err))
+			ExpectWithOffset(1, string(dr.output)).To(ContainSubstring("Completed"))
+
+			By("verifying container build appears in caib list")
+			verifyCaibList(containerBuildName)
+
+			By("verifying disk build appears in caib list")
+			verifyCaibList(diskBuildName)
+
+			By("verifying disk image file was downloaded")
+			diskImageDownloadFile := fmt.Sprintf("%s.gz", diskImageOutput)
+			info, statErr := os.Stat(diskImageDownloadFile)
+			ExpectWithOffset(1, statErr).NotTo(HaveOccurred())
+			ExpectWithOffset(1, info.Mode().IsRegular()).To(BeTrue())
+			ExpectWithOffset(1, info.Size()).To(BeNumerically(">", 0))
+		})
+	})
+})
 
 var _ = Describe("OIDC Authentication", Ordered, func() {
 	var oidcSuiteCreatedNamespace bool

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -26,7 +26,8 @@ import (
 	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck // Dot import is standard for Ginkgo
 )
 
-// Run executes the provided command within this context
+// Run executes the provided command within this context.
+// Not goroutine-safe due to os.Chdir; use RunSafe for concurrent execution.
 func Run(cmd *exec.Cmd) ([]byte, error) {
 	dir, _ := GetProjectDir()
 	cmd.Dir = dir
@@ -39,6 +40,24 @@ func Run(cmd *exec.Cmd) ([]byte, error) {
 	command := strings.Join(cmd.Args, " ")
 	_, _ = fmt.Fprintf(GinkgoWriter, "running: %s\n", command)
 	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return output, fmt.Errorf("%s failed with error: (%v) %s", command, err, string(output))
+	}
+
+	return output, nil
+}
+
+// RunSafe executes the provided command using cmd.Dir only (no os.Chdir).
+// Safe to call from multiple goroutines concurrently.
+func RunSafe(cmd *exec.Cmd) ([]byte, error) {
+	dir, _ := GetProjectDir()
+	cmd.Dir = dir
+
+	cmd.Env = append(os.Environ(), "GO111MODULE=on")
+	command := strings.Join(cmd.Args, " ")
+	_, _ = fmt.Fprintf(GinkgoWriter, "running: %s\n", command)
+	output, err := cmd.CombinedOutput()
+	_, _ = fmt.Fprintf(GinkgoWriter, "finished: %s\n", command)
 	if err != nil {
 		return output, fmt.Errorf("%s failed with error: (%v) %s", command, err, string(output))
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved local E2E orchestration: local registry and host/DNS wiring, cluster provisioning, ingress and pipeline deployment, richer failure log collection, extended timeouts, configurable component versions, and thorough cleanup.

* **Tests**
  * Added a comprehensive end-to-end image-build flow with parallel container/disk builds, architecture-aware execution, token/port-forward handling, and robust teardown and verification.

* **Refactor / Utilities**
  * Added a concurrency-safe test command runner and updated test helpers for safer parallel execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


https://github.com/centos-automotive-suite/automotive-dev-operator/issues/24