### PR TITLE
add Tekton Chains type hints and osbuild manifest attestation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ env:
     OPERATOR_IMAGE: ${{ vars.REGISTRY }}/${{ vars.REPOSITORY }}/automotive-dev-operator
     TOOLCHAIN_IMAGE: ${{ vars.REGISTRY }}/${{ vars.REPOSITORY }}/autosd-toolchain
     AIB_BASE_IMAGE: ${{ vars.REGISTRY }}/${{ vars.REPOSITORY }}/aib-base-dev
+    TEKTON_BUNDLE_IMAGE: ${{ vars.REGISTRY }}/${{ vars.REPOSITORY }}/automotive-dev-tekton-tasks
     VERSION: ${{ github.sha }}
     AIB_CLI_BINARY: "caib"
 
@@ -137,14 +138,64 @@ jobs:
                   ${{ env.TOOLCHAIN_IMAGE }}:latest-amd64 \
                   ${{ env.TOOLCHAIN_IMAGE }}:latest-arm64
 
+    build-tekton-bundle:
+        runs-on: ubuntu-latest
+        if: startsWith(github.ref, 'refs/heads/main') || startsWith(github.ref, 'refs/heads/release-')
+        steps:
+            - uses: actions/checkout@v6
+
+            - name: Set up Go
+              uses: actions/setup-go@v5
+              with:
+                  go-version: "1.24"
+
+            - name: Install tkn CLI
+              run: |
+                  curl -sSLO "https://github.com/tektoncd/cli/releases/download/v0.44.1/tkn_0.44.1_Linux_x86_64.tar.gz"
+                  echo "e18d287d9aabf6cf4e8281d2871a38e66b50ff6eb4d6d6c84d3e4d357bde1373  tkn_0.44.1_Linux_x86_64.tar.gz" | sha256sum -c
+                  tar xzf tkn_0.44.1_Linux_x86_64.tar.gz tkn
+                  sudo mv tkn /usr/local/bin/
+
+            - name: Login to Quay.io
+              uses: docker/login-action@v3
+              with:
+                  registry: ${{ env.REGISTRY }}
+                  username: ${{ secrets.REGISTRY_USER }}
+                  password: ${{ secrets.REGISTRY_PASSWORD }}
+
+            - name: Export Tekton tasks
+              run: make export-tasks
+
+            - name: Push Tekton Bundle
+              run: |
+                  bundle_args=()
+                  for f in _output/tasks/*.yaml; do
+                      bundle_args+=(-f "$f")
+                  done
+                  tkn bundle push "${{ env.TEKTON_BUNDLE_IMAGE }}:${{ env.VERSION }}" "${bundle_args[@]}"
+                  tkn bundle push "${{ env.TEKTON_BUNDLE_IMAGE }}:latest" "${bundle_args[@]}"
+
     retag-on-release:
         runs-on: ubuntu-latest
         if: startsWith(github.ref, 'refs/tags/')
+        outputs:
+            tekton-bundle-digest: ${{ steps.retag-bundle.outputs.digest }}
         steps:
             - uses: actions/checkout@v6
 
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v4
+
+            - name: Install crane
+              run: |
+                  curl -fsSLO "https://github.com/google/go-containerregistry/releases/download/v0.21.5/go-containerregistry_Linux_x86_64.tar.gz"
+                  curl -fsSLO "https://github.com/google/go-containerregistry/releases/download/v0.21.5/checksums.txt"
+                  grep "go-containerregistry_Linux_x86_64.tar.gz" checksums.txt | sha256sum -c -
+                  tar xzf go-containerregistry_Linux_x86_64.tar.gz crane
+                  sudo mv crane /usr/local/bin/
+
+            - name: Install cosign
+              uses: sigstore/cosign-installer@v3
 
             - name: Login to Quay.io
               uses: docker/login-action@v3
@@ -165,6 +216,18 @@ jobs:
                   TAG_NAME: ${{ github.ref_name }}
               run: |
                   docker buildx imagetools create -t "${{ env.TOOLCHAIN_IMAGE }}:${TAG_NAME}" "${{ env.TOOLCHAIN_IMAGE }}:${{ env.VERSION }}"
+
+            - name: Retag and sign Tekton Bundle
+              id: retag-bundle
+              env:
+                  TAG_NAME: ${{ github.ref_name }}
+                  COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+                  COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+              run: |
+                  crane tag "${{ env.TEKTON_BUNDLE_IMAGE }}:${{ env.VERSION }}" "${TAG_NAME}"
+                  cosign sign --yes --key env://COSIGN_PRIVATE_KEY "${{ env.TEKTON_BUNDLE_IMAGE }}:${TAG_NAME}"
+                  BUNDLE_DIGEST=$(crane digest "${{ env.TEKTON_BUNDLE_IMAGE }}:${TAG_NAME}")
+                  echo "digest=${BUNDLE_DIGEST}" >> "$GITHUB_OUTPUT"
 
     build-bundle:
         runs-on: ubuntu-latest
@@ -344,7 +407,7 @@ jobs:
     create-release:
         permissions:
             contents: write
-        needs: [build-caib-arm64, build-caib-amd64, build-caib-darwin-arm64, build-bundle, build-catalog]
+        needs: [build-caib-arm64, build-caib-amd64, build-caib-darwin-arm64, build-bundle, build-catalog, retag-on-release]
         runs-on: ubuntu-latest
         if: startsWith(github.ref, 'refs/tags/')
         steps:
@@ -399,6 +462,8 @@ jobs:
                       - Operator: `${{ env.OPERATOR_IMAGE }}:${{ github.ref_name }}`
                       - Bundle: `${{ vars.REGISTRY }}/${{ vars.REPOSITORY }}/automotive-dev-operator-bundle:${{ github.ref_name }}`
                       - Catalog: `${{ vars.REGISTRY }}/${{ vars.REPOSITORY }}/automotive-dev-operator-catalog:${{ github.ref_name }}`
+                      - Tekton Tasks Bundle: `${{ env.TEKTON_BUNDLE_IMAGE }}:${{ github.ref_name }}` (cosign signed)
+                        - Secure build ref: `${{ env.TEKTON_BUNDLE_IMAGE }}:${{ github.ref_name }}@${{ needs.retag-on-release.outputs.tekton-bundle-digest }}`
                       - Toolchain: `${{ env.TOOLCHAIN_IMAGE }}:${{ github.ref_name }}`
 
                       ### Install

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ pull-secret*
 
 catalog/automotive-dev-operator.yaml
 bundle/
+_output/

--- a/Makefile
+++ b/Makefile
@@ -378,6 +378,18 @@ build-caib: ## Build the caib tool
 build-api-server: ## Build the api server
 	go build -o bin/build-api cmd/build-api/main.go
 
+# Tekton Bundle configuration
+TEKTON_TASKS_DIR ?= _output/tasks
+TEKTON_BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-tekton-tasks:$(VERSION)
+
+.PHONY: export-tasks
+export-tasks: ## Export Tekton task definitions as YAML
+	go run ./cmd/export-tasks --output-dir $(TEKTON_TASKS_DIR)
+
+.PHONY: bundle-tasks
+bundle-tasks: export-tasks ## Build and push a Tekton Bundle OCI image from exported tasks
+	tkn bundle push $(TEKTON_BUNDLE_IMG) $(addprefix -f ,$(wildcard $(TEKTON_TASKS_DIR)/*.yaml))
+
 ##@ Release
 
 .PHONY: prepare-release

--- a/api/v1alpha1/imagebuild_types.go
+++ b/api/v1alpha1/imagebuild_types.go
@@ -64,6 +64,18 @@ type ImageBuildSpec struct {
 	// on completion so subsequent builds can reuse it.
 	// +optional
 	Workspace string `json:"workspace,omitempty"`
+
+	// SecureBuild enables supply chain security for this build.
+	// When true, pipeline tasks are resolved from the signed Tekton Bundle
+	// specified in TaskBundleRef instead of cluster-installed tasks.
+	// +optional
+	SecureBuild bool `json:"secureBuild,omitempty"`
+
+	// TaskBundleRef is the digest-pinned OCI reference to the Tekton Bundle
+	// used for this build. Set automatically by the Build API from the
+	// OperatorConfig at request time to prevent TOCTOU races.
+	// +optional
+	TaskBundleRef string `json:"taskBundleRef,omitempty"`
 }
 
 // FlashSpec defines configuration for flashing images to hardware via Jumpstarter

--- a/api/v1alpha1/operatorconfig_types.go
+++ b/api/v1alpha1/operatorconfig_types.go
@@ -535,6 +535,14 @@ type OSBuildsConfig struct {
 	// Certificates defines trusted certificate configuration for build tasks.
 	// +optional
 	Certificates *BuildCertificatesConfig `json:"certificates,omitempty"`
+
+	// TaskBundleRef is the OCI reference to a signed Tekton Bundle containing task definitions.
+	// When set, builds created with SecureBuild=true will resolve tasks from this bundle
+	// instead of the cluster-installed tasks. The bundle should be signed with cosign
+	// and contain the same tasks as the operator deploys.
+	// Example: "quay.io/rh-sdv-cloud/automotive-dev-tekton-tasks:v0.1.0@sha256:abc123..."
+	// +optional
+	TaskBundleRef string `json:"taskBundleRef,omitempty"`
 }
 
 // CertificateSourceRef references a Secret or ConfigMap that contains trusted CA certificates.

--- a/cmd/caib/buildcmd/build.go
+++ b/cmd/caib/buildcmd/build.go
@@ -70,6 +70,8 @@ type Options struct {
 	InternalRegistryImageName *string
 	InternalRegistryTag       *string
 
+	SecureBuild *bool
+
 	InsecureSkipTLS *bool
 
 	HandleError func(error)
@@ -444,6 +446,7 @@ func (h *Handler) RunBuild(cmd *cobra.Command, args []string) {
 		ExportOCI:              *h.opts.ExportOCI,
 		BuilderImage:           *h.opts.BuilderImage,
 		RebuildBuilder:         *h.opts.RebuildBuilder,
+		SecureBuild:            *h.opts.SecureBuild,
 	}
 
 	if err := h.applyRegistryCredentialsToRequest(&req); err != nil {
@@ -555,6 +558,7 @@ func (h *Handler) RunDisk(cmd *cobra.Command, args []string) {
 		AIBExtraArgs:           *h.opts.AIBExtraArgs,
 		Compression:            *h.opts.CompressionAlgo,
 		ExportOCI:              *h.opts.ExportOCI,
+		SecureBuild:            *h.opts.SecureBuild,
 	}
 
 	if err := h.applyRegistryCredentialsToRequest(&req); err != nil {
@@ -683,6 +687,7 @@ func (h *Handler) RunBuildDev(cmd *cobra.Command, args []string) {
 		Workspace:              *h.opts.Workspace,
 		Compression:            *h.opts.CompressionAlgo,
 		ExportOCI:              *h.opts.ExportOCI,
+		SecureBuild:            *h.opts.SecureBuild,
 	}
 
 	if err := h.applyRegistryCredentialsToRequest(&req); err != nil {

--- a/cmd/caib/buildcmd/build_disk_test.go
+++ b/cmd/caib/buildcmd/build_disk_test.go
@@ -45,6 +45,7 @@ func newTestDiskOpts() Options {
 		useInternalRegistry  bool
 		internalRegImageName string
 		internalRegTag       string
+		secureBuild          bool
 		insecureSkipTLS      bool
 	)
 	return Options{
@@ -81,6 +82,7 @@ func newTestDiskOpts() Options {
 		UseInternalRegistry:       &useInternalRegistry,
 		InternalRegistryImageName: &internalRegImageName,
 		InternalRegistryTag:       &internalRegTag,
+		SecureBuild:               &secureBuild,
 		InsecureSkipTLS:           &insecureSkipTLS,
 	}
 }

--- a/cmd/caib/image/image.go
+++ b/cmd/caib/image/image.go
@@ -68,6 +68,8 @@ type Options struct {
 	InternalRegistryImageName *string
 	InternalRegistryTag       *string
 
+	SecureBuild *bool
+
 	SealedBuilderImage      *string
 	SealedArchitecture      *string
 	SealedKeySecret         *string
@@ -154,6 +156,8 @@ func NewImageCmd(opts Options) *cobra.Command {
 	buildCmd.Flags().StringVar(opts.LeaseName, "lease", "", "existing Jumpstarter lease name (mutually exclusive with --lease-duration)")
 	buildCmd.Flags().StringVar(opts.FlashCmd, "flash-cmd", "", "override flash command (default: from OperatorConfig target mapping)")
 	buildCmd.Flags().StringVar(opts.ExporterSelector, "exporter", "", "direct exporter selector for flash (alternative to --target lookup)")
+	// Secure build
+	buildCmd.Flags().BoolVar(opts.SecureBuild, "secure", false, "resolve tasks from signed Tekton Bundle (requires OperatorConfig taskBundleRef)")
 	// Internal registry options
 	buildCmd.Flags().BoolVar(opts.UseInternalRegistry, "internal-registry", false, "push to OpenShift internal registry")
 	buildCmd.Flags().StringVar(opts.InternalRegistryImageName, "image-name", "", "override image name for internal registry (default: build name)")
@@ -209,6 +213,8 @@ func NewImageCmd(opts Options) *cobra.Command {
 	diskCmd.Flags().StringVar(opts.LeaseName, "lease", "", "existing Jumpstarter lease name (mutually exclusive with --lease-duration)")
 	diskCmd.Flags().StringVar(opts.FlashCmd, "flash-cmd", "", "override flash command (default: from OperatorConfig target mapping)")
 	diskCmd.Flags().StringVar(opts.ExporterSelector, "exporter", "", "direct exporter selector for flash (alternative to --target lookup)")
+	// Secure build
+	diskCmd.Flags().BoolVar(opts.SecureBuild, "secure", false, "resolve tasks from signed Tekton Bundle (requires OperatorConfig taskBundleRef)")
 	// Internal registry options
 	diskCmd.Flags().BoolVar(opts.UseInternalRegistry, "internal-registry", false, "push to OpenShift internal registry")
 	diskCmd.Flags().StringVar(opts.InternalRegistryImageName, "image-name", "", "override image name for internal registry (default: build name)")
@@ -251,6 +257,8 @@ func NewImageCmd(opts Options) *cobra.Command {
 	buildDevCmd.Flags().StringVar(opts.LeaseName, "lease", "", "existing Jumpstarter lease name (mutually exclusive with --lease-duration)")
 	buildDevCmd.Flags().StringVar(opts.FlashCmd, "flash-cmd", "", "override flash command (default: from OperatorConfig target mapping)")
 	buildDevCmd.Flags().StringVar(opts.ExporterSelector, "exporter", "", "direct exporter selector for flash (alternative to --target lookup)")
+	// Secure build
+	buildDevCmd.Flags().BoolVar(opts.SecureBuild, "secure", false, "resolve tasks from signed Tekton Bundle (requires OperatorConfig taskBundleRef)")
 	// Internal registry options
 	buildDevCmd.Flags().BoolVar(opts.UseInternalRegistry, "internal-registry", false, "push to OpenShift internal registry")
 	buildDevCmd.Flags().StringVar(opts.InternalRegistryImageName, "image-name", "", "override image name for internal registry (default: build name)")

--- a/cmd/caib/main.go
+++ b/cmd/caib/main.go
@@ -59,6 +59,9 @@ var (
 	internalRegistryImageName string
 	internalRegistryTag       string
 
+	// Secure build
+	secureBuild bool
+
 	// TLS options
 	insecureSkipTLS bool
 

--- a/cmd/caib/runtime_wiring.go
+++ b/cmd/caib/runtime_wiring.go
@@ -54,6 +54,8 @@ type runtimeState struct {
 	InternalRegistryImageName *string
 	InternalRegistryTag       *string
 
+	SecureBuild *bool
+
 	InsecureSkipTLS *bool
 
 	SealedBuilderImage      *string
@@ -111,6 +113,8 @@ func newRuntimeState() runtimeState {
 		UseInternalRegistry:       &useInternalRegistry,
 		InternalRegistryImageName: &internalRegistryImageName,
 		InternalRegistryTag:       &internalRegistryTag,
+
+		SecureBuild: &secureBuild,
 
 		InsecureSkipTLS: &insecureSkipTLS,
 
@@ -175,6 +179,7 @@ func (s runtimeState) newHandlers() handlerSet {
 			UseInternalRegistry:       s.UseInternalRegistry,
 			InternalRegistryImageName: s.InternalRegistryImageName,
 			InternalRegistryTag:       s.InternalRegistryTag,
+			SecureBuild:               s.SecureBuild,
 			InsecureSkipTLS:           s.InsecureSkipTLS,
 			HandleError:               handleError,
 		}),
@@ -294,6 +299,8 @@ func (s runtimeState) imageOptions(h handlerSet) image.Options {
 		UseInternalRegistry:       s.UseInternalRegistry,
 		InternalRegistryImageName: s.InternalRegistryImageName,
 		InternalRegistryTag:       s.InternalRegistryTag,
+
+		SecureBuild: s.SecureBuild,
 
 		SealedBuilderImage:      s.SealedBuilderImage,
 		SealedArchitecture:      s.SealedArchitecture,

--- a/cmd/export-tasks/main.go
+++ b/cmd/export-tasks/main.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package main exports Tekton Task definitions as YAML files for Tekton Bundle packaging.
+// Tasks are generated from the same Go code used by the operator, ensuring the bundle
+// contains the exact same task definitions as cluster-installed ones.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/tasks"
+)
+
+func main() {
+	outputDir := flag.String("output-dir", "", "Directory to write task YAML files (writes to stdout if empty)")
+	flag.Parse()
+
+	// Use nil buildConfig for defaults — bundle tasks should not bake in
+	// cluster-specific settings like memory volumes or custom timeouts.
+	taskList := []*tektonv1.Task{
+		tasks.GenerateBuildAutomotiveImageTask("", nil, ""),
+		tasks.GeneratePushArtifactRegistryTask("", nil),
+		tasks.GeneratePrepareBuilderTask("", nil),
+		tasks.GenerateFlashTask("", nil),
+	}
+	taskList = append(taskList, tasks.GenerateSealedTasks("")...)
+
+	if *outputDir != "" {
+		if err := os.MkdirAll(*outputDir, 0o755); err != nil {
+			fmt.Fprintf(os.Stderr, "error creating output directory: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	for _, task := range taskList {
+		// Strip namespace and runtime metadata — these are cluster concerns, not bundle content.
+		task.Namespace = ""
+		task.ManagedFields = nil
+		task.ResourceVersion = ""
+		task.UID = ""
+		task.CreationTimestamp.Reset()
+
+		data, err := yaml.Marshal(task)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error marshaling task %s: %v\n", task.Name, err)
+			os.Exit(1)
+		}
+
+		if *outputDir == "" {
+			fmt.Printf("---\n%s", data)
+		} else {
+			path := filepath.Join(*outputDir, task.Name+".yaml")
+			if err := os.WriteFile(path, data, 0o644); err != nil {
+				fmt.Fprintf(os.Stderr, "error writing %s: %v\n", path, err)
+				os.Exit(1)
+			}
+			fmt.Printf("wrote %s\n", path)
+		}
+	}
+}

--- a/config/crd/bases/automotive.sdv.cloud.redhat.com_imagebuilds.yaml
+++ b/config/crd/bases/automotive.sdv.cloud.redhat.com_imagebuilds.yaml
@@ -199,9 +199,21 @@ spec:
                   SecretRef is the name of the secret containing credentials for registry operations
                   The secret should contain keys like REGISTRY_AUTH_FILE for authentication
                 type: string
+              secureBuild:
+                description: |-
+                  SecureBuild enables supply chain security for this build.
+                  When true, pipeline tasks are resolved from the signed Tekton Bundle
+                  specified in TaskBundleRef instead of cluster-installed tasks.
+                type: boolean
               storageClass:
                 description: StorageClass is the name of the storage class to use
                   for the build PVC
+                type: string
+              taskBundleRef:
+                description: |-
+                  TaskBundleRef is the digest-pinned OCI reference to the Tekton Bundle
+                  used for this build. Set automatically by the Build API from the
+                  OperatorConfig at request time to prevent TOCTOU races.
                 type: string
               workspace:
                 description: |-

--- a/config/crd/bases/automotive.sdv.cloud.redhat.com_operatorconfigs.yaml
+++ b/config/crd/bases/automotive.sdv.cloud.redhat.com_operatorconfigs.yaml
@@ -762,6 +762,14 @@ spec:
                       StorageClass specifies the storage class for build PVCs
                       If empty, the cluster default storage class is used
                     type: string
+                  taskBundleRef:
+                    description: |-
+                      TaskBundleRef is the OCI reference to a signed Tekton Bundle containing task definitions.
+                      When set, builds created with SecureBuild=true will resolve tasks from this bundle
+                      instead of the cluster-installed tasks. The bundle should be signed with cosign
+                      and contain the same tasks as the operator deploys.
+                      Example: "quay.io/rh-sdv-cloud/automotive-dev-tekton-tasks:v0.1.0@sha256:abc123..."
+                    type: string
                   tolerations:
                     description: |-
                       Tolerations specifies tolerations to be added to build pods

--- a/internal/buildapi/server.go
+++ b/internal/buildapi/server.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -1936,6 +1937,26 @@ func buildAIBSpec(req *BuildRequest, manifest, manifestFileName string, inputFil
 	}
 }
 
+// digestPinnedRef matches an OCI reference with a sha256 digest: image@sha256:<64 hex chars>
+var digestPinnedRef = regexp.MustCompile(`^.+@sha256:[a-fA-F0-9]{64}$`)
+
+// validateSecureBuild checks that the OperatorConfig has a valid digest-pinned taskBundleRef.
+// Returns the validated ref, an HTTP status code, and error.
+func validateSecureBuild(ctx context.Context, k8sClient client.Client, namespace string) (string, int, error) {
+	operatorConfig := &automotivev1alpha1.OperatorConfig{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: "config", Namespace: namespace}, operatorConfig); err != nil {
+		return "", http.StatusInternalServerError, fmt.Errorf("secureBuild requested but OperatorConfig could not be read: %v", err)
+	}
+	if operatorConfig.Spec.OSBuilds == nil || operatorConfig.Spec.OSBuilds.TaskBundleRef == "" {
+		return "", http.StatusBadRequest, fmt.Errorf("secureBuild requested but OperatorConfig.spec.osBuilds.taskBundleRef is not set")
+	}
+	ref := strings.TrimSpace(operatorConfig.Spec.OSBuilds.TaskBundleRef)
+	if !digestPinnedRef.MatchString(ref) {
+		return "", http.StatusBadRequest, fmt.Errorf("secureBuild requires a digest-pinned taskBundleRef (must match image@sha256:<64 hex>), got %q", ref)
+	}
+	return ref, 0, nil
+}
+
 func (a *APIServer) createBuild(c *gin.Context) {
 	var req BuildRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -1985,6 +2006,19 @@ func (a *APIServer) createBuild(c *gin.Context) {
 	ctx := c.Request.Context()
 	namespace := resolveNamespace()
 	requestedBy := a.resolveRequester(c)
+
+	// Validate secureBuild requirements early, before creating any resources.
+	// Snapshot the validated ref to prevent TOCTOU races with OperatorConfig changes.
+	var taskBundleRef string
+	if req.SecureBuild {
+		var statusCode int
+		var err error
+		taskBundleRef, statusCode, err = validateSecureBuild(ctx, k8sClient, namespace)
+		if err != nil {
+			c.JSON(statusCode, gin.H{"error": err.Error()})
+			return
+		}
+	}
 
 	// Resolve --workspace: create/find build-cache PVC, forward lease, start file server
 	var buildCachePVCName string
@@ -2065,6 +2099,8 @@ func (a *APIServer) createBuild(c *gin.Context) {
 			Flash:         flashSpec,
 			BuildCachePVC: buildCachePVCName,
 			Workspace:     req.Workspace,
+			SecureBuild:   req.SecureBuild,
+			TaskBundleRef: taskBundleRef,
 		},
 	}
 	if err := k8sClient.Create(ctx, imageBuild); err != nil {
@@ -2355,6 +2391,7 @@ func getBuildTemplate(c *gin.Context, name string) {
 			CustomDefs:             build.Spec.GetCustomDefs(),
 			AIBExtraArgs:           build.Spec.GetAIBExtraArgs(),
 			Compression:            build.Spec.GetCompression(),
+			SecureBuild:            build.Spec.SecureBuild,
 		},
 		SourceFiles: sourceFiles,
 	})

--- a/internal/buildapi/types.go
+++ b/internal/buildapi/types.go
@@ -141,6 +141,9 @@ type BuildRequest struct {
 	InternalRegistryImageName string `json:"internalRegistryImageName,omitempty"` // Override image name (default: build name)
 	InternalRegistryTag       string `json:"internalRegistryTag,omitempty"`       // Tag for internal registry image (default: "bootc" for bootc mode, "disk" for disk/traditional mode)
 
+	// Secure build: resolve tasks from signed Tekton Bundle
+	SecureBuild bool `json:"secureBuild,omitempty"`
+
 	// Flash configuration for Jumpstarter device flashing after build
 	FlashEnabled          bool   `json:"flashEnabled,omitempty"`          // Enable flashing after build
 	FlashClientConfig     string `json:"flashClientConfig,omitempty"`     // Base64-encoded Jumpstarter client config

--- a/internal/common/tasks/pipeline_test.go
+++ b/internal/common/tasks/pipeline_test.go
@@ -1,0 +1,277 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildTaskRef_ClusterResolver(t *testing.T) {
+	ref := buildTaskRef("build-automotive-image", "test-ns", nil)
+
+	if ref.Resolver != TaskResolverCluster {
+		t.Fatalf("expected cluster resolver, got %q", ref.Resolver)
+	}
+
+	params := make(map[string]string)
+	for _, p := range ref.Params {
+		params[p.Name] = p.Value.StringVal
+	}
+
+	if params["name"] != "build-automotive-image" {
+		t.Errorf("expected name=build-automotive-image, got %q", params["name"])
+	}
+	if params["namespace"] != "test-ns" {
+		t.Errorf("expected namespace=test-ns, got %q", params["namespace"])
+	}
+	if params["kind"] != "task" {
+		t.Errorf("expected kind=task, got %q", params["kind"])
+	}
+}
+
+func TestBuildTaskRef_ClusterResolver_NilBuildConfig(t *testing.T) {
+	ref := buildTaskRef("push-artifact-registry", "ns", nil)
+	if ref.Resolver != TaskResolverCluster {
+		t.Fatalf("nil buildConfig should use cluster resolver, got %q", ref.Resolver)
+	}
+}
+
+func TestBuildTaskRef_ClusterResolver_EmptyTaskResolver(t *testing.T) {
+	ref := buildTaskRef("push-artifact-registry", "ns", &BuildConfig{})
+	if ref.Resolver != TaskResolverCluster {
+		t.Fatalf("empty TaskResolver should use cluster resolver, got %q", ref.Resolver)
+	}
+}
+
+func TestBuildTaskRef_BundleResolver(t *testing.T) {
+	bundleRef := "quay.io/org/tasks@sha256:abc123"
+	ref := buildTaskRef("build-automotive-image", "test-ns", &BuildConfig{
+		TaskResolver:  TaskResolverBundle,
+		TaskBundleRef: bundleRef,
+	})
+
+	if ref.Resolver != tektonResolverBundles {
+		t.Fatalf("expected bundles resolver, got %q", ref.Resolver)
+	}
+
+	params := make(map[string]string)
+	for _, p := range ref.Params {
+		params[p.Name] = p.Value.StringVal
+	}
+
+	if params["bundle"] != bundleRef {
+		t.Errorf("expected bundle=%s, got %q", bundleRef, params["bundle"])
+	}
+	if params["name"] != "build-automotive-image" {
+		t.Errorf("expected name=build-automotive-image, got %q", params["name"])
+	}
+	if params["kind"] != "task" {
+		t.Errorf("expected kind=task, got %q", params["kind"])
+	}
+	// Bundle resolver should NOT have namespace param
+	if _, ok := params["namespace"]; ok {
+		t.Error("bundle resolver should not have namespace param")
+	}
+}
+
+func TestBuildTaskRef_BundleResolver_MissingRef(t *testing.T) {
+	// TaskResolver=bundle but no TaskBundleRef should fall back to cluster
+	ref := buildTaskRef("flash-image", "ns", &BuildConfig{
+		TaskResolver: TaskResolverBundle,
+	})
+	if ref.Resolver != TaskResolverCluster {
+		t.Fatalf("bundle resolver with empty ref should fall back to cluster, got %q", ref.Resolver)
+	}
+}
+
+func TestGenerateTektonPipeline_HasImagesResult(t *testing.T) {
+	pipeline := GenerateTektonPipeline("test-pipeline", "test-ns", &BuildConfig{})
+
+	var found bool
+	for _, r := range pipeline.Spec.Results {
+		if r.Name == "IMAGES" {
+			found = true
+			if r.Value.StringVal != "$(finally.collect-images-result.results.IMAGES)" {
+				t.Errorf("IMAGES result value = %q, want finally task reference", r.Value.StringVal)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatal("pipeline should have IMAGES result for Tekton Chains")
+	}
+}
+
+func TestGenerateTektonPipeline_HasFinallyTask(t *testing.T) {
+	pipeline := GenerateTektonPipeline("test-pipeline", "test-ns", &BuildConfig{})
+
+	if len(pipeline.Spec.Finally) == 0 {
+		t.Fatal("pipeline should have finally tasks")
+	}
+
+	var collectTask bool
+	for _, task := range pipeline.Spec.Finally {
+		if task.Name == "collect-images-result" {
+			collectTask = true
+
+			// Verify it has the IMAGES result
+			if task.TaskSpec == nil {
+				t.Fatal("collect-images-result should have inline TaskSpec")
+			}
+			var hasImagesResult bool
+			for _, r := range task.TaskSpec.Results {
+				if r.Name == "IMAGES" {
+					hasImagesResult = true
+				}
+			}
+			if !hasImagesResult {
+				t.Error("collect-images-result task should have IMAGES result")
+			}
+
+			// Verify it reads from workspace files (no params or task-result refs)
+			if len(task.Params) != 0 {
+				t.Errorf("collect-images-result should have no params (reads from workspace), got %d", len(task.Params))
+			}
+			if len(task.Workspaces) == 0 {
+				t.Error("collect-images-result should bind the shared workspace")
+			}
+			break
+		}
+	}
+	if !collectTask {
+		t.Fatal("pipeline should have collect-images-result finally task")
+	}
+}
+
+func TestGenerateTektonPipeline_IntegrityDigestParam(t *testing.T) {
+	pipeline := GenerateTektonPipeline("test-pipeline", "test-ns", &BuildConfig{})
+
+	// Find push-disk-artifact task
+	for _, task := range pipeline.Spec.Tasks {
+		if task.Name == "push-disk-artifact" {
+			for _, p := range task.Params {
+				if p.Name == "expected-artifact-digest" {
+					if p.Value.StringVal != "$(tasks.build-image.results.ARTIFACT_INTEGRITY_DIGEST)" {
+						t.Errorf("expected-artifact-digest = %q, want build-image result ref", p.Value.StringVal)
+					}
+					return
+				}
+			}
+			t.Fatal("push-disk-artifact should have expected-artifact-digest param")
+		}
+	}
+	t.Fatal("pipeline should have push-disk-artifact task")
+}
+
+func TestGenerateTektonPipeline_BundleResolver(t *testing.T) {
+	bundleRef := "quay.io/org/tasks@sha256:abc123"
+	pipeline := GenerateTektonPipeline("test-pipeline", "test-ns", &BuildConfig{
+		TaskResolver:  TaskResolverBundle,
+		TaskBundleRef: bundleRef,
+	})
+
+	// All non-inline tasks should use bundles resolver
+	for _, task := range pipeline.Spec.Tasks {
+		if task.TaskRef == nil {
+			continue // skip tasks with inline TaskSpec
+		}
+		if task.TaskRef.Resolver != tektonResolverBundles {
+			t.Errorf("task %q should use bundles resolver, got %q", task.Name, task.TaskRef.Resolver)
+		}
+	}
+}
+
+func TestGenerateTektonPipeline_ClusterResolverDefault(t *testing.T) {
+	pipeline := GenerateTektonPipeline("test-pipeline", "test-ns", &BuildConfig{})
+
+	for _, task := range pipeline.Spec.Tasks {
+		if task.TaskRef == nil {
+			continue
+		}
+		if task.TaskRef.Resolver != TaskResolverCluster {
+			t.Errorf("task %q should use cluster resolver by default, got %q", task.Name, task.TaskRef.Resolver)
+		}
+	}
+}
+
+func TestGenerateBuildTask_HasIntegrityDigestResult(t *testing.T) {
+	task := GenerateBuildAutomotiveImageTask("test-ns", nil, "")
+
+	for _, r := range task.Spec.Results {
+		if r.Name == "ARTIFACT_INTEGRITY_DIGEST" {
+			return
+		}
+	}
+	t.Fatal("build task should have ARTIFACT_INTEGRITY_DIGEST result")
+}
+
+func TestGeneratePushTask_HasExpectedDigestParam(t *testing.T) {
+	task := GeneratePushArtifactRegistryTask("test-ns", nil)
+
+	for _, p := range task.Spec.Params {
+		if p.Name == "expected-artifact-digest" {
+			if p.Default == nil || p.Default.StringVal != "" {
+				t.Error("expected-artifact-digest should default to empty string")
+			}
+			return
+		}
+	}
+	t.Fatal("push task should have expected-artifact-digest param")
+}
+
+func TestCollectImagesScript_Format(t *testing.T) {
+	// Verify the finally task script reads from workspace files
+	pipeline := GenerateTektonPipeline("test-pipeline", "test-ns", &BuildConfig{})
+
+	for _, task := range pipeline.Spec.Finally {
+		if task.Name == "collect-images-result" {
+			if task.TaskSpec == nil {
+				t.Fatal("collect-images-result should have inline TaskSpec")
+			}
+			if len(task.TaskSpec.Steps) == 0 {
+				t.Fatal("collect-images-result should have steps")
+			}
+			script := task.TaskSpec.Steps[0].Script
+			if script == "" {
+				t.Fatal("collect step should have a script")
+			}
+			// Verify the script reads from workspace chain result files
+			if !strings.Contains(script, "CHAINS_DIR") {
+				t.Error("script should define CHAINS_DIR for workspace result files")
+			}
+			if !strings.Contains(script, "$CHAINS_DIR/container/url") {
+				t.Error("script should read container URL from workspace")
+			}
+			if !strings.Contains(script, "$CHAINS_DIR/disk/url") {
+				t.Error("script should read disk URL from workspace")
+			}
+			return
+		}
+	}
+	t.Fatal("pipeline should have collect-images-result task")
+}
+
+// TestImagesResultFormat verifies the image@digest format Chains expects
+func TestImagesResultFormat(t *testing.T) {
+	// Simulate what the collect-images script produces
+	containerURL := "registry.example.com/img:v1"
+	containerDigest := "sha256:abc123"
+	diskURL := "registry.example.com/disk:v1"
+	diskDigest := "sha256:def456"
+
+	result := containerURL + "@" + containerDigest + "\n" + diskURL + "@" + diskDigest
+
+	lines := strings.Split(result, "\n")
+	if len(lines) != 2 {
+		t.Errorf("expected 2 image lines, got %d", len(lines))
+	}
+	for _, line := range lines {
+		parts := strings.SplitN(line, "@", 2)
+		if len(parts) != 2 {
+			t.Errorf("line %q should contain exactly one '@' separator", line)
+			continue
+		}
+		if !strings.HasPrefix(parts[1], "sha256:") {
+			t.Errorf("digest %q should start with sha256:", parts[1])
+		}
+	}
+}

--- a/internal/common/tasks/scripts/build_image.sh
+++ b/internal/common/tasks/scripts/build_image.sh
@@ -14,6 +14,12 @@ umask 0077
 
 setup_cluster_auth
 
+# Initialize Tekton Chains type hint results with empty defaults.
+# Tekton requires all declared results to exist; these are overwritten
+# later if a container push actually happens.
+echo -n "" > /tekton/results/IMAGE_URL
+echo -n "" > /tekton/results/IMAGE_DIGEST
+
 # Read registry credentials from workspace and set up auth
 read_registry_creds "/workspace/registry-auth"
 setup_registry_auth || echo "No custom registry auth found, using cluster auth only"
@@ -462,12 +468,14 @@ PYEOF
           echo "⏱ Container annotate: $((ANNOTATE_DONE - COPY_DONE))s"
 
           echo "Pushing container to registry: $CONTAINER_PUSH"
-          skopeo copy --authfile="$REGISTRY_AUTH_FILE" "oci:${OCI_DIR}:latest" "docker://$CONTAINER_PUSH"
+          skopeo copy --digestfile /tmp/container-push-digest.txt \
+            --authfile="$REGISTRY_AUTH_FILE" "oci:${OCI_DIR}:latest" "docker://$CONTAINER_PUSH"
           rm -rf "${OCI_DIR:-/tmp/nonexistent}" 2>/dev/null || true
           PUSH_DONE=$(date +%s)
           echo "⏱ Container registry push: $((PUSH_DONE - ANNOTATE_DONE))s"
           echo "⏱ Container push total: $((PUSH_DONE - PUSH_START))s"
           echo "Container pushed successfully to $CONTAINER_PUSH"
+          echo "Container digest: $(cat /tmp/container-push-digest.txt 2>/dev/null)"
         ) &
         CONTAINER_PUSH_PID=$!
       fi
@@ -744,6 +752,17 @@ fi
 if [ -n "${CONTAINER_PUSH_PID:-}" ]; then
   echo "Waiting for container push to complete..."
   wait "$CONTAINER_PUSH_PID" || { echo "Error: Container push failed"; exit 1; }
+fi
+
+# Write Tekton Chains type hint results for bootc container
+if [ -n "${CONTAINER_PUSH:-}" ]; then
+  PUSHED_DIGEST=$(cat /tmp/container-push-digest.txt 2>/dev/null || echo "")
+  if [ -z "$PUSHED_DIGEST" ]; then
+    echo "WARNING: container push completed but no digest was captured, skipping Chains hints"
+  fi
+  echo -n "$CONTAINER_PUSH" > /tekton/results/IMAGE_URL
+  echo -n "$PUSHED_DIGEST" > /tekton/results/IMAGE_DIGEST
+  echo "Tekton Chains: IMAGE_URL=$CONTAINER_PUSH IMAGE_DIGEST=$PUSHED_DIGEST"
 fi
 
 BUILD_END_TIME=$(date +%s)

--- a/internal/common/tasks/scripts/build_image.sh
+++ b/internal/common/tasks/scripts/build_image.sh
@@ -14,11 +14,15 @@ umask 0077
 
 setup_cluster_auth
 
-# Initialize Tekton Chains type hint results with empty defaults.
+# Initialize Tekton results with empty defaults.
 # Tekton requires all declared results to exist; these are overwritten
-# later if a container push actually happens.
+# later when applicable.
 echo -n "" > /tekton/results/IMAGE_URL
 echo -n "" > /tekton/results/IMAGE_DIGEST
+echo -n "" > /tekton/results/ARTIFACT_INTEGRITY_DIGEST
+
+# Clear stale Chains result files from previous builds on reused workspace PVCs.
+rm -rf "$WORKSPACE_PATH/.chains"
 
 # Read registry credentials from workspace and set up auth
 read_registry_creds "/workspace/registry-auth"
@@ -748,6 +752,35 @@ else
   echo "Warning: final_name is empty, no artifact filename will be recorded"
 fi
 
+# Compute artifact integrity digest for cross-task verification.
+# Covers both multi-layer (parts directory) and single-file modes.
+if [ -n "$final_name" ] && [ "$final_name" != "container:$CONTAINER_PUSH" ]; then
+  parts_dir="$WORKSPACE_PATH/${final_name}-parts"
+
+  # For ride4/ridesx4 targets, duplicate boot_a as boot_b BEFORE computing the
+  # integrity digest so the digest covers the complete artifact that will be pushed.
+  if [ -d "$parts_dir" ]; then
+    case "$(params.target)" in
+      ride4*|ridesx4*)
+        for boot_a_file in "${parts_dir}"/boot_a.*; do
+          [ -f "$boot_a_file" ] || continue
+          boot_b_file=$(echo "$boot_a_file" | sed 's/boot_a/boot_b/')
+          if [ ! -f "$boot_b_file" ]; then
+            echo "Duplicating $(basename "$boot_a_file") as $(basename "$boot_b_file") for target $(params.target)"
+            cp "$boot_a_file" "$boot_b_file"
+          fi
+        done
+        ;;
+    esac
+  fi
+
+  ARTIFACT_DIGEST=$(compute_artifact_digest "$parts_dir" "$WORKSPACE_PATH/$final_name")
+  if [ -n "$ARTIFACT_DIGEST" ]; then
+    echo "Artifact integrity digest: $ARTIFACT_DIGEST"
+    echo -n "$ARTIFACT_DIGEST" > /tekton/results/ARTIFACT_INTEGRITY_DIGEST
+  fi
+fi
+
 # Wait for background container push to complete (bootc mode only)
 if [ -n "${CONTAINER_PUSH_PID:-}" ]; then
   echo "Waiting for container push to complete..."
@@ -763,6 +796,10 @@ if [ -n "${CONTAINER_PUSH:-}" ]; then
   echo -n "$CONTAINER_PUSH" > /tekton/results/IMAGE_URL
   echo -n "$PUSHED_DIGEST" > /tekton/results/IMAGE_DIGEST
   echo "Tekton Chains: IMAGE_URL=$CONTAINER_PUSH IMAGE_DIGEST=$PUSHED_DIGEST"
+  # Write to workspace for cross-task access (avoids Tekton result-ref issues with skipped tasks)
+  mkdir -p "$WORKSPACE_PATH/.chains/container"
+  echo -n "$CONTAINER_PUSH" > "$WORKSPACE_PATH/.chains/container/url"
+  echo -n "$PUSHED_DIGEST" > "$WORKSPACE_PATH/.chains/container/digest"
 fi
 
 BUILD_END_TIME=$(date +%s)

--- a/internal/common/tasks/scripts/common.sh
+++ b/internal/common/tasks/scripts/common.sh
@@ -165,6 +165,18 @@ load_custom_definitions() {
   echo "Loaded $((${#CUSTOM_DEFS_ARGS[@]} / 2)) custom definitions"
 }
 
+# Compute a content-addressable digest of an artifact (parts directory or single file).
+# Outputs "sha256:<hex>" to stdout, or empty string if nothing found.
+# Args: $1 = parts directory path, $2 = single file path
+compute_artifact_digest() {
+  local parts_dir="$1" single_file="$2"
+  if [ -d "$parts_dir" ] && [ -n "$(ls -A "$parts_dir" 2>/dev/null)" ]; then
+    echo "sha256:$(cd "$parts_dir" && find . -maxdepth 1 -type f ! -name '*.size' ! -name 'aib-manifest.yml' -printf '%f\n' | sort | xargs sha256sum | sha256sum | cut -d' ' -f1)"
+  elif [ -f "$single_file" ]; then
+    echo "sha256:$(sha256sum "$single_file" | cut -d' ' -f1)"
+  fi
+}
+
 # Create service account authentication JSON for container registries.
 # Args: $1 - registry URL, $2 - output file path, $3 - optional token (defaults to SA token)
 create_service_account_auth() {

--- a/internal/common/tasks/scripts/push_artifact.sh
+++ b/internal/common/tasks/scripts/push_artifact.sh
@@ -327,12 +327,14 @@ EOF
   # Push with multi-layer manifest using annotation file
   # Files are pushed from current directory (parts_dir) so they extract flat
   # shellcheck disable=SC2086
+  set -o pipefail
   "$HOME/bin/oras" push --disable-path-validation \
     --image-spec v1.1 \
     --artifact-type "${artifact_type}" \
     --annotation-file "$annotations_file" \
     "${repo_url}" \
-    ${layer_args}
+    ${layer_args} 2>&1 | tee /tmp/oras-push-output.txt
+  set +o pipefail
 
   # Clean up annotation file (also handled by trap)
   rm -f "$annotations_file"
@@ -388,15 +390,84 @@ PYEOF
   echo "  Media type: ${media_type}"
   echo "  Annotations: distro=${distro}, target=${target}, arch=${arch}"
 
+  set -o pipefail
   "$HOME/bin/oras" push --disable-path-validation \
     --image-spec v1.1 \
     --artifact-type "${media_type}" \
     --annotation-file "$single_annotations_file" \
     "${repo_url}" \
-    "${exportFile}:${media_type}"
+    "${exportFile}:${media_type}" 2>&1 | tee /tmp/oras-push-output.txt
+  set +o pipefail
 
   emit_progress "Pushing artifact" 1 1
 
   echo ""
   echo "=== Artifact pushed successfully ==="
+fi
+
+# Write Tekton Chains type hint results for disk artifact
+DISK_DIGEST=$(sed -n 's/.*Digest: \(sha256:[a-f0-9]*\).*/\1/p' /tmp/oras-push-output.txt 2>/dev/null | head -1)
+if [ -z "$DISK_DIGEST" ]; then
+  # Fallback: fetch manifest descriptor from registry
+  DISK_DIGEST=$("$HOME/bin/oras" manifest fetch --descriptor "${repo_url}" 2>/dev/null \
+    | python3 -c "import sys,json; print(json.load(sys.stdin).get('digest',''))" 2>/dev/null || echo "")
+fi
+echo -n "${repo_url}" > /tekton/results/IMAGE_URL
+echo -n "${DISK_DIGEST}" > /tekton/results/IMAGE_DIGEST
+echo "Tekton Chains: IMAGE_URL=${repo_url} IMAGE_DIGEST=${DISK_DIGEST}"
+
+# Attach sanitized osbuild manifest as OCI referrer for supply chain verification.
+# image.json is the fully-resolved osbuild manifest produced by AIB — it contains
+# the complete build recipe (RPMs, stages, filesystem layout). We strip credentials
+# (password hashes, repo auth, secrets) before publishing.
+OSBUILD_MANIFEST="/workspace/shared/image.json"
+if [ -f "$OSBUILD_MANIFEST" ] && [ -n "$DISK_DIGEST" ]; then
+  # Use a relative path so ORAS stores "image.json" as the OCI title (not /tmp/...)
+  SANITIZED_MANIFEST="./image-sanitized.json"
+
+  python3 - "$OSBUILD_MANIFEST" "$SANITIZED_MANIFEST" <<'PYEOF'
+import json, sys, re
+
+SENSITIVE_KEYS = {"password", "secrets", "secret", "auth", "token", "key", "credential", "passphrase"}
+
+def redact_sensitive(obj):
+    """Recursively redact fields with sensitive-sounding names anywhere in the tree."""
+    if isinstance(obj, dict):
+        for k in obj:
+            if k.lower() in SENSITIVE_KEYS:
+                obj[k] = "REDACTED"
+            else:
+                redact_sensitive(obj[k])
+    elif isinstance(obj, list):
+        for item in obj:
+            redact_sensitive(item)
+
+def redact_source_urls(sources):
+    """Strip embedded user:pass from source URLs (e.g. https://user:pass@host/...)."""
+    for source_data in sources.values():
+        items = source_data if isinstance(source_data, dict) else {}
+        for val in items.get("items", {}).values():
+            if isinstance(val, dict) and "url" in val:
+                val["url"] = re.sub(r'(https?://)([^@/]+)@', r'\1REDACTED@', val["url"])
+
+with open(sys.argv[1]) as f:
+    manifest = json.load(f)
+redact_sensitive(manifest)
+if "sources" in manifest:
+    redact_source_urls(manifest["sources"])
+
+with open(sys.argv[2], "w") as f:
+    json.dump(manifest, f, indent=2)
+PYEOF
+
+  echo "Attaching sanitized osbuild manifest to ${repo_url}@${DISK_DIGEST}"
+  "$HOME/bin/oras" attach \
+    --artifact-type "application/vnd.osbuild.manifest.v1+json" \
+    "${repo_url}@${DISK_DIGEST}" \
+    "${SANITIZED_MANIFEST}:application/vnd.osbuild.manifest.v1+json" 2>&1 || \
+    echo "WARNING: Failed to attach osbuild manifest — registry may not support OCI referrers (non-fatal)"
+
+  rm -f "$SANITIZED_MANIFEST"
+else
+  echo "No osbuild manifest found or no digest available, skipping manifest attach"
 fi

--- a/internal/common/tasks/scripts/push_artifact.sh
+++ b/internal/common/tasks/scripts/push_artifact.sh
@@ -176,6 +176,7 @@ builder_image_used="$(params.builder-image)"
 aib_version="$(params.aib-version)"
 aib_image="$(params.automotive-image-builder)"
 aib_command="$(params.aib-command)"
+SECURE_BUILD="$(params.secure-build)"
 
 config_file="/etc/target-defaults/target-defaults.yaml"
 default_partitions=""
@@ -194,6 +195,27 @@ fi
 
 cd /workspace/shared
 
+# Verify artifact integrity against the digest produced by the build task.
+EXPECTED_DIGEST="$(params.expected-artifact-digest)"
+if [ -n "$EXPECTED_DIGEST" ]; then
+  echo "=== Artifact Integrity Verification ==="
+  ACTUAL_DIGEST=$(compute_artifact_digest "${parts_dir}" "${exportFile}")
+  if [ -z "$ACTUAL_DIGEST" ]; then
+    echo "WARNING: Cannot verify integrity — artifact not found yet"
+  fi
+  if [ -n "$ACTUAL_DIGEST" ]; then
+    if [ "$EXPECTED_DIGEST" != "$ACTUAL_DIGEST" ]; then
+      echo "ERROR: Artifact integrity check failed!" >&2
+      echo "  Expected: $EXPECTED_DIGEST" >&2
+      echo "  Actual:   $ACTUAL_DIGEST" >&2
+      exit 1
+    fi
+    echo "  Integrity verified: $ACTUAL_DIGEST"
+  fi
+else
+  echo "No artifact integrity digest provided, skipping verification"
+fi
+
 echo "=== Artifact Push Configuration ==="
 echo "  Working directory: $(pwd)"
 echo "  Artifact file:     ${exportFile}"
@@ -206,7 +228,8 @@ if [ -d "${parts_dir}" ] && [ -n "$(ls -A "${parts_dir}" 2>/dev/null)" ]; then
   echo "Found parts directory: ${parts_dir}"
   echo "Using multi-layer push for individual partition files"
 
-  # For ride4/ridesx4 targets, duplicate boot_a as boot_b so both partitions get flashed
+  # For ride4/ridesx4 targets, ensure boot_b exists (normally created by build task;
+  # kept here as idempotent fallback for backwards compatibility with older bundles)
   case "$target" in
     ride4*|ridesx4*)
       for boot_a_file in "${parts_dir}"/boot_a.*; do
@@ -408,13 +431,18 @@ fi
 # Write Tekton Chains type hint results for disk artifact
 DISK_DIGEST=$(sed -n 's/.*Digest: \(sha256:[a-f0-9]*\).*/\1/p' /tmp/oras-push-output.txt 2>/dev/null | head -1)
 if [ -z "$DISK_DIGEST" ]; then
-  # Fallback: fetch manifest descriptor from registry
-  DISK_DIGEST=$("$HOME/bin/oras" manifest fetch --descriptor "${repo_url}" 2>/dev/null \
-    | python3 -c "import sys,json; print(json.load(sys.stdin).get('digest',''))" 2>/dev/null || echo "")
+  echo "ERROR: Could not extract digest from oras push output." >&2
+  echo "Push output was:" >&2
+  cat /tmp/oras-push-output.txt >&2
+  exit 1
 fi
 echo -n "${repo_url}" > /tekton/results/IMAGE_URL
 echo -n "${DISK_DIGEST}" > /tekton/results/IMAGE_DIGEST
 echo "Tekton Chains: IMAGE_URL=${repo_url} IMAGE_DIGEST=${DISK_DIGEST}"
+# Write to workspace for cross-task access (avoids Tekton result-ref issues with skipped tasks)
+mkdir -p /workspace/shared/.chains/disk
+echo -n "${repo_url}" > /workspace/shared/.chains/disk/url
+echo -n "${DISK_DIGEST}" > /workspace/shared/.chains/disk/digest
 
 # Attach sanitized osbuild manifest as OCI referrer for supply chain verification.
 # image.json is the fully-resolved osbuild manifest produced by AIB — it contains
@@ -461,11 +489,16 @@ with open(sys.argv[2], "w") as f:
 PYEOF
 
   echo "Attaching sanitized osbuild manifest to ${repo_url}@${DISK_DIGEST}"
-  "$HOME/bin/oras" attach \
+  if ! "$HOME/bin/oras" attach \
     --artifact-type "application/vnd.osbuild.manifest.v1+json" \
     "${repo_url}@${DISK_DIGEST}" \
-    "${SANITIZED_MANIFEST}:application/vnd.osbuild.manifest.v1+json" 2>&1 || \
+    "${SANITIZED_MANIFEST}:application/vnd.osbuild.manifest.v1+json" 2>&1; then
+    if [ "$SECURE_BUILD" = "true" ]; then
+      echo "ERROR: Failed to attach osbuild manifest (fatal in secure build mode)"
+      exit 1
+    fi
     echo "WARNING: Failed to attach osbuild manifest — registry may not support OCI referrers (non-fatal)"
+  fi
 
   rm -f "$SANITIZED_MANIFEST"
 else

--- a/internal/common/tasks/tasks.go
+++ b/internal/common/tasks/tasks.go
@@ -211,6 +211,16 @@ func GeneratePushArtifactRegistryTask(namespace string, buildConfig *BuildConfig
 					},
 				},
 			},
+			Results: []tektonv1.TaskResult{
+				{
+					Name:        "IMAGE_URL",
+					Description: "Pushed disk artifact OCI URL (Tekton Chains type hint)",
+				},
+				{
+					Name:        "IMAGE_DIGEST",
+					Description: "Pushed disk artifact OCI digest (Tekton Chains type hint)",
+				},
+			},
 			Workspaces: []tektonv1.WorkspaceDeclaration{
 				{
 					Name:        workspaceNameShared,
@@ -439,6 +449,14 @@ func GenerateBuildAutomotiveImageTask(namespace string, buildConfig *BuildConfig
 				{
 					Name:        "build-timing",
 					Description: "JSON timing breakdown of build phases in seconds",
+				},
+				{
+					Name:        "IMAGE_URL",
+					Description: "Pushed bootc container image URL (Tekton Chains type hint)",
+				},
+				{
+					Name:        "IMAGE_DIGEST",
+					Description: "Pushed bootc container image digest (Tekton Chains type hint)",
 				},
 			},
 			Workspaces: []tektonv1.WorkspaceDeclaration{
@@ -914,6 +932,26 @@ func GenerateTektonPipeline(name, namespace string, buildConfig *BuildConfig) *t
 					Name:        "build-timing",
 					Description: "JSON timing breakdown of build phases in seconds",
 					Value:       tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "$(tasks.build-image.results.build-timing)"},
+				},
+				{
+					Name:        "container-image-url",
+					Description: "Pushed bootc container image URL",
+					Value:       tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "$(tasks.build-image.results.IMAGE_URL)"},
+				},
+				{
+					Name:        "container-image-digest",
+					Description: "Pushed bootc container image digest",
+					Value:       tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "$(tasks.build-image.results.IMAGE_DIGEST)"},
+				},
+				{
+					Name:        "disk-artifact-url",
+					Description: "Pushed disk artifact OCI URL",
+					Value:       tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "$(tasks.push-disk-artifact.results.IMAGE_URL)"},
+				},
+				{
+					Name:        "disk-artifact-digest",
+					Description: "Pushed disk artifact OCI digest",
+					Value:       tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "$(tasks.push-disk-artifact.results.IMAGE_DIGEST)"},
 				},
 			},
 			Tasks: []tektonv1.PipelineTask{

--- a/internal/common/tasks/tasks.go
+++ b/internal/common/tasks/tasks.go
@@ -29,6 +29,62 @@ type BuildConfig struct {
 	TrustedCABundleKind         string
 	TrustedCABundleName         string
 	UsePVCScratchVolumes        bool
+	TaskResolver                string // TaskResolverCluster (default) or TaskResolverBundle
+	TaskBundleRef               string // OCI bundle ref when TaskResolver is TaskResolverBundle
+}
+
+const (
+	// TaskResolverCluster resolves tasks from the cluster-installed resources.
+	TaskResolverCluster = "cluster"
+	// TaskResolverBundle resolves tasks from a signed Tekton Bundle OCI image.
+	TaskResolverBundle = "bundle"
+	// tektonResolverBundles is the Tekton-internal resolver name for bundles (plural).
+	tektonResolverBundles = "bundles"
+)
+
+// buildTaskRef constructs a TaskRef that uses either the cluster resolver or the
+// bundles resolver, depending on BuildConfig.TaskResolver.
+func buildTaskRef(taskName, namespace string, buildConfig *BuildConfig) *tektonv1.TaskRef {
+	if buildConfig != nil && buildConfig.TaskResolver == TaskResolverBundle && buildConfig.TaskBundleRef != "" {
+		return &tektonv1.TaskRef{
+			ResolverRef: tektonv1.ResolverRef{
+				Resolver: tektonResolverBundles,
+				Params: []tektonv1.Param{
+					{
+						Name:  "bundle",
+						Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: buildConfig.TaskBundleRef},
+					},
+					{
+						Name:  "name",
+						Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: taskName},
+					},
+					{
+						Name:  "kind",
+						Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "task"},
+					},
+				},
+			},
+		}
+	}
+	return &tektonv1.TaskRef{
+		ResolverRef: tektonv1.ResolverRef{
+			Resolver: TaskResolverCluster,
+			Params: []tektonv1.Param{
+				{
+					Name:  "kind",
+					Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "task"},
+				},
+				{
+					Name:  "name",
+					Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: taskName},
+				},
+				{
+					Name:  "namespace",
+					Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: namespace},
+				},
+			},
+		},
+	}
 }
 
 // getAutomotiveImageBuilderImage returns the AIB image from config or the default constant
@@ -205,6 +261,15 @@ func GeneratePushArtifactRegistryTask(namespace string, buildConfig *BuildConfig
 					Name:        "aib-command",
 					Type:        tektonv1.ParamTypeString,
 					Description: "The exact AIB command used to build the image",
+					Default: &tektonv1.ParamValue{
+						Type:      tektonv1.ParamTypeString,
+						StringVal: "",
+					},
+				},
+				{
+					Name:        "expected-artifact-digest",
+					Type:        tektonv1.ParamTypeString,
+					Description: "Expected SHA-256 digest of the artifact(s) from the build task, for integrity verification",
 					Default: &tektonv1.ParamValue{
 						Type:      tektonv1.ParamTypeString,
 						StringVal: "",
@@ -457,6 +522,10 @@ func GenerateBuildAutomotiveImageTask(namespace string, buildConfig *BuildConfig
 				{
 					Name:        "IMAGE_DIGEST",
 					Description: "Pushed bootc container image digest (Tekton Chains type hint)",
+				},
+				{
+					Name:        "ARTIFACT_INTEGRITY_DIGEST",
+					Description: "SHA-256 digest of disk artifact(s) for cross-task integrity verification",
 				},
 			},
 			Workspaces: []tektonv1.WorkspaceDeclaration{
@@ -953,38 +1022,16 @@ func GenerateTektonPipeline(name, namespace string, buildConfig *BuildConfig) *t
 					Description: "Pushed disk artifact OCI digest",
 					Value:       tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "$(tasks.push-disk-artifact.results.IMAGE_DIGEST)"},
 				},
+				{
+					Name:        "IMAGES",
+					Description: "Newline-separated image@digest list for Tekton Chains attestation",
+					Value:       tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "$(finally.collect-images-result.results.IMAGES)"},
+				},
 			},
 			Tasks: []tektonv1.PipelineTask{
 				{
-					Name: "build-image",
-					TaskRef: &tektonv1.TaskRef{
-						ResolverRef: tektonv1.ResolverRef{
-							Resolver: "cluster",
-							Params: []tektonv1.Param{
-								{
-									Name: "kind",
-									Value: tektonv1.ParamValue{
-										Type:      tektonv1.ParamTypeString,
-										StringVal: "task",
-									},
-								},
-								{
-									Name: "name",
-									Value: tektonv1.ParamValue{
-										Type:      tektonv1.ParamTypeString,
-										StringVal: "build-automotive-image",
-									},
-								},
-								{
-									Name: "namespace",
-									Value: tektonv1.ParamValue{
-										Type:      tektonv1.ParamTypeString,
-										StringVal: namespace,
-									},
-								},
-							},
-						},
-					},
+					Name:    "build-image",
+					TaskRef: buildTaskRef("build-automotive-image", namespace, buildConfig),
 					Params: []tektonv1.Param{
 						{
 							Name: "target-architecture",
@@ -1103,35 +1150,8 @@ func GenerateTektonPipeline(name, namespace string, buildConfig *BuildConfig) *t
 					Timeout: &metav1.Duration{Duration: time.Duration(buildConfig.getBuildTimeoutMinutes()) * time.Minute},
 				},
 				{
-					Name: "push-disk-artifact",
-					TaskRef: &tektonv1.TaskRef{
-						ResolverRef: tektonv1.ResolverRef{
-							Resolver: "cluster",
-							Params: []tektonv1.Param{
-								{
-									Name: "kind",
-									Value: tektonv1.ParamValue{
-										Type:      tektonv1.ParamTypeString,
-										StringVal: "task",
-									},
-								},
-								{
-									Name: "name",
-									Value: tektonv1.ParamValue{
-										Type:      tektonv1.ParamTypeString,
-										StringVal: "push-artifact-registry",
-									},
-								},
-								{
-									Name: "namespace",
-									Value: tektonv1.ParamValue{
-										Type:      tektonv1.ParamTypeString,
-										StringVal: namespace,
-									},
-								},
-							},
-						},
-					},
+					Name:    "push-disk-artifact",
+					TaskRef: buildTaskRef("push-artifact-registry", namespace, buildConfig),
 					Params: []tektonv1.Param{
 						{
 							Name: "distro",
@@ -1210,6 +1230,13 @@ func GenerateTektonPipeline(name, namespace string, buildConfig *BuildConfig) *t
 								StringVal: "$(tasks.build-image.results.aib-command)",
 							},
 						},
+						{
+							Name: "expected-artifact-digest",
+							Value: tektonv1.ParamValue{
+								Type:      tektonv1.ParamTypeString,
+								StringVal: "$(tasks.build-image.results.ARTIFACT_INTEGRITY_DIGEST)",
+							},
+						},
 					},
 					Workspaces: []tektonv1.WorkspacePipelineTaskBinding{
 						{Name: workspaceNameShared, Workspace: workspaceNameShared},
@@ -1229,35 +1256,8 @@ func GenerateTektonPipeline(name, namespace string, buildConfig *BuildConfig) *t
 					},
 				},
 				{
-					Name: "flash-image",
-					TaskRef: &tektonv1.TaskRef{
-						ResolverRef: tektonv1.ResolverRef{
-							Resolver: "cluster",
-							Params: []tektonv1.Param{
-								{
-									Name: "kind",
-									Value: tektonv1.ParamValue{
-										Type:      tektonv1.ParamTypeString,
-										StringVal: "task",
-									},
-								},
-								{
-									Name: "name",
-									Value: tektonv1.ParamValue{
-										Type:      tektonv1.ParamTypeString,
-										StringVal: "flash-image",
-									},
-								},
-								{
-									Name: "namespace",
-									Value: tektonv1.ParamValue{
-										Type:      tektonv1.ParamTypeString,
-										StringVal: namespace,
-									},
-								},
-							},
-						},
-					},
+					Name:    "flash-image",
+					TaskRef: buildTaskRef("flash-image", namespace, buildConfig),
 					Params: []tektonv1.Param{
 						{
 							Name: "image-ref",
@@ -1321,6 +1321,58 @@ func GenerateTektonPipeline(name, namespace string, buildConfig *BuildConfig) *t
 						},
 					},
 					Timeout: &metav1.Duration{Duration: time.Duration(buildConfig.getFlashTimeoutMinutes()) * time.Minute},
+				},
+			},
+			Finally: []tektonv1.PipelineTask{
+				{
+					Name: "collect-images-result",
+					TaskSpec: &tektonv1.EmbeddedTask{
+						TaskSpec: tektonv1.TaskSpec{
+							Workspaces: []tektonv1.WorkspaceDeclaration{
+								{Name: workspaceNameShared, MountPath: "/workspace/shared"},
+							},
+							Results: []tektonv1.TaskResult{
+								{
+									Name:        "IMAGES",
+									Description: "Newline-separated image@digest list for Tekton Chains attestation",
+								},
+							},
+							Steps: []tektonv1.Step{
+								{
+									Name:  "collect",
+									Image: buildConfig.getYQHelperImage(),
+									Script: `#!/bin/sh
+# Read results from workspace files written by build/push tasks.
+# This avoids referencing results from potentially-skipped tasks.
+CHAINS_DIR="/workspace/shared/.chains"
+IMAGES=""
+if [ -f "$CHAINS_DIR/container/url" ] && [ -f "$CHAINS_DIR/container/digest" ]; then
+  url=$(cat "$CHAINS_DIR/container/url")
+  digest=$(cat "$CHAINS_DIR/container/digest")
+  if [ -n "$url" ] && [ -n "$digest" ]; then
+    IMAGES="${url}@${digest}"
+  fi
+fi
+if [ -f "$CHAINS_DIR/disk/url" ] && [ -f "$CHAINS_DIR/disk/digest" ]; then
+  url=$(cat "$CHAINS_DIR/disk/url")
+  digest=$(cat "$CHAINS_DIR/disk/digest")
+  if [ -n "$url" ] && [ -n "$digest" ]; then
+    if [ -n "$IMAGES" ]; then
+      IMAGES="${IMAGES}
+"
+    fi
+    IMAGES="${IMAGES}${url}@${digest}"
+  fi
+fi
+printf '%s' "$IMAGES" > "$(results.IMAGES.path)"
+`,
+								},
+							},
+						},
+					},
+					Workspaces: []tektonv1.WorkspacePipelineTaskBinding{
+						{Name: workspaceNameShared, Workspace: workspaceNameShared},
+					},
 				},
 			},
 		},

--- a/internal/common/tasks/tasks.go
+++ b/internal/common/tasks/tasks.go
@@ -140,11 +140,13 @@ const workspaceNameShared = "shared-workspace"
 // Tekton resolves this at runtime to the actual volume name in the pod spec.
 const workspaceVolumeRef = "$(workspaces." + workspaceNameShared + ".volume)"
 
-const defaultTrustedCABundleConfigMap = "rhivos-ca-bundle"
+// DefaultTrustedCABundleConfigMap is the default ConfigMap name for trusted CA bundles.
+// Exported so the controller can detect divergence when using bundle-resolved tasks.
+const DefaultTrustedCABundleConfigMap = "rhivos-ca-bundle"
 
 func trustedCABundleVolumeSource(buildConfig *BuildConfig) corev1.VolumeSource {
 	kind := "ConfigMap"
-	name := defaultTrustedCABundleConfigMap
+	name := DefaultTrustedCABundleConfigMap
 	optional := true
 	if buildConfig != nil {
 		// Explicit trusted CA configuration should fail fast when missing.
@@ -275,6 +277,24 @@ func GeneratePushArtifactRegistryTask(namespace string, buildConfig *BuildConfig
 						StringVal: "",
 					},
 				},
+				{
+					Name:        "secure-build",
+					Type:        tektonv1.ParamTypeString,
+					Description: "When true, attestation failures (e.g. oras attach) are fatal instead of best-effort",
+					Default: &tektonv1.ParamValue{
+						Type:      tektonv1.ParamTypeString,
+						StringVal: "false",
+					},
+				},
+				{
+					Name:        "yq-helper-image",
+					Type:        tektonv1.ParamTypeString,
+					Description: "Container image for yq helper steps",
+					Default: &tektonv1.ParamValue{
+						Type:      tektonv1.ParamTypeString,
+						StringVal: buildConfig.getYQHelperImage(),
+					},
+				},
 			},
 			Results: []tektonv1.TaskResult{
 				{
@@ -296,7 +316,7 @@ func GeneratePushArtifactRegistryTask(namespace string, buildConfig *BuildConfig
 			Steps: []tektonv1.Step{
 				{
 					Name:  "push-artifact",
-					Image: buildConfig.getYQHelperImage(),
+					Image: "$(params.yq-helper-image)",
 					Env: []corev1.EnvVar{
 						{
 							Name:  "DOCKER_CONFIG",
@@ -485,6 +505,15 @@ func GenerateBuildAutomotiveImageTask(namespace string, buildConfig *BuildConfig
 						StringVal: "false",
 					},
 				},
+				{
+					Name:        "yq-helper-image",
+					Type:        tektonv1.ParamTypeString,
+					Description: "Container image for yq helper steps",
+					Default: &tektonv1.ParamValue{
+						Type:      tektonv1.ParamTypeString,
+						StringVal: buildConfig.getYQHelperImage(),
+					},
+				},
 			},
 			Results: []tektonv1.TaskResult{
 				{
@@ -549,7 +578,7 @@ func GenerateBuildAutomotiveImageTask(namespace string, buildConfig *BuildConfig
 			Steps: []tektonv1.Step{
 				{
 					Name:   "find-manifest-file",
-					Image:  buildConfig.getYQHelperImage(),
+					Image:  "$(params.yq-helper-image)",
 					Script: FindManifestScript,
 					VolumeMounts: []corev1.VolumeMount{
 						{
@@ -829,6 +858,15 @@ func GenerateTektonPipeline(name, namespace string, buildConfig *BuildConfig) *t
 					Description: "automotive-image-builder container image to use for building",
 				},
 				{
+					Name: "yq-helper-image",
+					Type: tektonv1.ParamTypeString,
+					Default: &tektonv1.ParamValue{
+						Type:      tektonv1.ParamTypeString,
+						StringVal: buildConfig.getYQHelperImage(),
+					},
+					Description: "Container image for yq helper steps",
+				},
+				{
 					Name:        "secret-ref",
 					Type:        tektonv1.ParamTypeString,
 					Description: "Secret reference for registry credentials",
@@ -968,6 +1006,15 @@ func GenerateTektonPipeline(name, namespace string, buildConfig *BuildConfig) *t
 					Name:        "use-persistent-cache",
 					Type:        tektonv1.ParamTypeString,
 					Description: "Use persistent build cache on the shared workspace PVC (true/false)",
+					Default: &tektonv1.ParamValue{
+						Type:      tektonv1.ParamTypeString,
+						StringVal: "false",
+					},
+				},
+				{
+					Name:        "secure-build",
+					Type:        tektonv1.ParamTypeString,
+					Description: "When true, attestation failures are fatal (true/false)",
 					Default: &tektonv1.ParamValue{
 						Type:      tektonv1.ParamTypeString,
 						StringVal: "false",
@@ -1141,6 +1188,13 @@ func GenerateTektonPipeline(name, namespace string, buildConfig *BuildConfig) *t
 								StringVal: "$(params.use-persistent-cache)",
 							},
 						},
+						{
+							Name: "yq-helper-image",
+							Value: tektonv1.ParamValue{
+								Type:      tektonv1.ParamTypeString,
+								StringVal: "$(params.yq-helper-image)",
+							},
+						},
 					},
 					Workspaces: []tektonv1.WorkspacePipelineTaskBinding{
 						{Name: workspaceNameShared, Workspace: workspaceNameShared},
@@ -1235,6 +1289,20 @@ func GenerateTektonPipeline(name, namespace string, buildConfig *BuildConfig) *t
 							Value: tektonv1.ParamValue{
 								Type:      tektonv1.ParamTypeString,
 								StringVal: "$(tasks.build-image.results.ARTIFACT_INTEGRITY_DIGEST)",
+							},
+						},
+						{
+							Name: "secure-build",
+							Value: tektonv1.ParamValue{
+								Type:      tektonv1.ParamTypeString,
+								StringVal: "$(params.secure-build)",
+							},
+						},
+						{
+							Name: "yq-helper-image",
+							Value: tektonv1.ParamValue{
+								Type:      tektonv1.ParamTypeString,
+								StringVal: "$(params.yq-helper-image)",
 							},
 						},
 					},

--- a/internal/common/tasks/trusted_ca_test.go
+++ b/internal/common/tasks/trusted_ca_test.go
@@ -13,8 +13,8 @@ func TestTrustedCABundleVolumeSource_DefaultsToConfigMap(t *testing.T) {
 	if src.ConfigMap == nil {
 		t.Fatalf("expected ConfigMap source by default")
 	}
-	if src.ConfigMap.Name != defaultTrustedCABundleConfigMap {
-		t.Fatalf("expected default configmap %q, got %q", defaultTrustedCABundleConfigMap, src.ConfigMap.Name)
+	if src.ConfigMap.Name != DefaultTrustedCABundleConfigMap {
+		t.Fatalf("expected default configmap %q, got %q", DefaultTrustedCABundleConfigMap, src.ConfigMap.Name)
 	}
 }
 

--- a/internal/controller/imagebuild/controller.go
+++ b/internal/controller/imagebuild/controller.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -50,6 +51,9 @@ const (
 
 	maxK8sNameLength = 63
 )
+
+// digestPinnedRef matches an OCI reference with a sha256 digest.
+var digestPinnedRef = regexp.MustCompile(`^.+@sha256:[a-fA-F0-9]{64}$`)
 
 const (
 	eventReasonPhaseChanged     = "PhaseChanged"
@@ -505,6 +509,15 @@ func (r *ImageBuildReconciler) startNewBuild(
 	// PVC is now created via VolumeClaimTemplate in createBuildTaskRun
 	// to ensure proper zone affinity with WaitForFirstConsumer
 	if err := r.createBuildTaskRun(ctx, imageBuild); err != nil {
+		// secureBuild validation errors are terminal — set Failed status
+		// instead of returning a reconcile error that causes infinite requeue
+		if strings.Contains(err.Error(), "secureBuild") {
+			msg := fmt.Sprintf("Build configuration error: %v", err)
+			if statusErr := r.updateStatus(ctx, imageBuild, phaseFailed, msg); statusErr != nil {
+				return ctrl.Result{}, statusErr
+			}
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, fmt.Errorf("failed to create build task run: %w", err)
 	}
 
@@ -527,6 +540,11 @@ func (r *ImageBuildReconciler) createBuildTaskRun(
 		return fmt.Errorf("failed to get OperatorConfig configuration: %w", err)
 	}
 
+	// Fail closed: secureBuild must not silently fall back to the cluster pipeline
+	if imageBuild.Spec.SecureBuild && (err != nil || operatorConfig.Spec.OSBuilds == nil) {
+		return fmt.Errorf("secureBuild requested but OperatorConfig or spec.osBuilds is not available")
+	}
+
 	var buildConfig *tasks.BuildConfig
 	if err == nil && operatorConfig.Spec.OSBuilds != nil {
 		// Convert OSBuildsConfig to BuildConfig
@@ -543,9 +561,39 @@ func (r *ImageBuildReconciler) createBuildTaskRun(
 			UsePVCScratchVolumes:        operatorConfig.Spec.OSBuilds.GetUsePVCScratchVolumes(),
 		}
 		controllerutils.ApplyTrustedCABundleFromOSBuilds(buildConfig, operatorConfig.Spec.OSBuilds)
-	}
-	_ = buildConfig // buildConfig used for RuntimeClassName if needed
+		if imageBuild.Spec.SecureBuild {
+			// Use the digest-pinned ref snapshotted on the CR by the Build API,
+			// not the current OperatorConfig value (which may have changed).
+			ref := strings.TrimSpace(imageBuild.Spec.TaskBundleRef)
+			if ref == "" {
+				return fmt.Errorf("secureBuild requested but taskBundleRef is not set on the ImageBuild")
+			}
+			if !digestPinnedRef.MatchString(ref) {
+				return fmt.Errorf("secureBuild requires a digest-pinned taskBundleRef (must match image@sha256:<64 hex>), got %q", ref)
+			}
+			buildConfig.TaskResolver = tasks.TaskResolverBundle
+			buildConfig.TaskBundleRef = ref
 
+			// Bundle tasks are exported with nil BuildConfig (defaults only).
+			// Reject settings that would silently diverge from the bundle.
+			if buildConfig.TrustedCABundleName != "" && buildConfig.TrustedCABundleName != tasks.DefaultTrustedCABundleConfigMap {
+				return fmt.Errorf("secureBuild: OperatorConfig specifies custom CA bundle %q but bundle tasks use default %q; build a custom bundle or remove the CA override",
+					buildConfig.TrustedCABundleName, tasks.DefaultTrustedCABundleConfigMap)
+			}
+			if buildConfig.TrustedCABundleKind != "" && !strings.EqualFold(buildConfig.TrustedCABundleKind, "ConfigMap") {
+				return fmt.Errorf("secureBuild: OperatorConfig specifies CA bundle kind %q but bundle tasks use ConfigMap; build a custom bundle or remove the CA override",
+					buildConfig.TrustedCABundleKind)
+			}
+			if buildConfig.UseMemoryVolumes {
+				r.emitEventf(imageBuild, corev1.EventTypeWarning, "SecureBuildConfigDrift",
+					"OperatorConfig.useMemoryVolumes is enabled but bundle tasks use disk-backed emptyDir; memory volumes will not apply to this build")
+			}
+			if buildConfig.UsePVCScratchVolumes {
+				r.emitEventf(imageBuild, corev1.EventTypeWarning, "SecureBuildConfigDrift",
+					"OperatorConfig.usePVCScratchVolumes is enabled but bundle tasks use emptyDir; PVC scratch will not apply to this build")
+			}
+		}
+	}
 	// PVC is created via VolumeClaimTemplate in the PipelineRun workspace binding
 	// to ensure proper zone affinity with WaitForFirstConsumer storage class
 
@@ -646,6 +694,13 @@ func (r *ImageBuildReconciler) createBuildTaskRun(
 			Value: tektonv1.ParamValue{
 				Type:      tektonv1.ParamTypeString,
 				StringVal: fmt.Sprintf("%t", imageBuild.Spec.BuildCachePVC != ""),
+			},
+		},
+		{
+			Name: "secure-build",
+			Value: tektonv1.ParamValue{
+				Type:      tektonv1.ParamTypeString,
+				StringVal: fmt.Sprintf("%t", imageBuild.Spec.SecureBuild),
 			},
 		},
 	}
@@ -996,6 +1051,26 @@ func (r *ImageBuildReconciler) createBuildTaskRun(
 		log.Info("Setting RuntimeClassName from ImageBuild spec", "runtimeClassName", imageBuild.Spec.RuntimeClassName)
 		podTemplate.RuntimeClassName = &imageBuild.Spec.RuntimeClassName
 	}
+	pipelineRunSpec := tektonv1.PipelineRunSpec{
+		Params:     params,
+		Workspaces: pipelineWorkspaces,
+		TaskRunTemplate: tektonv1.PipelineTaskRunTemplate{
+			PodTemplate:        podTemplate,
+			ServiceAccountName: automotivev1alpha1.BuildServiceAccountName,
+		},
+	}
+
+	// When using bundle resolver, embed the pipeline spec inline so task refs
+	// point to the signed bundle. Otherwise reference the cluster-installed pipeline.
+	if buildConfig != nil && buildConfig.TaskResolver == tasks.TaskResolverBundle {
+		pipeline := tasks.GenerateTektonPipeline("", imageBuild.Namespace, buildConfig)
+		pipelineRunSpec.PipelineSpec = &pipeline.Spec
+	} else {
+		pipelineRunSpec.PipelineRef = &tektonv1.PipelineRef{
+			Name: "automotive-build-pipeline",
+		}
+	}
+
 	pipelineRun := &tektonv1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: safeDerivedName(imageBuild.Name, "-build-"),
@@ -1014,17 +1089,7 @@ func (r *ImageBuildReconciler) createBuildTaskRun(
 				},
 			},
 		},
-		Spec: tektonv1.PipelineRunSpec{
-			PipelineRef: &tektonv1.PipelineRef{
-				Name: "automotive-build-pipeline",
-			},
-			Params:     params,
-			Workspaces: pipelineWorkspaces,
-			TaskRunTemplate: tektonv1.PipelineTaskRunTemplate{
-				PodTemplate:        podTemplate,
-				ServiceAccountName: automotivev1alpha1.BuildServiceAccountName,
-			},
-		},
+		Spec: pipelineRunSpec,
 	}
 
 	if err := r.Create(ctx, pipelineRun); err != nil {

--- a/internal/controller/imagebuild/controller.go
+++ b/internal/controller/imagebuild/controller.go
@@ -1994,14 +1994,33 @@ func (r *ImageBuildReconciler) createUploadPod(ctx context.Context, imageBuild *
 		},
 	}
 
-	// Apply the same nodeSelector and tolerations used by build pods so the upload
-	// pod lands in the same AZ, ensuring the WaitForFirstConsumer PVC is provisioned
-	// on a topology reachable by the build pod.
+	// Apply the same scheduling constraints used by build pods so the upload
+	// pod lands in the same AZ and architecture, ensuring the WaitForFirstConsumer
+	// PVC is provisioned on a topology reachable by the build pod.
 	if operatorConfig.Spec.OSBuilds != nil && len(operatorConfig.Spec.OSBuilds.NodeSelector) > 0 {
 		pod.Spec.NodeSelector = operatorConfig.Spec.OSBuilds.NodeSelector
 	}
 	if operatorConfig.Spec.OSBuilds != nil && len(operatorConfig.Spec.OSBuilds.Tolerations) > 0 {
 		pod.Spec.Tolerations = operatorConfig.Spec.OSBuilds.Tolerations
+	}
+	if imageBuild.Spec.Architecture != "" {
+		pod.Spec.Affinity = &corev1.Affinity{
+			NodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						{
+							MatchExpressions: []corev1.NodeSelectorRequirement{
+								{
+									Key:      corev1.LabelArchStable,
+									Operator: corev1.NodeSelectorOpIn,
+									Values:   []string{imageBuild.Spec.Architecture},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
 	}
 
 	if err := r.Create(ctx, pod); err != nil && !errors.IsAlreadyExists(err) {

--- a/internal/controller/operatorconfig/controller.go
+++ b/internal/controller/operatorconfig/controller.go
@@ -642,6 +642,9 @@ func (r *OperatorConfigReconciler) deployOSBuilds(
 			buildConfig.TrustedCABundleKind = config.Spec.OSBuilds.Certificates.TrustedCABundle.Kind
 			buildConfig.TrustedCABundleName = config.Spec.OSBuilds.Certificates.TrustedCABundle.Name
 		}
+		if config.Spec.OSBuilds.TaskBundleRef != "" {
+			buildConfig.TaskBundleRef = config.Spec.OSBuilds.TaskBundleRef
+		}
 	}
 
 	// Create target defaults ConfigMap (architecture, partition rules, etc.)


### PR DESCRIPTION
Emit IMAGE_URL and IMAGE_DIGEST task results from build and push tasks, enabling Tekton Chains to automatically discover artifacts and generate signed SLSA provenance attestations. Attach the sanitized osbuild manifest (image.json) as an OCI referrer on the disk artifact for supply chain verification.

- build_image.sh: capture bootc container digest via --digestfile, write to /tekton/results/ (empty defaults prevent TaskRun failure when no container push occurs)
- push_artifact.sh: capture ORAS push digest via tee + sed fallback, write to /tekton/results/; sanitize and attach osbuild manifest as OCI referrer (strips password hashes, secrets, embedded credentials)
- tasks.go: declare IMAGE_URL/IMAGE_DIGEST results on both tasks; surface as pipeline results (named differently to avoid Chains double-counting)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Secure build mode: CLI flag, API fields and server/controller validation to require a digest-pinned Tekton bundle; resolver selection supports bundle vs cluster.
  * Export tool and pipeline bundling support to produce signed Tekton task bundles.

* **Build & Infrastructure**
  * CI and Make targets to export, bundle, push and cosign Tekton task bundles.

* **Features**
  * Artifact integrity digest computation and optional verification before push; push outputs and image digests are recorded for pipeline results and Chains hints.

* **Bug Fixes**
  * More robust push flow, sanitized metadata attachment, and resilient handling of partition artifacts.

* **Tests**
  * New unit tests for task/pipeline generation, resolver selection, and result wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->