### PR TITLE
add a jumpstarter namespace field

### DIFF
--- a/api/v1alpha1/operatorconfig_types.go
+++ b/api/v1alpha1/operatorconfig_types.go
@@ -65,6 +65,10 @@ type JumpstarterConfig struct {
 	// +optional
 	Image string `json:"image,omitempty"`
 
+	// Namespace is the OpenShift namespace where Jumpstarter is installed
+	// +optional
+	Namespace string `json:"namespace,omitempty"`
+
 	// TargetMappings maps build targets to Jumpstarter exporter configurations
 	// +optional
 	TargetMappings map[string]JumpstarterTargetMapping `json:"targetMappings,omitempty"`

--- a/bundle/manifests/automotive.sdv.cloud.redhat.com_operatorconfigs.yaml
+++ b/bundle/manifests/automotive.sdv.cloud.redhat.com_operatorconfigs.yaml
@@ -433,6 +433,10 @@ spec:
                     description: Image is the container image for Jumpstarter CLI
                       operations
                     type: string
+                  namespace:
+                    description: Namespace is the OpenShift namespace where Jumpstarter
+                      is installed
+                    type: string
                   targetMappings:
                     additionalProperties:
                       description: JumpstarterTargetMapping defines the Jumpstarter

--- a/config/crd/bases/automotive.sdv.cloud.redhat.com_operatorconfigs.yaml
+++ b/config/crd/bases/automotive.sdv.cloud.redhat.com_operatorconfigs.yaml
@@ -433,6 +433,10 @@ spec:
                     description: Image is the container image for Jumpstarter CLI
                       operations
                     type: string
+                  namespace:
+                    description: Namespace is the OpenShift namespace where Jumpstarter
+                      is installed
+                    type: string
                   targetMappings:
                     additionalProperties:
                       description: JumpstarterTargetMapping defines the Jumpstarter


### PR DESCRIPTION
So we can use a specific jumpstarter instance

fixes https://github.com/centos-automotive-suite/automotive-dev-operator/issues/47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional "namespace" setting to Jumpstarter configuration, letting operators specify the Kubernetes/OpenShift namespace where Jumpstarter is installed.
  * When Jumpstarter runs in namespace-scoped mode, this setting selects which namespace is used for exporter and lease operations.
  * The OperatorConfig/CRD schema has been updated to expose this new optional field; leaving it unset preserves existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->