### PR TITLE
consolidate output format into global --output-format flag

### DIFF
--- a/cmd/caib/catalog/catalog.go
+++ b/cmd/caib/catalog/catalog.go
@@ -27,14 +27,14 @@ import (
 )
 
 const (
-	defaultNamespace = "default"
+	defaultNamespace  = "default"
+	outputFormatTable = "table"
 )
 
 var (
-	serverURL    string
-	authToken    string
-	namespace    string
-	outputFormat string
+	serverURL string
+	authToken string
+	namespace string
 )
 
 // NewCatalogCmd creates the catalog command with subcommands
@@ -61,7 +61,16 @@ func addCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&serverURL, "server", "", "REST API server base URL (env: CAIB_SERVER)")
 	cmd.Flags().StringVar(&authToken, "token", "", "Bearer token for authentication (env: CAIB_TOKEN)")
 	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Kubernetes namespace")
-	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "Output format (table, json, yaml)")
+}
+
+// getOutputFormat returns the output format from the root command's --output-format flag.
+func getOutputFormat(cmd *cobra.Command) string {
+	if cmd.Root() != nil {
+		if flag := cmd.Root().PersistentFlags().Lookup("output-format"); flag != nil {
+			return flag.Value.String()
+		}
+	}
+	return outputFormatTable
 }
 
 // getInsecureSkipTLS returns whether to skip TLS verification

--- a/cmd/caib/catalog/catalog_test.go
+++ b/cmd/caib/catalog/catalog_test.go
@@ -1,0 +1,49 @@
+package catalog
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	testFormatTable = "table"
+	testFormatJSON  = "json"
+	testFormatYAML  = "yaml"
+)
+
+func TestGetOutputFormat_ReadsFromRoot(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().String("output-format", "table", "output format")
+
+	child := &cobra.Command{Use: "child"}
+	root.AddCommand(child)
+
+	// Default
+	if got := getOutputFormat(child); got != testFormatTable {
+		t.Errorf("expected default %q, got %q", testFormatTable, got)
+	}
+
+	// Set to json
+	if err := root.PersistentFlags().Set("output-format", testFormatJSON); err != nil {
+		t.Fatal(err)
+	}
+	if got := getOutputFormat(child); got != testFormatJSON {
+		t.Errorf("expected %q, got %q", testFormatJSON, got)
+	}
+
+	// Set to yaml
+	if err := root.PersistentFlags().Set("output-format", testFormatYAML); err != nil {
+		t.Fatal(err)
+	}
+	if got := getOutputFormat(child); got != testFormatYAML {
+		t.Errorf("expected %q, got %q", testFormatYAML, got)
+	}
+}
+
+func TestGetOutputFormat_FallbackWithoutFlag(t *testing.T) {
+	cmd := &cobra.Command{Use: "standalone"}
+	if got := getOutputFormat(cmd); got != testFormatTable {
+		t.Errorf("expected fallback %q, got %q", testFormatTable, got)
+	}
+}

--- a/cmd/caib/catalog/get.go
+++ b/cmd/caib/catalog/get.go
@@ -22,6 +22,8 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
+	"text/tabwriter"
 
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/config"
 	"github.com/spf13/cobra"
@@ -98,7 +100,8 @@ func runGet(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to read response: %w", err)
 	}
 
-	switch outputFormat {
+	format := strings.ToLower(strings.TrimSpace(getOutputFormat(cmd)))
+	switch format {
 	case "json":
 		var result map[string]interface{}
 		if err := json.Unmarshal(body, &result); err != nil {
@@ -106,14 +109,61 @@ func runGet(cmd *cobra.Command, args []string) error {
 		}
 		output, _ := json.MarshalIndent(result, "", "  ")
 		fmt.Println(string(output))
-	default:
+	case "yaml", "yml":
 		var result map[string]interface{}
 		if err := json.Unmarshal(body, &result); err != nil {
 			return fmt.Errorf("failed to parse JSON response: %w", err)
 		}
 		output, _ := yaml.Marshal(result)
-		fmt.Println(string(output))
+		fmt.Print(string(output))
+	case outputFormatTable:
+		var img CatalogImageResponse
+		if err := json.Unmarshal(body, &img); err != nil {
+			return fmt.Errorf("failed to parse response: %w", err)
+		}
+		printImageDetails(img)
+	default:
+		return fmt.Errorf("invalid output format %q (supported: table, json, yaml)", format)
 	}
 
 	return nil
+}
+
+func printImageDetails(img CatalogImageResponse) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	defer func() {
+		if err := w.Flush(); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to flush output: %v\n", err)
+		}
+	}()
+
+	target := ""
+	if len(img.Targets) > 0 {
+		names := make([]string, len(img.Targets))
+		for i, t := range img.Targets {
+			names[i] = t.Name
+		}
+		target = fmt.Sprintf("%v", names)
+	}
+
+	rows := [][2]string{
+		{"Name", img.Name},
+		{"Namespace", img.Namespace},
+		{"Registry URL", img.RegistryURL},
+		{"Phase", img.Phase},
+		{"Architecture", img.Architecture},
+		{"Distro", img.Distro},
+		{"Targets", target},
+		{"Created At", img.CreatedAt},
+	}
+	if img.SizeBytes > 0 {
+		rows = append(rows, [2]string{"Size", fmt.Sprintf("%d bytes", img.SizeBytes)})
+	}
+
+	for _, row := range rows {
+		if _, err := fmt.Fprintf(w, "%s\t%s\n", row[0], row[1]); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to write output row: %v\n", err)
+			return
+		}
+	}
 }

--- a/cmd/caib/catalog/list.go
+++ b/cmd/caib/catalog/list.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/config"
@@ -171,15 +172,18 @@ func runList(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Output in requested format
-	switch outputFormat {
+	format := strings.ToLower(strings.TrimSpace(getOutputFormat(cmd)))
+	switch format {
 	case "json":
 		output, _ := json.MarshalIndent(result, "", "  ")
 		fmt.Println(string(output))
-	case "yaml":
+	case "yaml", "yml":
 		output, _ := yaml.Marshal(result)
 		fmt.Println(string(output))
-	default:
+	case outputFormatTable:
 		printTable(result.Items)
+	default:
+		return fmt.Errorf("invalid output format %q (supported: table, json, yaml)", format)
 	}
 
 	return nil

--- a/cmd/caib/image/image.go
+++ b/cmd/caib/image/image.go
@@ -32,7 +32,6 @@ type Options struct {
 	ServerURL              *string
 	AuthToken              *string
 	BuildName              *string
-	ShowOutputFormat       *string
 	Distro                 *string
 	Target                 *string
 	Architecture           *string
@@ -173,9 +172,6 @@ func NewImageCmd(opts Options) *cobra.Command {
 	showCmd.Flags().StringVar(
 		opts.AuthToken, "token", os.Getenv("CAIB_TOKEN"),
 		"Bearer token for authentication (e.g., OpenShift access token)",
-	)
-	showCmd.Flags().StringVarP(
-		opts.ShowOutputFormat, "output", "o", "table", "Output format (table, json, yaml)",
 	)
 
 	// disk command flags (create disk from existing container)
@@ -425,7 +421,7 @@ Examples:
   caib image show my-build
 
   # Show details as JSON
-  caib image show my-build -o json`,
+  caib image show my-build --output-format json`,
 		Args: cobra.ExactArgs(1),
 		Run:  opts.RunShow,
 	}

--- a/cmd/caib/main.go
+++ b/cmd/caib/main.go
@@ -15,7 +15,7 @@ var (
 	serverURL              string
 	manifest               string
 	buildName              string
-	showOutputFormat       string
+	outputFormat           string
 	distro                 string
 	target                 string
 	architecture           string

--- a/cmd/caib/main_test.go
+++ b/cmd/caib/main_test.go
@@ -251,6 +251,65 @@ func TestSanitizeBuildName(t *testing.T) {
 	}
 }
 
+func TestOutputFormatFlagRegistered(t *testing.T) {
+	rootCmd := newRootCmd()
+	flag := rootCmd.PersistentFlags().Lookup("output-format")
+	if flag == nil {
+		t.Fatal("expected --output-format persistent flag on root command")
+	}
+	if flag.DefValue != "table" {
+		t.Errorf("expected default value 'table', got %q", flag.DefValue)
+	}
+}
+
+func TestOutputFormatFlagPropagates(t *testing.T) {
+	rootCmd := newRootCmd()
+
+	// Simulate: caib image list --output-format json
+	// Find the image subcommand, then list under it
+	imageCmd, _, err := rootCmd.Find([]string{"image", "list"})
+	if err != nil {
+		t.Fatalf("could not find image list command: %v", err)
+	}
+
+	flag := imageCmd.Root().PersistentFlags().Lookup("output-format")
+	if flag == nil {
+		t.Fatal("expected --output-format to be visible from image list command")
+	}
+}
+
+func TestOutputFormatFlagSetFromArgs(t *testing.T) {
+	originalFormat := outputFormat
+	t.Cleanup(func() { outputFormat = originalFormat })
+
+	rootCmd := newRootCmd()
+
+	// Parse --output-format json at root level
+	rootCmd.SetArgs([]string{"--output-format", "json", "--help"})
+	_ = rootCmd.Execute()
+
+	if outputFormat != "json" {
+		t.Errorf("expected outputFormat to be 'json' after parsing, got %q", outputFormat)
+	}
+}
+
+func TestValidOutputFormats(t *testing.T) {
+	// This tests the validOutputFormats map keys directly.
+	// Note: PersistentPreRunE applies strings.ToLower before the lookup,
+	// so CLI users can pass e.g. "--output-format TABLE" and it will be
+	// accepted as "table". This test only validates the canonical map entries.
+	for _, f := range []string{"table", "json", "yaml", "yml"} {
+		if !validOutputFormats[f] {
+			t.Errorf("expected %q to be a valid output format", f)
+		}
+	}
+	for _, f := range []string{"csv", "xml", "", "TABLE"} {
+		if validOutputFormats[f] {
+			t.Errorf("expected %q to NOT be a valid output format", f)
+		}
+	}
+}
+
 func TestApplyTargetDefaults_MappingWithEmptyArchDoesNotOverride(t *testing.T) {
 	cmd := newCmdWithArchFlag(archAMD64, false)
 	config := &buildapitypes.OperatorConfigResponse{

--- a/cmd/caib/querycmd/query.go
+++ b/cmd/caib/querycmd/query.go
@@ -17,12 +17,14 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const outputFormatTable = "table"
+
 // Options wires query handlers to caller-owned state and helper callbacks.
 type Options struct {
-	ServerURL        *string
-	AuthToken        *string
-	ShowOutputFormat *string
-	InsecureSkipTLS  *bool
+	ServerURL       *string
+	AuthToken       *string
+	OutputFormat    *string
+	InsecureSkipTLS *bool
 
 	HandleError func(error)
 }
@@ -45,8 +47,30 @@ func (h *Handler) handleError(err error) {
 	panic(err)
 }
 
+// resolveOutputFormat normalises and validates the configured output format.
+// It returns the canonical lowercase format string or an error for unsupported values.
+func (h *Handler) resolveOutputFormat() (string, error) {
+	format := outputFormatTable
+	if h.opts.OutputFormat != nil && strings.TrimSpace(*h.opts.OutputFormat) != "" {
+		format = strings.ToLower(strings.TrimSpace(*h.opts.OutputFormat))
+	}
+
+	switch format {
+	case outputFormatTable, "json", "yaml", "yml":
+		return format, nil
+	default:
+		return "", fmt.Errorf("invalid output format %q (supported: table, json, yaml)", format)
+	}
+}
+
 // RunList handles `caib image list`.
 func (h *Handler) RunList(_ *cobra.Command, _ []string) {
+	format, err := h.resolveOutputFormat()
+	if err != nil {
+		h.handleError(err)
+		return
+	}
+
 	ctx := context.Background()
 	if h.opts.ServerURL == nil || strings.TrimSpace(*h.opts.ServerURL) == "" {
 		h.handleError(fmt.Errorf("server URL required (use --server, CAIB_SERVER, run 'caib login <server-url>' or 'jmp login <endpoint>')"))
@@ -61,7 +85,7 @@ func (h *Handler) RunList(_ *cobra.Command, _ []string) {
 	insecureSkipTLS := *h.opts.InsecureSkipTLS
 
 	var items []buildapitypes.BuildListItem
-	err := common.ExecuteWithReauth(serverURL, h.opts.AuthToken, insecureSkipTLS, func(api *buildapiclient.Client) error {
+	err = common.ExecuteWithReauth(serverURL, h.opts.AuthToken, insecureSkipTLS, func(api *buildapiclient.Client) error {
 		var listErr error
 		items, listErr = api.ListBuilds(ctx)
 		return listErr
@@ -70,43 +94,32 @@ func (h *Handler) RunList(_ *cobra.Command, _ []string) {
 		h.handleError(fmt.Errorf("error listing ImageBuilds: %w", err))
 		return
 	}
-	if len(items) == 0 {
-		fmt.Println("No ImageBuilds found")
-		return
-	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	defer func() {
-		if flushErr := w.Flush(); flushErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to flush output: %v\n", flushErr)
-		}
-	}()
+	h.renderList(format, items)
+}
 
-	if _, err := fmt.Fprintln(w, "NAME\tSTATUS\tAGE\tREQUESTED BY\tARTIFACT"); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: failed to write header: %v\n", err)
-		return
+// renderList formats and prints a list of builds according to the configured output format.
+func (h *Handler) renderList(format string, items []buildapitypes.BuildListItem) {
+	if items == nil {
+		items = []buildapitypes.BuildListItem{}
 	}
-	for _, it := range items {
-		artifact := it.DiskImage
-		if artifact == "" {
-			artifact = it.ContainerImage
+	h.renderFormatted(format, items, func() error {
+		if len(items) == 0 {
+			fmt.Println("No ImageBuilds found")
+			return nil
 		}
-		if _, err := fmt.Fprintf(
-			w,
-			"%s\t%s\t%s\t%s\t%s\n",
-			it.Name,
-			it.Phase,
-			formatAge(it.CreatedAt),
-			it.RequestedBy,
-			artifact,
-		); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to write row: %v\n", err)
-		}
-	}
+		return printBuildList(items)
+	})
 }
 
 // RunShow handles `caib image show`.
 func (h *Handler) RunShow(_ *cobra.Command, args []string) {
+	format, err := h.resolveOutputFormat()
+	if err != nil {
+		h.handleError(err)
+		return
+	}
+
 	ctx := context.Background()
 	showBuildName := args[0]
 
@@ -118,16 +131,11 @@ func (h *Handler) RunShow(_ *cobra.Command, args []string) {
 		h.handleError(fmt.Errorf("internal error: --insecure option is not configured"))
 		return
 	}
-	if h.opts.ShowOutputFormat == nil {
-		h.handleError(fmt.Errorf("internal error: output format option is not configured"))
-		return
-	}
-
 	serverURL := strings.TrimSpace(*h.opts.ServerURL)
 	insecureSkipTLS := *h.opts.InsecureSkipTLS
 
 	var st *buildapitypes.BuildResponse
-	err := common.ExecuteWithReauth(serverURL, h.opts.AuthToken, insecureSkipTLS, func(api *buildapiclient.Client) error {
+	err = common.ExecuteWithReauth(serverURL, h.opts.AuthToken, insecureSkipTLS, func(api *buildapiclient.Client) error {
 		var getErr error
 		st, getErr = api.GetBuild(ctx, showBuildName)
 		return getErr
@@ -158,26 +166,37 @@ func (h *Handler) RunShow(_ *cobra.Command, args []string) {
 		}
 	}
 
-	switch strings.ToLower(*h.opts.ShowOutputFormat) {
+	h.renderShow(format, st)
+}
+
+// renderShow formats and prints a single build response according to the configured output format.
+func (h *Handler) renderShow(format string, st *buildapitypes.BuildResponse) {
+	h.renderFormatted(format, st, func() error { return printBuildDetails(st) })
+}
+
+// renderFormatted outputs data in the given format, using tablePrinter for table output.
+func (h *Handler) renderFormatted(format string, data any, tablePrinter func() error) {
+	switch format {
 	case "json":
-		out, marshalErr := json.MarshalIndent(st, "", "  ")
+		out, marshalErr := json.MarshalIndent(data, "", "  ")
 		if marshalErr != nil {
 			h.handleError(fmt.Errorf("error rendering JSON output: %w", marshalErr))
 			return
 		}
 		fmt.Println(string(out))
 	case "yaml", "yml":
-		out, marshalErr := yaml.Marshal(st)
+		out, marshalErr := yaml.Marshal(data)
 		if marshalErr != nil {
 			h.handleError(fmt.Errorf("error rendering YAML output: %w", marshalErr))
 			return
 		}
 		fmt.Print(string(out))
-	case "table":
-		printBuildDetails(st)
+	case outputFormatTable:
+		if err := tablePrinter(); err != nil {
+			h.handleError(fmt.Errorf("error writing table output: %w", err))
+		}
 	default:
-		h.handleError(fmt.Errorf("invalid output format %q (supported: table, json, yaml)", *h.opts.ShowOutputFormat))
-		return
+		h.handleError(fmt.Errorf("invalid output format %q (supported: table, json, yaml)", format))
 	}
 }
 
@@ -223,13 +242,34 @@ func buildParametersFromTemplate(tpl *buildapitypes.BuildTemplateResponse) *buil
 	return params
 }
 
-func printBuildDetails(st *buildapitypes.BuildResponse) {
+func printBuildList(items []buildapitypes.BuildListItem) error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	defer func() {
-		if err := w.Flush(); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to flush output: %v\n", err)
+
+	if _, err := fmt.Fprintln(w, "NAME\tSTATUS\tAGE\tREQUESTED BY\tARTIFACT"); err != nil {
+		return err
+	}
+	for _, it := range items {
+		artifact := it.DiskImage
+		if artifact == "" {
+			artifact = it.ContainerImage
 		}
-	}()
+		if _, err := fmt.Fprintf(
+			w,
+			"%s\t%s\t%s\t%s\t%s\n",
+			it.Name,
+			it.Phase,
+			formatAge(it.CreatedAt),
+			it.RequestedBy,
+			artifact,
+		); err != nil {
+			return err
+		}
+	}
+	return w.Flush()
+}
+
+func printBuildDetails(st *buildapitypes.BuildResponse) error {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 
 	rows := [][2]string{
 		{"Name", st.Name},
@@ -268,10 +308,10 @@ func printBuildDetails(st *buildapitypes.BuildResponse) {
 
 	for _, row := range rows {
 		if _, err := fmt.Fprintf(w, "%s\t%s\n", row[0], row[1]); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to write output row: %v\n", err)
-			return
+			return err
 		}
 	}
+	return w.Flush()
 }
 
 func valueOrDash(v string) string {

--- a/cmd/caib/querycmd/query_test.go
+++ b/cmd/caib/querycmd/query_test.go
@@ -1,0 +1,292 @@
+package querycmd
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	buildapitypes "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	testFormatJSON  = "json"
+	testFormatYAML  = "yaml"
+	testFormatTable = "table"
+)
+
+func sampleItems() []buildapitypes.BuildListItem {
+	return []buildapitypes.BuildListItem{
+		{
+			Name:           "build-1",
+			Phase:          "Succeeded",
+			RequestedBy:    "alice",
+			CreatedAt:      "2025-01-01T00:00:00Z",
+			ContainerImage: "quay.io/org/img:v1",
+		},
+		{
+			Name:      "build-2",
+			Phase:     "Running",
+			CreatedAt: "2025-06-01T12:00:00Z",
+			DiskImage: "quay.io/org/disk:v2",
+		},
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+
+	fn()
+
+	_ = w.Close()
+	os.Stdout = old
+
+	buf := make([]byte, 64*1024)
+	n, _ := r.Read(buf)
+	return string(buf[:n])
+}
+
+func TestPrintBuildList_Table(t *testing.T) {
+	items := sampleItems()
+	out := captureStdout(t, func() {
+		_ = printBuildList(items)
+	})
+
+	if !strings.Contains(out, "NAME") || !strings.Contains(out, "STATUS") {
+		t.Errorf("expected table header, got: %s", out)
+	}
+	if !strings.Contains(out, "build-1") || !strings.Contains(out, "build-2") {
+		t.Errorf("expected both build names in output, got: %s", out)
+	}
+	if !strings.Contains(out, "alice") {
+		t.Errorf("expected requestedBy in output, got: %s", out)
+	}
+}
+
+func TestPrintBuildList_DiskImagePreferred(t *testing.T) {
+	items := sampleItems()
+	out := captureStdout(t, func() {
+		_ = printBuildList(items)
+	})
+
+	// build-2 has DiskImage set — it should appear instead of ContainerImage
+	if !strings.Contains(out, "quay.io/org/disk:v2") {
+		t.Errorf("expected disk image artifact for build-2, got: %s", out)
+	}
+}
+
+func TestFormatOutputJSON_List(t *testing.T) {
+	format := testFormatJSON
+	items := sampleItems()
+
+	var lastErr error
+	h := NewHandler(Options{
+		OutputFormat: &format,
+		HandleError:  func(err error) { lastErr = err },
+	})
+
+	out := captureStdout(t, func() {
+		h.renderList(format, items)
+	})
+
+	if lastErr != nil {
+		t.Fatalf("unexpected error: %v", lastErr)
+	}
+
+	var parsed []buildapitypes.BuildListItem
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, out)
+	}
+	if len(parsed) != 2 {
+		t.Errorf("expected 2 items, got %d", len(parsed))
+	}
+	if parsed[0].Name != "build-1" {
+		t.Errorf("expected first item name build-1, got %s", parsed[0].Name)
+	}
+}
+
+func TestFormatOutputYAML_List(t *testing.T) {
+	format := testFormatYAML
+	items := sampleItems()
+
+	var lastErr error
+	h := NewHandler(Options{
+		OutputFormat: &format,
+		HandleError:  func(err error) { lastErr = err },
+	})
+
+	out := captureStdout(t, func() {
+		h.renderList(format, items)
+	})
+
+	if lastErr != nil {
+		t.Fatalf("unexpected error: %v", lastErr)
+	}
+
+	var parsed []map[string]interface{}
+	if err := yaml.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("output is not valid YAML: %v\noutput: %s", err, out)
+	}
+	if len(parsed) != 2 {
+		t.Errorf("expected 2 items, got %d", len(parsed))
+	}
+}
+
+func TestFormatOutputTable_List(t *testing.T) {
+	format := testFormatTable
+	items := sampleItems()
+
+	var lastErr error
+	h := NewHandler(Options{
+		OutputFormat: &format,
+		HandleError:  func(err error) { lastErr = err },
+	})
+
+	out := captureStdout(t, func() {
+		h.renderList(format, items)
+	})
+
+	if lastErr != nil {
+		t.Fatalf("unexpected error: %v", lastErr)
+	}
+
+	if !strings.Contains(out, "NAME") {
+		t.Errorf("expected table header, got: %s", out)
+	}
+}
+
+func TestFormatOutputNil_DefaultsToTable(t *testing.T) {
+	items := sampleItems()
+
+	var lastErr error
+	h := NewHandler(Options{
+		OutputFormat: nil,
+		HandleError:  func(err error) { lastErr = err },
+	})
+
+	out := captureStdout(t, func() {
+		h.renderList(testFormatTable, items)
+	})
+
+	if lastErr != nil {
+		t.Fatalf("unexpected error: %v", lastErr)
+	}
+
+	if !strings.Contains(out, "NAME") {
+		t.Errorf("expected table output when format is nil, got: %s", out)
+	}
+}
+
+func TestFormatOutputInvalid_ReturnsError(t *testing.T) {
+	format := "csv"
+	items := sampleItems()
+
+	var lastErr error
+	h := NewHandler(Options{
+		OutputFormat: &format,
+		HandleError:  func(err error) { lastErr = err },
+	})
+
+	captureStdout(t, func() {
+		h.renderList(format, items)
+	})
+
+	if lastErr == nil {
+		t.Fatal("expected error for invalid format")
+	}
+	if !strings.Contains(lastErr.Error(), "csv") {
+		t.Errorf("expected error to mention the invalid format, got: %v", lastErr)
+	}
+}
+
+func TestFormatOutputJSON_Show(t *testing.T) {
+	format := testFormatJSON
+	resp := &buildapitypes.BuildResponse{
+		Name:  "test-build",
+		Phase: "Succeeded",
+	}
+
+	var lastErr error
+	h := NewHandler(Options{
+		OutputFormat: &format,
+		HandleError:  func(err error) { lastErr = err },
+	})
+
+	out := captureStdout(t, func() {
+		h.renderShow(format, resp)
+	})
+
+	if lastErr != nil {
+		t.Fatalf("unexpected error: %v", lastErr)
+	}
+
+	var parsed buildapitypes.BuildResponse
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, out)
+	}
+	if parsed.Name != "test-build" {
+		t.Errorf("expected name test-build, got %s", parsed.Name)
+	}
+}
+
+func TestFormatOutputYAML_Show(t *testing.T) {
+	format := testFormatYAML
+	resp := &buildapitypes.BuildResponse{
+		Name:  "test-build",
+		Phase: "Succeeded",
+	}
+
+	var lastErr error
+	h := NewHandler(Options{
+		OutputFormat: &format,
+		HandleError:  func(err error) { lastErr = err },
+	})
+
+	out := captureStdout(t, func() {
+		h.renderShow(format, resp)
+	})
+
+	if lastErr != nil {
+		t.Fatalf("unexpected error: %v", lastErr)
+	}
+
+	var parsed map[string]interface{}
+	if err := yaml.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("output is not valid YAML: %v\noutput: %s", err, out)
+	}
+	if parsed["name"] != "test-build" {
+		t.Errorf("expected name test-build, got %v", parsed["name"])
+	}
+}
+
+func TestValueOrDash(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"hello", "hello"},
+		{"", "-"},
+		{"  ", "-"},
+	}
+	for _, tt := range tests {
+		got := valueOrDash(tt.input)
+		if got != tt.want {
+			t.Errorf("valueOrDash(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestFormatAge(t *testing.T) {
+	// non-RFC3339 input should be returned as-is
+	got := formatAge("not-a-date")
+	if got != "not-a-date" {
+		t.Errorf("formatAge(invalid) = %q, want %q", got, "not-a-date")
+	}
+}

--- a/cmd/caib/root.go
+++ b/cmd/caib/root.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/authcmd"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/catalog"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/container"
@@ -9,11 +12,25 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var validOutputFormats = map[string]bool{
+	"table": true,
+	"json":  true,
+	"yaml":  true,
+	"yml":   true,
+}
+
 func newRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:     "caib",
 		Short:   "Cloud Automotive Image Builder",
 		Version: version,
+		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+			f := strings.ToLower(strings.TrimSpace(outputFormat))
+			if !validOutputFormats[f] {
+				return fmt.Errorf("invalid output format %q (supported: table, json, yaml)", outputFormat)
+			}
+			return nil
+		},
 	}
 
 	rootCmd.InitDefaultVersionFlag()
@@ -24,6 +41,12 @@ func newRootCmd() *cobra.Command {
 		"insecure",
 		envBool("CAIB_INSECURE"),
 		"skip TLS certificate verification (insecure, for testing only; env: CAIB_INSECURE)",
+	)
+	rootCmd.PersistentFlags().StringVar(
+		&outputFormat,
+		"output-format",
+		"table",
+		"output format: table, json, yaml",
 	)
 	state := newRuntimeState()
 	handlers := state.newHandlers()

--- a/cmd/caib/runtime_wiring.go
+++ b/cmd/caib/runtime_wiring.go
@@ -14,7 +14,7 @@ type runtimeState struct {
 	ServerURL              *string
 	Manifest               *string
 	BuildName              *string
-	ShowOutputFormat       *string
+	OutputFormat           *string
 	Distro                 *string
 	Target                 *string
 	Architecture           *string
@@ -72,7 +72,7 @@ func newRuntimeState() runtimeState {
 		ServerURL:              &serverURL,
 		Manifest:               &manifest,
 		BuildName:              &buildName,
-		ShowOutputFormat:       &showOutputFormat,
+		OutputFormat:           &outputFormat,
 		Distro:                 &distro,
 		Target:                 &target,
 		Architecture:           &architecture,
@@ -179,11 +179,11 @@ func (s runtimeState) newHandlers() handlerSet {
 			HandleError:               handleError,
 		}),
 		query: querycmd.NewHandler(querycmd.Options{
-			ServerURL:        s.ServerURL,
-			AuthToken:        s.AuthToken,
-			ShowOutputFormat: s.ShowOutputFormat,
-			InsecureSkipTLS:  s.InsecureSkipTLS,
-			HandleError:      handleError,
+			ServerURL:       s.ServerURL,
+			AuthToken:       s.AuthToken,
+			OutputFormat:    s.OutputFormat,
+			InsecureSkipTLS: s.InsecureSkipTLS,
+			HandleError:     handleError,
 		}),
 		download: downloadcmd.NewHandler(downloadcmd.Options{
 			ServerURL:       s.ServerURL,
@@ -259,7 +259,6 @@ func (s runtimeState) imageOptions(h handlerSet) image.Options {
 		ServerURL:              s.ServerURL,
 		AuthToken:              s.AuthToken,
 		BuildName:              s.BuildName,
-		ShowOutputFormat:       s.ShowOutputFormat,
 		Distro:                 s.Distro,
 		Target:                 s.Target,
 		Architecture:           s.Architecture,


### PR DESCRIPTION
Replace per-command -o/--output flags with a single --output-format persistent flag on the root command. Fix catalog commands silently accepting invalid format values, and deduplicate render logic in querycmd via shared renderFormatted method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global --output-format flag (default: table); per-command -o/--output flags removed. Table rendering enhanced for list/get/show outputs (more compact/detail views).

* **Bug Fixes**
  * Invalid formats now return clear errors; yaml and yml accepted equivalently. Help/examples updated to reference --output-format.

* **Tests**
  * New tests for root flag behavior, validation, and formatted output rendering (table/json/yaml).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->