### PR TITLE
improve build volumes handling

### DIFF
--- a/api/v1alpha1/operatorconfig_types.go
+++ b/api/v1alpha1/operatorconfig_types.go
@@ -26,7 +26,13 @@ import (
 // This type is used internally for compatibility with task generation
 type BuildConfig struct {
 	// UseMemoryVolumes determines whether to use memory-backed volumes for build operations
+	// Default: false (disk-backed)
 	UseMemoryVolumes bool `json:"useMemoryVolumes,omitempty"`
+
+	// UseMemoryContainerStorage determines whether to use memory-backed volumes for container storage
+	// This controls /var/lib/containers/storage, /run/osbuild, and /var/tmp volumes
+	// Default: false (disk-backed)
+	UseMemoryContainerStorage bool `json:"useMemoryContainerStorage,omitempty"`
 
 	// MemoryVolumeSize specifies the size limit for memory-backed volumes (required if UseMemoryVolumes is true)
 	// Example: "2Gi"
@@ -154,10 +160,18 @@ type OSBuildsConfig struct {
 	Enabled bool `json:"enabled"`
 
 	// UseMemoryVolumes determines whether to use memory-backed volumes for build operations
+	// Default: false (disk-backed)
 	// +optional
 	UseMemoryVolumes bool `json:"useMemoryVolumes,omitempty"`
 
-	// MemoryVolumeSize specifies the size limit for memory-backed volumes (required if UseMemoryVolumes is true)
+	// UseMemoryContainerStorage determines whether to use memory-backed volumes for container storage
+	// This controls /var/lib/containers/storage, /run/osbuild, and /var/tmp volumes
+	// Default: false (disk-backed)
+	// +optional
+	UseMemoryContainerStorage bool `json:"useMemoryContainerStorage,omitempty"`
+
+	// MemoryVolumeSize specifies the size limit for memory-backed volumes
+	// Only used when UseMemoryVolumes or UseMemoryContainerStorage is true
 	// Example: "2Gi"
 	// +optional
 	MemoryVolumeSize string `json:"memoryVolumeSize,omitempty"`

--- a/bundle/manifests/automotive.sdv.cloud.redhat.com_operatorconfigs.yaml
+++ b/bundle/manifests/automotive.sdv.cloud.redhat.com_operatorconfigs.yaml
@@ -475,7 +475,8 @@ spec:
                     type: boolean
                   memoryVolumeSize:
                     description: |-
-                      MemoryVolumeSize specifies the size limit for memory-backed volumes (required if UseMemoryVolumes is true)
+                      MemoryVolumeSize specifies the size limit for memory-backed volumes
+                      Only used when UseMemoryVolumes or UseMemoryContainerStorage is true
                       Example: "2Gi"
                     type: string
                   nodeSelector:
@@ -539,9 +540,16 @@ spec:
                           type: string
                       type: object
                     type: array
+                  useMemoryContainerStorage:
+                    description: |-
+                      UseMemoryContainerStorage determines whether to use memory-backed volumes for container storage
+                      This controls /var/lib/containers/storage, /run/osbuild, and /var/tmp volumes
+                      Default: false (disk-backed)
+                    type: boolean
                   useMemoryVolumes:
-                    description: UseMemoryVolumes determines whether to use memory-backed
-                      volumes for build operations
+                    description: |-
+                      UseMemoryVolumes determines whether to use memory-backed volumes for build operations
+                      Default: false (disk-backed)
                     type: boolean
                 required:
                 - enabled

--- a/config/crd/bases/automotive.sdv.cloud.redhat.com_operatorconfigs.yaml
+++ b/config/crd/bases/automotive.sdv.cloud.redhat.com_operatorconfigs.yaml
@@ -475,7 +475,8 @@ spec:
                     type: boolean
                   memoryVolumeSize:
                     description: |-
-                      MemoryVolumeSize specifies the size limit for memory-backed volumes (required if UseMemoryVolumes is true)
+                      MemoryVolumeSize specifies the size limit for memory-backed volumes
+                      Only used when UseMemoryVolumes or UseMemoryContainerStorage is true
                       Example: "2Gi"
                     type: string
                   nodeSelector:
@@ -539,9 +540,16 @@ spec:
                           type: string
                       type: object
                     type: array
+                  useMemoryContainerStorage:
+                    description: |-
+                      UseMemoryContainerStorage determines whether to use memory-backed volumes for container storage
+                      This controls /var/lib/containers/storage, /run/osbuild, and /var/tmp volumes
+                      Default: false (disk-backed)
+                    type: boolean
                   useMemoryVolumes:
-                    description: UseMemoryVolumes determines whether to use memory-backed
-                      volumes for build operations
+                    description: |-
+                      UseMemoryVolumes determines whether to use memory-backed volumes for build operations
+                      Default: false (disk-backed)
                     type: boolean
                 required:
                 - enabled

--- a/config/samples/automotive_v1_operatorconfig.yaml
+++ b/config/samples/automotive_v1_operatorconfig.yaml
@@ -17,10 +17,17 @@ spec:
     pvcSize: "8Gi"
 
     # Optional: Use memory-backed volumes for faster builds
-    # Requires memoryVolumeSize to be set if enabled
+    # Default: false (disk-backed)
     # useMemoryVolumes: false
 
-    # Optional: Size limit for memory-backed volumes (only if useMemoryVolumes is true)
+    # Optional: Use memory-backed volumes for container storage
+    # Controls /var/lib/containers/storage, /run/osbuild, and /var/tmp volumes
+    # Default: false (disk-backed)
+    # Set to true for memory-backed storage (faster but uses more memory)
+    # useMemoryContainerStorage: false
+
+    # Optional: Size limit for memory-backed volumes
+    # Only used when useMemoryVolumes or useMemoryContainerStorage is true
     # Example: "2Gi"
     # memoryVolumeSize: "2Gi"
 

--- a/internal/controller/operatorconfig/controller.go
+++ b/internal/controller/operatorconfig/controller.go
@@ -485,10 +485,11 @@ func (r *OperatorConfigReconciler) deployOSBuilds(
 	var buildConfig *tasks.BuildConfig
 	if config.Spec.OSBuilds != nil {
 		buildConfig = &tasks.BuildConfig{
-			UseMemoryVolumes: config.Spec.OSBuilds.UseMemoryVolumes,
-			MemoryVolumeSize: config.Spec.OSBuilds.MemoryVolumeSize,
-			PVCSize:          config.Spec.OSBuilds.PVCSize,
-			RuntimeClassName: config.Spec.OSBuilds.RuntimeClassName,
+			UseMemoryVolumes:          config.Spec.OSBuilds.UseMemoryVolumes,
+			UseMemoryContainerStorage: config.Spec.OSBuilds.UseMemoryContainerStorage,
+			MemoryVolumeSize:          config.Spec.OSBuilds.MemoryVolumeSize,
+			PVCSize:                   config.Spec.OSBuilds.PVCSize,
+			RuntimeClassName:          config.Spec.OSBuilds.RuntimeClassName,
 		}
 	}
 
@@ -502,7 +503,7 @@ func (r *OperatorConfigReconciler) deployOSBuilds(
 	tektonTasks := []*tektonv1.Task{
 		tasks.GenerateBuildAutomotiveImageTask(operatorNamespace, buildConfig, ""),
 		tasks.GeneratePushArtifactRegistryTask(operatorNamespace),
-		tasks.GeneratePrepareBuilderTask(operatorNamespace),
+		tasks.GeneratePrepareBuilderTask(operatorNamespace, buildConfig),
 		tasks.GenerateFlashTask(operatorNamespace),
 	}
 


### PR DESCRIPTION
we were using memory volumes by default for too many paths. Instead we should use disk, unless explictly asked by the config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a useMemoryContainerStorage option to enable memory-backed storage for container-specific paths (default: false — disk-backed).

* **Documentation**
  * Clarified that memoryVolumeSize applies only when either memory-backed option is enabled.
  * Updated CRD, sample configuration, and field descriptions to include useMemoryContainerStorage and explicit defaults for memory-backed options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->