### PR TITLE
caib: restore caib download

### DIFF
--- a/internal/buildapi/server.go
+++ b/internal/buildapi/server.go
@@ -1277,7 +1277,9 @@ func getBuild(c *gin.Context, name string) {
 			}
 			return ""
 		}(),
-		Jumpstarter: jumpstarterInfo,
+		ContainerImage: build.Spec.GetContainerPush(),
+		DiskImage:      build.Spec.GetExportOCI(),
+		Jumpstarter:    jumpstarterInfo,
 	})
 }
 

--- a/internal/buildapi/types.go
+++ b/internal/buildapi/types.go
@@ -208,6 +208,8 @@ type BuildResponse struct {
 	RequestedBy    string           `json:"requestedBy,omitempty"`
 	StartTime      string           `json:"startTime,omitempty"`
 	CompletionTime string           `json:"completionTime,omitempty"`
+	ContainerImage string           `json:"containerImage,omitempty"`
+	DiskImage      string           `json:"diskImage,omitempty"`
 	Jumpstarter    *JumpstarterInfo `json:"jumpstarter,omitempty"`
 }
 

--- a/internal/controller/operatorconfig/resources.go
+++ b/internal/controller/operatorconfig/resources.go
@@ -76,10 +76,9 @@ func (r *OperatorConfigReconciler) buildBuildAPIContainers(isOpenShift bool) []c
 	}
 	containers := []corev1.Container{
 		{
-			Name:            "build-api",
-			Image:           getOperatorImage(),
-			ImagePullPolicy: corev1.PullIfNotPresent,
-			Command:         []string{"/build-api"},
+			Name:    "build-api",
+			Image:   getOperatorImage(),
+			Command: []string{"/build-api"},
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("50m"),
@@ -108,9 +107,8 @@ func (r *OperatorConfigReconciler) buildBuildAPIContainers(isOpenShift bool) []c
 	// Only add oauth-proxy on OpenShift
 	if isOpenShift {
 		containers = append(containers, corev1.Container{
-			Name:            "oauth-proxy",
-			Image:           "registry.redhat.io/openshift4/ose-oauth-proxy:latest",
-			ImagePullPolicy: corev1.PullIfNotPresent,
+			Name:  "oauth-proxy",
+			Image: "registry.redhat.io/openshift4/ose-oauth-proxy:latest",
 			Args: []string{
 				"--provider=openshift",
 				"--https-address=",
@@ -199,10 +197,9 @@ func (r *OperatorConfigReconciler) buildBuildAPIDeployment(isOpenShift bool) *ap
 					ServiceAccountName: "ado-controller-manager",
 					InitContainers: []corev1.Container{
 						{
-							Name:            "init-secrets",
-							Image:           getOperatorImage(),
-							ImagePullPolicy: corev1.PullIfNotPresent,
-							Command:         []string{"/init-secrets"},
+							Name:    "init-secrets",
+							Image:   getOperatorImage(),
+							Command: []string{"/init-secrets"},
 							Env: []corev1.EnvVar{
 								{
 									Name: "POD_NAMESPACE",


### PR DESCRIPTION
To download already built images

fixes https://github.com/centos-automotive-suite/automotive-dev-operator/issues/76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command to download disk images from completed builds with server/token flags and output destination.
  * Build status responses now include container and disk image artifact references.

* **Chores**
  * Removed explicit image pull policy specifications to rely on default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->