### PR TITLE
fix: update backport label pattern to match backport/ prefix

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -35,6 +35,7 @@ jobs:
         uses: korthout/backport-action@v4
         with:
           github_token: ${{ steps.app-token.outputs.token }}
+          label_pattern: ^backport/([^ ]+)$
           merge_commits: skip
           pull_description: |-
             Backport to `${target_branch}`, triggered by a label in #${pull_number}.


### PR DESCRIPTION
- The backport action's default label_pattern expects `backport <branch>` (with a space), but our labels use `backport/<branch>` (with a slash)
- Adds explicit `label_pattern: ^backport/([^ ]+)$` to match the slash-based convention