### PR TITLE
Add login option for caib and save the configuration locally

### DIFF
--- a/cmd/caib/catalog/add.go
+++ b/cmd/caib/catalog/add.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/config"
 	"github.com/spf13/cobra"
 )
 
@@ -95,10 +96,10 @@ func runAdd(_ *cobra.Command, args []string) error {
 
 	server := serverURL
 	if server == "" {
-		server = os.Getenv("CAIB_SERVER")
+		server = config.DefaultServer()
 	}
 	if server == "" {
-		return fmt.Errorf("server URL required (use --server or CAIB_SERVER env var)")
+		return fmt.Errorf("server URL required (use --server, CAIB_SERVER, or run 'caib login <server-url>')")
 	}
 
 	token := authToken

--- a/cmd/caib/catalog/get.go
+++ b/cmd/caib/catalog/get.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/config"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -45,10 +46,10 @@ func runGet(_ *cobra.Command, args []string) error {
 
 	server := serverURL
 	if server == "" {
-		server = os.Getenv("CAIB_SERVER")
+		server = config.DefaultServer()
 	}
 	if server == "" {
-		return fmt.Errorf("server URL required (use --server or CAIB_SERVER env var)")
+		return fmt.Errorf("server URL required (use --server, CAIB_SERVER, or run 'caib login <server-url>')")
 	}
 
 	token := authToken

--- a/cmd/caib/catalog/list.go
+++ b/cmd/caib/catalog/list.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"text/tabwriter"
 
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/config"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -92,10 +93,10 @@ func runList(_ *cobra.Command, _ []string) error {
 	// Get server URL
 	server := serverURL
 	if server == "" {
-		server = os.Getenv("CAIB_SERVER")
+		server = config.DefaultServer()
 	}
 	if server == "" {
-		return fmt.Errorf("server URL required (use --server or CAIB_SERVER env var)")
+		return fmt.Errorf("server URL required (use --server, CAIB_SERVER env var or run 'caib login <server-url>')")
 	}
 
 	// Get auth token

--- a/cmd/caib/catalog/publish.go
+++ b/cmd/caib/catalog/publish.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/config"
 	"github.com/spf13/cobra"
 )
 
@@ -62,10 +63,10 @@ func runPublish(_ *cobra.Command, args []string) error {
 
 	server := serverURL
 	if server == "" {
-		server = os.Getenv("CAIB_SERVER")
+		server = config.DefaultServer()
 	}
 	if server == "" {
-		return fmt.Errorf("server URL required (use --server or CAIB_SERVER env var)")
+		return fmt.Errorf("server URL required (use --server, CAIB_SERVER, or run 'caib login <server-url>')")
 	}
 
 	token := authToken

--- a/cmd/caib/catalog/remove.go
+++ b/cmd/caib/catalog/remove.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/config"
 	"github.com/spf13/cobra"
 )
 
@@ -51,10 +52,10 @@ func runRemove(_ *cobra.Command, args []string) error {
 
 	server := serverURL
 	if server == "" {
-		server = os.Getenv("CAIB_SERVER")
+		server = config.DefaultServer()
 	}
 	if server == "" {
-		return fmt.Errorf("server URL required (use --server or CAIB_SERVER env var)")
+		return fmt.Errorf("server URL required (use --server, CAIB_SERVER, or run 'caib login <server-url>')")
 	}
 
 	token := authToken

--- a/cmd/caib/catalog/verify.go
+++ b/cmd/caib/catalog/verify.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/config"
 	"github.com/spf13/cobra"
 )
 
@@ -55,10 +56,10 @@ func runVerify(_ *cobra.Command, args []string) error {
 
 	server := serverURL
 	if server == "" {
-		server = os.Getenv("CAIB_SERVER")
+		server = config.DefaultServer()
 	}
 	if server == "" {
-		return fmt.Errorf("server URL required (use --server or CAIB_SERVER env var)")
+		return fmt.Errorf("server URL required (use --server, CAIB_SERVER, or run 'caib login <server-url>')")
 	}
 
 	token := authToken

--- a/cmd/caib/config/config.go
+++ b/cmd/caib/config/config.go
@@ -1,0 +1,76 @@
+// Package config provides local CLI configuration (e.g. default server URL) for caib.
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	configDir  = ".caib"
+	configFile = "cli.json"
+)
+
+// CLIConfig holds saved CLI settings.
+type CLIConfig struct {
+	ServerURL string `json:"server_url"`
+}
+
+// DefaultServer returns the effective default server URL: CAIB_SERVER env, then saved config.
+func DefaultServer() string {
+	if s := strings.TrimSpace(os.Getenv("CAIB_SERVER")); s != "" {
+		return s
+	}
+	cfg, err := Read()
+	if err != nil || cfg == nil {
+		return ""
+	}
+	return strings.TrimSpace(cfg.ServerURL)
+}
+
+// Read reads the CLI config from the user's home directory.
+func Read() (*CLIConfig, error) {
+	dir, err := configDirPath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(filepath.Join(dir, configFile))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var cfg CLIConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// SaveServerURL writes the given server URL to the local config file.
+func SaveServerURL(serverURL string) error {
+	dir, err := configDirPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+	cfg := &CLIConfig{ServerURL: strings.TrimSpace(serverURL)}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, configFile), data, 0600)
+}
+
+func configDirPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, configDir), nil
+}


### PR DESCRIPTION
This PR adds a new flag to the caib CLI that allows users to log in on the first interaction with the server. The server endpoint is saved locally under `~/.caib/cli.json`, eliminating the need to set an environment variable or explicitly pass --server on each iteration.

Usage:
`caib login <server-endpoint>`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `caib login <server-url>` command to save and manage server configuration locally.
  * Server URL is now persisted and used as a default when not provided via flag or environment variable.

* **Improvements**
  * Updated error messages across catalog commands to guide users to use `caib login`, `--server` flag, or `CAIB_SERVER` environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->