### PR TITLE
fix flashing to internal registry

### DIFF
--- a/internal/controller/imagebuild/controller.go
+++ b/internal/controller/imagebuild/controller.go
@@ -472,7 +472,7 @@ func (r *ImageBuildReconciler) createBuildTaskRun(
 		}
 		// Resolve the flash image ref — for internal registry builds, translate to external URL
 		flashImageRef := imageBuild.Spec.GetExportOCI()
-		flashOCIAuthSecretName := ""
+		flashOCIAuthSecretName = ""
 		if imageBuild.Spec.GetUseServiceAccountAuth() && flashImageRef != "" {
 			if clusterRegistryRoute != "" {
 				flashImageRef = strings.Replace(flashImageRef,


### PR DESCRIPTION
fix passing credentials, and put caib credentials in a file instead of showing in the output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Registry credentials are written to a temporary auth file (valid ~4 hours) with fallback to inline display if writing fails.
  * Image export/flash operations forward credentials via an auth-file approach when available and consistently capture the operation's exit status.
* **Bug Fixes**
  * Fixed a variable-scoping issue affecting credential handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->