### PR TITLE
Create catalog directory before writing YAML in deploy-catalog.sh

### DIFF
--- a/hack/deploy-catalog.sh
+++ b/hack/deploy-catalog.sh
@@ -235,6 +235,7 @@ fi
 echo ""
 echo "Regenerating catalog..."
 BUNDLE_IMG_INTERNAL="image-registry.openshift-image-registry.svc:5000/${CATALOG_NAMESPACE}/automotive-dev-operator-bundle:v${VERSION}"
+mkdir -p catalog
 cat > catalog/automotive-dev-operator.yaml << EOF
 ---
 defaultChannel: alpha


### PR DESCRIPTION
create the catalog/ dir during the script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced deployment reliability by ensuring required directories are created before writing configuration files, preventing potential write failures during catalog deployment operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->