### PR TITLE
add boot_b mapping for ride4 boards

### DIFF
--- a/internal/common/tasks/scripts/push_artifact.sh
+++ b/internal/common/tasks/scripts/push_artifact.sh
@@ -209,6 +209,21 @@ echo ""
 if [ -d "${parts_dir}" ] && [ -n "$(ls -A "${parts_dir}" 2>/dev/null)" ]; then
   echo "Found parts directory: ${parts_dir}"
   echo "Using multi-layer push for individual partition files"
+
+  # For ride4/ridesx4 targets, duplicate boot_a as boot_b so both partitions get flashed
+  case "$target" in
+    ride4*|ridesx4*)
+      for boot_a_file in "${parts_dir}"/boot_a.*; do
+        [ -f "$boot_a_file" ] || continue
+        boot_b_file=$(echo "$boot_a_file" | sed 's/boot_a/boot_b/')
+        if [ ! -f "$boot_b_file" ]; then
+          echo "Duplicating $(basename "$boot_a_file") as $(basename "$boot_b_file") for target $target"
+          cp "$boot_a_file" "$boot_b_file"
+        fi
+      done
+      ;;
+  esac
+
   ls -la "${parts_dir}/"
 
   cd "${parts_dir}"

--- a/internal/controller/operatorconfig/controller.go
+++ b/internal/controller/operatorconfig/controller.go
@@ -571,7 +571,11 @@ func (r *OperatorConfigReconciler) createOrUpdatePartitionConfig(ctx context.Con
 		Data: map[string]string{
 			"partition-rules.yaml": `targets:
   ridesx4:
-    include: ["system_a", "system_b", "boot_a"]
+    include: ["system_a", "system_b", "boot_a", "boot_b"]
+  ridesx4_scmi:
+    include: ["system_a", "system_b", "boot_a", "boot_b"]
+  ride4_sa8775p_sx_r3:
+    include: ["system_a", "system_b", "boot_a", "boot_b"]
 `,
 		},
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced boot partition handling for specific device targets to ensure proper multi-partition flashing.
  * Extended partition configuration support for additional device platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->