### PR TITLE
fix bootc build with PVC scratch volumes

### DIFF
--- a/internal/common/tasks/scripts/build_image.sh
+++ b/internal/common/tasks/scripts/build_image.sh
@@ -70,6 +70,11 @@ if [ "$(params.use-persistent-cache)" = "true" ]; then
   done
 else
   BUILD_DIR="/_build"
+
+  # When scratch volumes are PVC-backed (usePVCScratchVolumes), OpenShift applies
+  # setgid + namespace GID on the mount. Clear it so osbuild doesn't create files
+  # with GIDs that don't exist in the target rootfs.
+  chmod g-s "/_build" 2>/dev/null || true
 fi
 
 install_custom_ca_certs


### PR DESCRIPTION
openshift applies setgid + namespace GID on PVC mount points. When usePVCScratchVolumes is enabled, the build-dir scratch volume is a PVC subpath, causing osbuild to create files that inherit a GID not present in the target rootfs. ostree.preptree then fails with "failed to find group ID".

Clear the setgid bit on /_build before the build starts. This is a no-op on emptyDir/tmpfs mounts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved file ownership issues in build processes using PVC-backed scratch volumes to ensure artifacts are created with valid GIDs compatible with target environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->