### PR TITLE
fix: generate catalog YAML from scratch using opm render

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -338,14 +338,24 @@ catalog-deploy: ## Build and deploy the catalog to OpenShift OperatorHub
 	./deploy-catalog.sh
 
 .PHONY: catalog-update
-catalog-update: ## Update catalog configuration with current version
-	@echo "Updating catalog configuration for version $(VERSION)..."
-	@sed -i.bak \
-		-e "s|name: automotive-dev-operator\.v[^[:space:]]*|name: automotive-dev-operator.v$(VERSION)|g" \
-		-e "s|image:[[:space:]]*[^[:space:]]*automotive-dev-operator-bundle:[^[:space:]]*|image: $(BUNDLE_IMG)|g" \
-		catalog/automotive-dev-operator.yaml
-	@rm -f catalog/automotive-dev-operator.yaml.bak
-	@echo "Catalog updated to version $(VERSION) with bundle image: $(BUNDLE_IMG)"
+catalog-update: opm ## Generate catalog configuration for current version
+	@echo "Generating catalog configuration for version $(VERSION)..."
+	@mkdir -p catalog
+	@{ \
+		echo "---"; \
+		echo "defaultChannel: $(or $(DEFAULT_CHANNEL),alpha)"; \
+		echo "name: automotive-dev-operator"; \
+		echo "schema: olm.package"; \
+		echo "---"; \
+		echo "schema: olm.channel"; \
+		echo "package: automotive-dev-operator"; \
+		echo "name: $(or $(DEFAULT_CHANNEL),alpha)"; \
+		echo "entries:"; \
+		echo "  - name: automotive-dev-operator.v$(VERSION)"; \
+		echo "---"; \
+		$(OPM) render $(BUNDLE_IMG); \
+	} > catalog/automotive-dev-operator.yaml
+	@echo "Catalog generated for version $(VERSION) with bundle image: $(BUNDLE_IMG)"
 
 .PHONY: build-caib
 build-caib: ## Build the caib tool

--- a/Makefile
+++ b/Makefile
@@ -355,6 +355,19 @@ catalog-update: opm ## Generate catalog configuration for current version
 		echo "---"; \
 		$(OPM) render $(BUNDLE_IMG); \
 	} > catalog/automotive-dev-operator.yaml
+	@# Add openshift-pipelines dependency (opm render doesn't include it)
+	@awk '\
+		/^- type: olm\.package$$/ { in_pkg=1 } \
+		in_pkg && /version:/ { \
+			print; \
+			print "- type: olm.package.required"; \
+			print "  value:"; \
+			print "    packageName: openshift-pipelines-operator-rh"; \
+			print "    versionRange: \">=1.12.0\""; \
+			in_pkg=0; next \
+		} \
+		{ print }' catalog/automotive-dev-operator.yaml > catalog/automotive-dev-operator.yaml.tmp
+	@mv catalog/automotive-dev-operator.yaml.tmp catalog/automotive-dev-operator.yaml
 	@echo "Catalog generated for version $(VERSION) with bundle image: $(BUNDLE_IMG)"
 
 .PHONY: build-caib


### PR DESCRIPTION
catalog/automotive-dev-operator.yaml is gitignored and doesn't exist in CI checkouts. Replace sed-based catalog-update with opm render to generate the full FBC catalog from the bundle image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build now fully regenerates the operator catalog for the current version to ensure consistent, reliable catalog output instead of in-place edits.
  * The regenerated catalog automatically includes a required dependency for the pipelines operator and updates completion logging to indicate generated output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->