### PR TITLE
use containers_image_openpgp tag for building caib

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,7 +246,8 @@ jobs:
             - name: Build CLI for darwin/arm64
               run: |
                   mkdir -p ./bin
-                  CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags "-X main.version=${{ github.ref_name }}" -o ${AIB_CLI_BINARY}-${{ github.ref_name }}-darwin ./cmd/caib/main.go
+                  CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 make build-caib VERSION=${{ github.ref_name }}
+                  cp bin/caib ${AIB_CLI_BINARY}-${{ github.ref_name }}-darwin
 
             - name: Upload darwin/arm64 artifact
               uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -346,7 +346,7 @@ catalog-update: ## Update catalog configuration with current bundle image
 
 .PHONY: build-caib
 build-caib: ## Build the caib tool
-	go build -ldflags "-X main.version=$(VERSION)" -o bin/caib cmd/caib/main.go
+	go build -tags containers_image_openpgp -ldflags "-X main.version=$(VERSION)" -o bin/caib cmd/caib/main.go
 
 .PHONY: build-api-server
 build-api-server: ## Build the api server


### PR DESCRIPTION
To avoid gpgme issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to improve build process consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->