### PR TITLE
add `caib status`

### DIFF
--- a/cmd/caib/root.go
+++ b/cmd/caib/root.go
@@ -31,6 +31,7 @@ func newRootCmd() *cobra.Command {
 	rootCmd.AddCommand(
 		image.NewImageCmd(state.imageOptions(handlers)),
 		newLoginCmd(),
+		newStatusCmd(),
 		container.NewContainerCmd(),
 		catalog.NewCatalogCmd(),
 		authcmd.NewAuthCmd(),

--- a/cmd/caib/status.go
+++ b/cmd/caib/status.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/config"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	statusReachable     = "reachable"
+	statusNotConfigured = "not configured"
+	sourceCAIBEnv       = "CAIB_SERVER env"
+)
+
+var statusOutputFormat string
+
+func newStatusCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show which Build API server builds will run on",
+		Long: `Display which Build API server caib is configured to use.
+
+Shows the resolved server URL (from CAIB_SERVER env, saved config, or Jumpstarter
+derivation) and whether the server is reachable.
+
+Examples:
+  caib status
+  caib status -o json
+  caib status -o yaml`,
+		Run: runStatus,
+	}
+	cmd.Flags().StringVarP(&statusOutputFormat, "output", "o", "table", "output format: table, json, yaml")
+	return cmd
+}
+
+type statusInfo struct {
+	Server serverInfo `json:"server" yaml:"server"`
+}
+
+type serverInfo struct {
+	URL    string `json:"url" yaml:"url"`
+	Source string `json:"source" yaml:"source"`
+	Status string `json:"status" yaml:"status"`
+}
+
+func runStatus(_ *cobra.Command, _ []string) {
+	info := gatherStatus()
+
+	switch strings.ToLower(statusOutputFormat) {
+	case "json":
+		out, err := json.MarshalIndent(info, "", "  ")
+		if err != nil {
+			handleError(fmt.Errorf("error rendering JSON: %w", err))
+			return
+		}
+		fmt.Println(string(out))
+	case "yaml", "yml":
+		out, err := yaml.Marshal(info)
+		if err != nil {
+			handleError(fmt.Errorf("error rendering YAML: %w", err))
+			return
+		}
+		fmt.Print(string(out))
+	case "table":
+		printStatusTable(info)
+	default:
+		handleError(fmt.Errorf("invalid output format %q (supported: table, json, yaml)", statusOutputFormat))
+	}
+}
+
+func gatherStatus() statusInfo {
+	var info statusInfo
+
+	info.Server.URL, info.Server.Source = resolveServerWithSource()
+
+	if info.Server.URL != "" {
+		info.Server.Status = checkServerHealth(info.Server.URL)
+	} else {
+		info.Server.Status = statusNotConfigured
+	}
+
+	return info
+}
+
+// resolveServerWithSource returns the effective server URL and a human-readable source label.
+func resolveServerWithSource() (string, string) {
+	if s := strings.TrimSpace(os.Getenv("CAIB_SERVER")); s != "" {
+		return s, sourceCAIBEnv
+	}
+
+	cfg, err := config.Read()
+	if err == nil && cfg != nil {
+		if s := strings.TrimSpace(cfg.ServerURL); s != "" {
+			return s, "saved config (~/.config/caib/cli.json)"
+		}
+	}
+
+	if s := config.DeriveServerFromJumpstarter(); s != "" {
+		return s, "derived from Jumpstarter"
+	}
+
+	return "", ""
+}
+
+func checkServerHealth(serverURL string) string {
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipTLS, MinVersion: tls.VersionTLS12}, //nolint:gosec
+		},
+	}
+
+	resp, err := client.Get(serverURL + "/v1/healthz")
+	if err != nil {
+		return fmt.Sprintf("unreachable (%v)", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusOK {
+		return statusReachable
+	}
+	return fmt.Sprintf("unhealthy (HTTP %d)", resp.StatusCode)
+}
+
+func printStatusTable(info statusInfo) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	defer func() {
+		if err := w.Flush(); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to flush output: %v\n", err)
+		}
+	}()
+
+	writeRows(w, [][2]string{
+		{"Server", valueOrNone(info.Server.URL)},
+		{"Source", valueOrNone(info.Server.Source)},
+	})
+	printServerStatus(w, info.Server.Status)
+}
+
+func writeRows(w *tabwriter.Writer, rows [][2]string) {
+	for _, r := range rows {
+		if _, err := fmt.Fprintf(w, "%s\t%s\n", r[0], r[1]); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to write output: %v\n", err)
+			return
+		}
+	}
+}
+
+func printServerStatus(w *tabwriter.Writer, status string) {
+	var colored string
+	switch {
+	case status == statusReachable:
+		colored = color.GreenString(status)
+	case strings.HasPrefix(status, "unreachable"):
+		colored = color.RedString(status)
+	default:
+		colored = color.YellowString(status)
+	}
+	if _, err := fmt.Fprintf(w, "Status\t%s\n", colored); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to write output: %v\n", err)
+	}
+}
+
+func valueOrNone(v string) string {
+	if strings.TrimSpace(v) == "" {
+		return color.YellowString("not configured")
+	}
+	return v
+}

--- a/cmd/caib/status_test.go
+++ b/cmd/caib/status_test.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// isolateEnv sets env vars for the test and auto-restores them on cleanup.
+func isolateEnv(t *testing.T, vars map[string]string) {
+	t.Helper()
+	for k, v := range vars {
+		t.Setenv(k, v)
+	}
+}
+
+// --- resolveServerWithSource ---
+
+func TestResolveServerWithSource_EnvVar(t *testing.T) {
+	tmp := t.TempDir()
+	isolateEnv(t, map[string]string{
+		"CAIB_SERVER":     "https://from-env.example.com",
+		"HOME":            tmp,
+		"XDG_CONFIG_HOME": filepath.Join(tmp, "xdg"),
+	})
+
+	url, source := resolveServerWithSource()
+	if url != "https://from-env.example.com" {
+		t.Errorf("expected URL from env, got %q", url)
+	}
+	if source != sourceCAIBEnv {
+		t.Errorf("expected source %q, got %q", sourceCAIBEnv, source)
+	}
+}
+
+func TestResolveServerWithSource_SavedConfig(t *testing.T) {
+	tmp := t.TempDir()
+	isolateEnv(t, map[string]string{
+		"CAIB_SERVER":     "",
+		"HOME":            tmp,
+		"XDG_CONFIG_HOME": filepath.Join(tmp, "xdg"),
+	})
+
+	configDir := filepath.Join(tmp, "xdg", "caib")
+	if err := os.MkdirAll(configDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(configDir, "cli.json"),
+		[]byte(`{"server_url":"https://from-config.example.com"}`),
+		0600,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	url, source := resolveServerWithSource()
+	if url != "https://from-config.example.com" {
+		t.Errorf("expected URL from config, got %q", url)
+	}
+	if source != "saved config (~/.config/caib/cli.json)" {
+		t.Errorf("expected source 'saved config', got %q", source)
+	}
+}
+
+func TestResolveServerWithSource_NothingConfigured(t *testing.T) {
+	tmp := t.TempDir()
+	isolateEnv(t, map[string]string{
+		"CAIB_SERVER":            "",
+		"HOME":                   tmp,
+		"XDG_CONFIG_HOME":        filepath.Join(tmp, "xdg"),
+		"JMP_CLIENT_CONFIG_HOME": filepath.Join(tmp, "no-jmp"),
+	})
+
+	url, source := resolveServerWithSource()
+	if url != "" {
+		t.Errorf("expected empty URL, got %q", url)
+	}
+	if source != "" {
+		t.Errorf("expected empty source, got %q", source)
+	}
+}
+
+// --- checkServerHealth ---
+
+func TestCheckServerHealth_Reachable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	status := checkServerHealth(srv.URL)
+	if status != statusReachable {
+		t.Errorf("expected %q, got %q", statusReachable, status)
+	}
+}
+
+func TestCheckServerHealth_Unhealthy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	status := checkServerHealth(srv.URL)
+	expected := "unhealthy (HTTP 503)"
+	if status != expected {
+		t.Errorf("expected %q, got %q", expected, status)
+	}
+}
+
+func TestCheckServerHealth_Unreachable(t *testing.T) {
+	status := checkServerHealth("http://127.0.0.1:1")
+	if len(status) < 12 || status[:11] != "unreachable" {
+		t.Errorf("expected 'unreachable (...)', got %q", status)
+	}
+}
+
+// --- gatherStatus ---
+
+func TestGatherStatus_WithServer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	isolateEnv(t, map[string]string{
+		"CAIB_SERVER":            srv.URL,
+		"HOME":                   tmp,
+		"XDG_CONFIG_HOME":        filepath.Join(tmp, "xdg"),
+		"JMP_CLIENT_CONFIG_HOME": filepath.Join(tmp, "no-jmp"),
+	})
+
+	info := gatherStatus()
+
+	if info.Server.URL != srv.URL {
+		t.Errorf("expected server URL %q, got %q", srv.URL, info.Server.URL)
+	}
+	if info.Server.Source != sourceCAIBEnv {
+		t.Errorf("expected source %q, got %q", sourceCAIBEnv, info.Server.Source)
+	}
+	if info.Server.Status != statusReachable {
+		t.Errorf("expected status %q, got %q", statusReachable, info.Server.Status)
+	}
+}
+
+func TestGatherStatus_NoServer(t *testing.T) {
+	tmp := t.TempDir()
+	isolateEnv(t, map[string]string{
+		"CAIB_SERVER":            "",
+		"HOME":                   tmp,
+		"XDG_CONFIG_HOME":        filepath.Join(tmp, "xdg"),
+		"JMP_CLIENT_CONFIG_HOME": filepath.Join(tmp, "no-jmp"),
+	})
+
+	info := gatherStatus()
+
+	if info.Server.URL != "" {
+		t.Errorf("expected empty server URL, got %q", info.Server.URL)
+	}
+	if info.Server.Status != statusNotConfigured {
+		t.Errorf("expected status %q, got %q", statusNotConfigured, info.Server.Status)
+	}
+}
+
+// --- JSON / YAML output ---
+
+func TestStatusInfo_JSONRoundTrip(t *testing.T) {
+	info := statusInfo{
+		Server: serverInfo{
+			URL:    "https://api.example.com",
+			Source: sourceCAIBEnv,
+			Status: statusReachable,
+		},
+	}
+
+	data, err := json.MarshalIndent(info, "", "  ")
+	if err != nil {
+		t.Fatalf("JSON marshal failed: %v", err)
+	}
+
+	var decoded statusInfo
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("JSON unmarshal failed: %v", err)
+	}
+
+	if decoded.Server.URL != info.Server.URL {
+		t.Errorf("JSON round-trip: server URL mismatch: %q vs %q", decoded.Server.URL, info.Server.URL)
+	}
+	if decoded.Server.Source != info.Server.Source {
+		t.Errorf("JSON round-trip: source mismatch: %q vs %q", decoded.Server.Source, info.Server.Source)
+	}
+}
+
+func TestStatusInfo_YAMLRoundTrip(t *testing.T) {
+	info := statusInfo{
+		Server: serverInfo{
+			URL:    "https://api.example.com",
+			Source: "saved config",
+			Status: "unreachable",
+		},
+	}
+
+	data, err := yaml.Marshal(info)
+	if err != nil {
+		t.Fatalf("YAML marshal failed: %v", err)
+	}
+
+	var decoded statusInfo
+	if err := yaml.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("YAML unmarshal failed: %v", err)
+	}
+
+	if decoded.Server.Status != info.Server.Status {
+		t.Errorf("YAML round-trip: status mismatch: %q vs %q", decoded.Server.Status, info.Server.Status)
+	}
+	if decoded.Server.URL != info.Server.URL {
+		t.Errorf("YAML round-trip: URL mismatch: %q vs %q", decoded.Server.URL, info.Server.URL)
+	}
+}


### PR DESCRIPTION
```
$ caib status
Server  https://ado-build-api-automotive-dev-operator-system.apps.openshiftapps.com
Source  saved config (~/.config/caib/cli.json)
Status  reachable
```
## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [X] Tested on OpenShift cluster (if applicable)
