### PR TITLE
caib: support source_glob

### DIFF
--- a/cmd/caib/buildcmd/build.go
+++ b/cmd/caib/buildcmd/build.go
@@ -447,6 +447,13 @@ func (h *Handler) RunBuild(cmd *cobra.Command, args []string) {
 		return
 	}
 
+	localRefs, refsErr := common.FindLocalFileReferences(string(manifestBytes), filepath.Dir(manifestPath))
+	if refsErr != nil {
+		h.handleError(fmt.Errorf("manifest file reference error: %w", refsErr))
+		return
+	}
+	req.HasLocalFiles = len(localRefs) > 0
+
 	resp, err := api.CreateBuild(ctx, req)
 	if err != nil {
 		h.handleError(err)
@@ -455,11 +462,6 @@ func (h *Handler) RunBuild(cmd *cobra.Command, args []string) {
 	fmt.Printf("Build %s accepted: %s - %s\n", resp.Name, resp.Phase, resp.Message)
 	h.displayBuildLogsCommand(resp.Name)
 
-	localRefs, refsErr := common.FindLocalFileReferences(string(manifestBytes))
-	if refsErr != nil {
-		h.handleError(fmt.Errorf("manifest file reference error: %w", refsErr))
-		return
-	}
 	if len(localRefs) > 0 {
 		if err := h.handleFileUploads(ctx, api, resp.Name, localRefs); err != nil {
 			h.handleError(err)
@@ -680,6 +682,13 @@ func (h *Handler) RunBuildDev(cmd *cobra.Command, args []string) {
 		return
 	}
 
+	localRefs, refsErr := common.FindLocalFileReferences(string(manifestBytes), filepath.Dir(manifestPath))
+	if refsErr != nil {
+		h.handleError(fmt.Errorf("manifest file reference error: %w", refsErr))
+		return
+	}
+	req.HasLocalFiles = len(localRefs) > 0
+
 	resp, err := api.CreateBuild(ctx, req)
 	if err != nil {
 		h.handleError(err)
@@ -688,11 +697,6 @@ func (h *Handler) RunBuildDev(cmd *cobra.Command, args []string) {
 	fmt.Printf("Build %s accepted: %s - %s\n", resp.Name, resp.Phase, resp.Message)
 	h.displayBuildLogsCommand(resp.Name)
 
-	localRefs, refsErr := common.FindLocalFileReferences(string(manifestBytes))
-	if refsErr != nil {
-		h.handleError(fmt.Errorf("manifest file reference error: %w", refsErr))
-		return
-	}
 	if len(localRefs) > 0 {
 		if err := h.handleFileUploads(ctx, api, resp.Name, localRefs); err != nil {
 			h.handleError(err)

--- a/cmd/caib/common/manifest_artifact_helpers.go
+++ b/cmd/caib/common/manifest_artifact_helpers.go
@@ -11,8 +11,12 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// FindLocalFileReferences extracts manifest add_files source_path references.
-func FindLocalFileReferences(manifestContent string) ([]map[string]string, error) {
+// FindLocalFileReferences extracts manifest add_files source_path and
+// source_glob references. Glob patterns are expanded locally and each
+// matched file is returned as a separate source_path entry.
+// manifestDir is the directory containing the manifest, used to resolve
+// relative glob patterns.
+func FindLocalFileReferences(manifestContent string, manifestDir string) ([]map[string]string, error) {
 	var manifestData map[string]any
 	var localFiles []map[string]string
 
@@ -54,18 +58,39 @@ func FindLocalFileReferences(manifestContent string) ([]map[string]string, error
 
 	processAddFiles := func(addFiles []any) error {
 		for _, file := range addFiles {
-			if fileMap, ok := file.(map[string]any); ok {
-				path, hasPath := fileMap["path"].(string)
-				sourcePath, hasSourcePath := fileMap["source_path"].(string)
-				if hasPath && hasSourcePath {
-					if err := isPathSafe(sourcePath); err != nil {
+			fileMap, ok := file.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			// Handle source_glob entries
+			if sourceGlob, hasGlob := fileMap["source_glob"].(string); hasGlob {
+				matches, err := expandSourceGlob(sourceGlob, manifestDir)
+				if err != nil {
+					return err
+				}
+				for _, m := range matches {
+					if err := isPathSafe(m); err != nil {
 						return err
 					}
 					localFiles = append(localFiles, map[string]string{
-						"path":        path,
-						"source_path": sourcePath,
+						"source_path": m,
 					})
 				}
+				continue
+			}
+
+			// Handle source_path entries
+			path, hasPath := fileMap["path"].(string)
+			sourcePath, hasSourcePath := fileMap["source_path"].(string)
+			if hasPath && hasSourcePath {
+				if err := isPathSafe(sourcePath); err != nil {
+					return err
+				}
+				localFiles = append(localFiles, map[string]string{
+					"path":        path,
+					"source_path": sourcePath,
+				})
 			}
 		}
 		return nil
@@ -89,6 +114,138 @@ func FindLocalFileReferences(manifestContent string) ([]map[string]string, error
 	}
 
 	return localFiles, nil
+}
+
+// expandSourceGlob expands a glob pattern relative to manifestDir and returns
+// the matched file paths (relative to manifestDir if the pattern was relative).
+// Supports ** for recursive directory matching (e.g. "dir/**/*.yaml").
+func expandSourceGlob(pattern string, manifestDir string) ([]string, error) {
+	isAbs := filepath.IsAbs(pattern)
+
+	// Resolve the glob pattern relative to the manifest directory
+	var fullPattern string
+	if isAbs {
+		fullPattern = pattern
+	} else {
+		fullPattern = filepath.Join(manifestDir, pattern)
+	}
+
+	// Use recursive walk for ** patterns since filepath.Glob doesn't support **
+	var matches []string
+	if strings.Contains(fullPattern, "**") {
+		var err error
+		matches, err = expandDoubleStarGlob(fullPattern)
+		if err != nil {
+			return nil, fmt.Errorf("error expanding glob %q: %w", pattern, err)
+		}
+	} else {
+		var err error
+		matches, err = filepath.Glob(fullPattern)
+		if err != nil {
+			return nil, fmt.Errorf("invalid glob pattern %q: %w", pattern, err)
+		}
+		// filepath.Glob can return directories; filter to files only
+		matches = filterFiles(matches)
+	}
+
+	// Convert matches to the appropriate path form
+	var files []string
+	for _, m := range matches {
+		if isAbs {
+			files = append(files, m)
+		} else {
+			rel, err := filepath.Rel(manifestDir, m)
+			if err != nil {
+				return nil, fmt.Errorf("error computing relative path for %s: %w", m, err)
+			}
+			files = append(files, rel)
+		}
+	}
+
+	return files, nil
+}
+
+// filterFiles returns only regular files from a list of paths.
+func filterFiles(paths []string) []string {
+	files := make([]string, 0, len(paths))
+	for _, p := range paths {
+		info, err := os.Stat(p)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		files = append(files, p)
+	}
+	return files
+}
+
+// expandDoubleStarGlob handles glob patterns containing ** by walking the
+// directory tree. It splits the pattern at the first ** segment, walks the
+// base directory recursively, and matches remaining segments against each path.
+// If the prefix before ** contains wildcards, those are expanded first.
+func expandDoubleStarGlob(pattern string) ([]string, error) {
+	// e.g. "/tmp/dir/files/**/*.yaml" -> basePattern="/tmp/dir/files", tail="*.yaml"
+	parts := strings.SplitN(pattern, "**", 2)
+	basePattern := strings.TrimRight(parts[0], string(filepath.Separator))
+	if basePattern == "" {
+		basePattern = "."
+	}
+	tail := ""
+	if len(parts) > 1 {
+		tail = strings.TrimPrefix(parts[1], string(filepath.Separator))
+	}
+
+	// Expand the base if it contains wildcards (e.g. "images/*/**/*.rpm")
+	var bases []string
+	if strings.ContainsAny(basePattern, "*?[") {
+		expanded, err := filepath.Glob(basePattern)
+		if err != nil {
+			return nil, fmt.Errorf("invalid base pattern %q: %w", basePattern, err)
+		}
+		for _, b := range expanded {
+			info, statErr := os.Stat(b)
+			if statErr == nil && info.IsDir() {
+				bases = append(bases, b)
+			}
+		}
+	} else {
+		bases = []string{filepath.Clean(basePattern)}
+	}
+
+	var matches []string
+	for _, base := range bases {
+		err := filepath.WalkDir(base, func(path string, d os.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil
+			}
+
+			if tail == "" {
+				matches = append(matches, path)
+				return nil
+			}
+
+			rel, relErr := filepath.Rel(base, path)
+			if relErr != nil {
+				return nil
+			}
+
+			// Try matching tail against every suffix of the relative path so that
+			// patterns like **/deep/nested/*.yaml match a/b/deep/nested/f.yaml.
+			segments := strings.Split(rel, string(filepath.Separator))
+			for i := range segments {
+				suffix := filepath.Join(segments[i:]...)
+				if matched, _ := filepath.Match(tail, suffix); matched {
+					matches = append(matches, path)
+					return nil
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return matches, nil
 }
 
 func configuredSafeDirectories() []string {

--- a/cmd/caib/common/manifest_artifact_helpers_test.go
+++ b/cmd/caib/common/manifest_artifact_helpers_test.go
@@ -1,0 +1,445 @@
+package caibcommon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFindLocalFileReferences_SourcePath(t *testing.T) {
+	manifest := `
+content:
+  add_files:
+    - path: /usr/bin/app
+      source_path: app-binary
+    - path: /etc/config.yaml
+      source_path: configs/config.yaml
+`
+	refs, err := FindLocalFileReferences(manifest, "/tmp/manifest-dir")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(refs) != 2 {
+		t.Fatalf("expected 2 refs, got %d", len(refs))
+	}
+	if refs[0]["source_path"] != "app-binary" {
+		t.Errorf("expected source_path 'app-binary', got %q", refs[0]["source_path"])
+	}
+	if refs[1]["source_path"] != "configs/config.yaml" {
+		t.Errorf("expected source_path 'configs/config.yaml', got %q", refs[1]["source_path"])
+	}
+}
+
+func TestFindLocalFileReferences_QMSourcePath(t *testing.T) {
+	manifest := `
+qm:
+  content:
+    add_files:
+      - path: /etc/qm.conf
+        source_path: qm.conf
+`
+	refs, err := FindLocalFileReferences(manifest, "/tmp/manifest-dir")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("expected 1 ref, got %d", len(refs))
+	}
+	if refs[0]["source_path"] != "qm.conf" {
+		t.Errorf("expected source_path 'qm.conf', got %q", refs[0]["source_path"])
+	}
+}
+
+func TestFindLocalFileReferences_TextAndURL(t *testing.T) {
+	manifest := `
+content:
+  add_files:
+    - path: /etc/note.txt
+      text: "hello world"
+    - path: /etc/data.json
+      url: https://example.com/data.json
+`
+	refs, err := FindLocalFileReferences(manifest, "/tmp/manifest-dir")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(refs) != 0 {
+		t.Fatalf("expected 0 refs for text/url entries, got %d", len(refs))
+	}
+}
+
+func TestFindLocalFileReferences_SourceGlob(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create test files matching the glob
+	confDir := filepath.Join(dir, "conf")
+	if err := os.MkdirAll(confDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"a.yaml", "b.yaml", "c.txt"} {
+		if err := os.WriteFile(filepath.Join(confDir, name), []byte("test"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	manifest := `
+content:
+  add_files:
+    - path: /etc/configs
+      source_glob: "conf/*.yaml"
+`
+	refs, err := FindLocalFileReferences(manifest, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(refs) != 2 {
+		t.Fatalf("expected 2 refs (*.yaml), got %d: %v", len(refs), refs)
+	}
+
+	paths := map[string]bool{}
+	for _, ref := range refs {
+		paths[ref["source_path"]] = true
+	}
+	if !paths["conf/a.yaml"] {
+		t.Error("expected conf/a.yaml in results")
+	}
+	if !paths["conf/b.yaml"] {
+		t.Error("expected conf/b.yaml in results")
+	}
+	if paths["conf/c.txt"] {
+		t.Error("c.txt should not match *.yaml glob")
+	}
+}
+
+func TestFindLocalFileReferences_SourceGlobSkipsDirectories(t *testing.T) {
+	dir := t.TempDir()
+
+	confDir := filepath.Join(dir, "data")
+	if err := os.MkdirAll(filepath.Join(confDir, "subdir"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(confDir, "file.txt"), []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest := `
+content:
+  add_files:
+    - path: /etc/data
+      source_glob: "data/*"
+`
+	refs, err := FindLocalFileReferences(manifest, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should only match the file, not the subdirectory
+	if len(refs) != 1 {
+		t.Fatalf("expected 1 ref (file only, not dir), got %d: %v", len(refs), refs)
+	}
+	if refs[0]["source_path"] != "data/file.txt" {
+		t.Errorf("expected data/file.txt, got %q", refs[0]["source_path"])
+	}
+}
+
+func TestFindLocalFileReferences_SourceGlobNoMatches(t *testing.T) {
+	dir := t.TempDir()
+
+	manifest := `
+content:
+  add_files:
+    - path: /etc/configs
+      source_glob: "nonexistent/*.yaml"
+`
+	refs, err := FindLocalFileReferences(manifest, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// No matches is not an error — AIB handles allow_empty semantics
+	if len(refs) != 0 {
+		t.Fatalf("expected 0 refs for no-match glob, got %d", len(refs))
+	}
+}
+
+func TestFindLocalFileReferences_SourceGlobParentDir(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create files in parent directory relative to a subdir
+	if err := os.WriteFile(filepath.Join(dir, "root.conf"), []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	subdir := filepath.Join(dir, "manifests")
+	if err := os.MkdirAll(subdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest := `
+content:
+  add_files:
+    - path: /etc/configs
+      source_glob: "../*.conf"
+`
+	refs, err := FindLocalFileReferences(manifest, subdir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("expected 1 ref, got %d: %v", len(refs), refs)
+	}
+	if refs[0]["source_path"] != "../root.conf" {
+		t.Errorf("expected ../root.conf, got %q", refs[0]["source_path"])
+	}
+}
+
+func TestFindLocalFileReferences_MixedSourceTypes(t *testing.T) {
+	dir := t.TempDir()
+
+	confDir := filepath.Join(dir, "conf")
+	if err := os.MkdirAll(confDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(confDir, "app.conf"), []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest := `
+content:
+  add_files:
+    - path: /usr/bin/app
+      source_path: my-binary
+    - path: /etc/configs
+      source_glob: "conf/*.conf"
+    - path: /etc/note.txt
+      text: "hello"
+    - path: /etc/data.json
+      url: https://example.com/data.json
+`
+	refs, err := FindLocalFileReferences(manifest, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// source_path (1) + glob match (1) = 2 refs; text and url are skipped
+	if len(refs) != 2 {
+		t.Fatalf("expected 2 refs, got %d: %v", len(refs), refs)
+	}
+	paths := map[string]bool{}
+	for _, ref := range refs {
+		paths[ref["source_path"]] = true
+	}
+	if !paths["my-binary"] {
+		t.Errorf("expected my-binary in results, got %v", refs)
+	}
+	if !paths["conf/app.conf"] {
+		t.Errorf("expected conf/app.conf in results, got %v", refs)
+	}
+}
+
+func TestFindLocalFileReferences_QMSourceGlob(t *testing.T) {
+	dir := t.TempDir()
+
+	qmDir := filepath.Join(dir, "qm-files")
+	if err := os.MkdirAll(qmDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(qmDir, "policy.conf"), []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest := `
+qm:
+  content:
+    add_files:
+      - path: /etc/qm
+        source_glob: "qm-files/*.conf"
+`
+	refs, err := FindLocalFileReferences(manifest, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("expected 1 ref, got %d", len(refs))
+	}
+	if refs[0]["source_path"] != "qm-files/policy.conf" {
+		t.Errorf("expected qm-files/policy.conf, got %q", refs[0]["source_path"])
+	}
+}
+
+func TestFindLocalFileReferences_RecursiveGlob(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a nested directory structure mimicking the CES2026 manifest
+	for _, path := range []string{
+		"files/root_fs/etc/lighttpd/lighttpd.conf",
+		"files/root_fs/etc/lighttpd/conf.d/cgi.conf",
+		"files/root_fs/etc/chrony.conf",
+		"files/root_fs/usr/share/lighttpd/index.html",
+		"files/root_fs/usr/share/lighttpd/css/styles.css",
+		"files/root_fs/usr/lib/tmpfiles.d/lighttpd-webroot.conf",
+	} {
+		full := filepath.Join(dir, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte("test"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	manifest := `
+content:
+  add_files:
+    - source_glob: "files/root_fs/etc/**/*"
+      path: /etc/
+      preserve_path: true
+    - source_glob: "files/root_fs/usr/**/*"
+      path: /usr/
+      preserve_path: true
+`
+	refs, err := FindLocalFileReferences(manifest, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// etc: lighttpd.conf, conf.d/cgi.conf, chrony.conf = 3
+	// usr: index.html, css/styles.css, tmpfiles.d/lighttpd-webroot.conf = 3
+	if len(refs) != 6 {
+		t.Fatalf("expected 6 refs from recursive glob, got %d:", len(refs))
+	}
+
+	paths := map[string]bool{}
+	for _, ref := range refs {
+		paths[ref["source_path"]] = true
+	}
+	for _, expected := range []string{
+		"files/root_fs/etc/lighttpd/lighttpd.conf",
+		"files/root_fs/etc/lighttpd/conf.d/cgi.conf",
+		"files/root_fs/etc/chrony.conf",
+		"files/root_fs/usr/share/lighttpd/index.html",
+		"files/root_fs/usr/share/lighttpd/css/styles.css",
+		"files/root_fs/usr/lib/tmpfiles.d/lighttpd-webroot.conf",
+	} {
+		if !paths[expected] {
+			t.Errorf("expected %q in results, got: %v", expected, paths)
+		}
+	}
+}
+
+func TestExpandSourceGlob_DoubleStarAllFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create nested structure
+	for _, path := range []string{
+		"a.txt",
+		"sub/b.txt",
+		"sub/deep/c.txt",
+	} {
+		full := filepath.Join(dir, "data", path)
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte("test"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	files, err := expandSourceGlob("data/**/*", dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(files) != 3 {
+		t.Fatalf("expected 3 files from **/* glob, got %d: %v", len(files), files)
+	}
+}
+
+func TestExpandSourceGlob_DoubleStarWithExtension(t *testing.T) {
+	dir := t.TempDir()
+
+	for _, path := range []string{
+		"a.yaml",
+		"a.txt",
+		"sub/b.yaml",
+		"sub/b.txt",
+	} {
+		full := filepath.Join(dir, "conf", path)
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte("test"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	files, err := expandSourceGlob("conf/**/*.yaml", dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("expected 2 .yaml files, got %d: %v", len(files), files)
+	}
+}
+
+func TestExpandSourceGlob_DoubleStarNestedSubdir(t *testing.T) {
+	dir := t.TempDir()
+
+	for _, path := range []string{
+		"a/b/nested/file.yaml",
+		"nested/other.yaml",
+		"top.yaml",
+	} {
+		full := filepath.Join(dir, "src", path)
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte("test"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Pattern **/nested/*.yaml should match files inside any "nested" dir
+	files, err := expandSourceGlob("src/**/nested/*.yaml", dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("expected 2 files matching **/nested/*.yaml, got %d: %v", len(files), files)
+	}
+
+	paths := map[string]bool{}
+	for _, f := range files {
+		paths[f] = true
+	}
+	if !paths["src/a/b/nested/file.yaml"] {
+		t.Error("expected src/a/b/nested/file.yaml")
+	}
+	if !paths["src/nested/other.yaml"] {
+		t.Error("expected src/nested/other.yaml")
+	}
+	if paths["src/top.yaml"] {
+		t.Error("src/top.yaml should not match **/nested/*.yaml")
+	}
+}
+
+func TestExpandSourceGlob_InvalidPattern(t *testing.T) {
+	_, err := expandSourceGlob("[invalid", t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for invalid glob pattern")
+	}
+}
+
+func TestExpandSourceGlob_AbsolutePattern(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "abs.txt"), []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	pattern := filepath.Join(dir, "*.txt")
+	files, err := expandSourceGlob(pattern, "/some/other/dir")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+	if !filepath.IsAbs(files[0]) {
+		t.Errorf("expected absolute path for absolute pattern, got %q", files[0])
+	}
+}

--- a/internal/buildapi/server.go
+++ b/internal/buildapi/server.go
@@ -1943,7 +1943,7 @@ func (a *APIServer) createBuild(c *gin.Context) {
 		return
 	}
 
-	needsUpload := strings.Contains(req.Manifest, "source_path")
+	needsUpload := req.HasLocalFiles || manifestNeedsUpload(req.Manifest)
 
 	if err := validateBuildRequest(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -2339,20 +2339,7 @@ func getBuildTemplate(c *gin.Context, name string) {
 		manifestFileName = "manifest.aib.yml"
 	}
 
-	var sourceFiles []string
-	for _, line := range strings.Split(manifest, "\n") {
-		s := strings.TrimSpace(line)
-		if strings.HasPrefix(s, "source:") || strings.HasPrefix(s, "source_path:") {
-			parts := strings.SplitN(s, ":", 2)
-			if len(parts) == 2 {
-				p := strings.TrimSpace(parts[1])
-				p = strings.Trim(p, "'\"")
-				if p != "" && !strings.HasPrefix(p, "/") && !strings.HasPrefix(p, "http") {
-					sourceFiles = append(sourceFiles, p)
-				}
-			}
-		}
-	}
+	sourceFiles := extractManifestSourceFiles(manifest)
 
 	writeJSON(c, http.StatusOK, BuildTemplateResponse{
 		BuildRequest: BuildRequest{
@@ -2371,6 +2358,67 @@ func getBuildTemplate(c *gin.Context, name string) {
 		},
 		SourceFiles: sourceFiles,
 	})
+}
+
+// manifestAddFile represents a single add_files entry from an AIB manifest.
+type manifestAddFile struct {
+	SourcePath string `yaml:"source_path"`
+	SourceGlob string `yaml:"source_glob"`
+	Source     string `yaml:"source"`
+}
+
+// manifestContent represents the content section of an AIB manifest.
+type manifestContent struct {
+	AddFiles []manifestAddFile `yaml:"add_files"`
+}
+
+// manifestSchema is a minimal schema for parsing add_files from AIB manifests.
+type manifestSchema struct {
+	Content manifestContent `yaml:"content"`
+	QM      struct {
+		Content manifestContent `yaml:"content"`
+	} `yaml:"qm"`
+}
+
+// manifestNeedsUpload parses the manifest YAML and returns true if any
+// add_files entry references local files via source_path.
+// Note: source_glob is intentionally excluded — only the client can determine
+// whether a glob expands to actual files. This fallback exists for backward
+// compatibility with older clients that don't send HasLocalFiles.
+func manifestNeedsUpload(manifest string) bool {
+	var m manifestSchema
+	if err := yaml.Unmarshal([]byte(manifest), &m); err != nil {
+		log.Printf("warning: failed to parse manifest for upload detection: %v", err)
+		return false
+	}
+	for _, sections := range [][]manifestAddFile{m.Content.AddFiles, m.QM.Content.AddFiles} {
+		for _, f := range sections {
+			if f.SourcePath != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// extractManifestSourceFiles parses the manifest YAML and returns the list of
+// relative, non-HTTP source references (source, source_path, source_glob).
+func extractManifestSourceFiles(manifest string) []string {
+	var m manifestSchema
+	if err := yaml.Unmarshal([]byte(manifest), &m); err != nil {
+		return nil
+	}
+	var files []string
+	for _, sections := range [][]manifestAddFile{m.Content.AddFiles, m.QM.Content.AddFiles} {
+		for _, f := range sections {
+			for _, p := range []string{f.Source, f.SourcePath, f.SourceGlob} {
+				if p != "" && !strings.HasPrefix(p, "/") && !strings.HasPrefix(p, "http") {
+					files = append(files, p)
+				}
+			}
+		}
+	}
+	return files
 }
 
 // uploadContext holds the context needed for file upload operations.

--- a/internal/buildapi/types.go
+++ b/internal/buildapi/types.go
@@ -134,6 +134,7 @@ type BuildRequest struct {
 	ExportOCI      string `json:"exportOci,omitempty"`      // Registry URL to push disk as OCI artifact
 	BuilderImage   string `json:"builderImage,omitempty"`   // Custom builder image
 	RebuildBuilder bool   `json:"rebuildBuilder,omitempty"` // Force rebuild of bootc builder image
+	HasLocalFiles  bool   `json:"hasLocalFiles,omitempty"`  // Client has local files to upload (source_path/source_glob)
 
 	// Internal registry push configuration
 	UseInternalRegistry       bool   `json:"useInternalRegistry,omitempty"`       // Push to OpenShift internal registry

--- a/internal/common/tasks/scripts/find_manifest.sh
+++ b/internal/common/tasks/scripts/find_manifest.sh
@@ -39,31 +39,33 @@ fi
 
 cat "$workspace_manifest" > "$workspace_manifest.tmp"
 
-if yq eval '.content.add_files' "$workspace_manifest.tmp" | grep -q '^[^#]'; then
-  indices=$(yq eval '.content.add_files | to_entries | .[] | select(.value.source != null and .value.text == null) | .key' "$workspace_manifest.tmp")
+# rewrite_add_files_paths rewrites relative source/source_path/source_glob
+# values in add_files to absolute /manifest-work/ paths.
+# Usage: rewrite_add_files_paths <yq_prefix>
+#   e.g. rewrite_add_files_paths ".content.add_files"
+rewrite_add_files_paths() {
+  prefix="$1"
+  yq eval "$prefix" "$workspace_manifest.tmp" | grep -q '^[^#]' || return 0
 
-  for idx in $indices; do
-    yq eval -i ".content.add_files[$idx].source_path = \"/manifest-work/\" + (.content.add_files[$idx].source // \"\")" "$workspace_manifest.tmp"
+  # source -> source_path (legacy field)
+  for idx in $(yq eval "$prefix | to_entries | .[] | select(.value.source != null and .value.text == null) | .key" "$workspace_manifest.tmp"); do
+    yq eval -i "${prefix}[$idx].source_path = \"/manifest-work/\" + (${prefix}[$idx].source // \"\")" "$workspace_manifest.tmp"
   done
 
-  sp_indices=$(yq eval '.content.add_files | to_entries | .[] | select(.value.source_path != null and (.value.source_path | test("^/") | not) and .value.text == null) | .key' "$workspace_manifest.tmp")
-  for idx in $sp_indices; do
-    yq eval -i ".content.add_files[$idx].source_path = \"/manifest-work/\" + (.content.add_files[$idx].source_path // \"\")" "$workspace_manifest.tmp"
-  done
-fi
-
-if yq eval '.qm.content.add_files' "$workspace_manifest.tmp" | grep -q '^[^#]'; then
-  indices=$(yq eval '.qm.content.add_files | to_entries | .[] | select(.value.source != null and .value.text == null) | .key' "$workspace_manifest.tmp")
-
-  for idx in $indices; do
-    yq eval -i ".qm.content.add_files[$idx].source_path = \"/manifest-work/\" + (.qm.content.add_files[$idx].source // \"\")" "$workspace_manifest.tmp"
+  # source_path (relative only)
+  for idx in $(yq eval "$prefix | to_entries | .[] | select(.value.source_path != null and (.value.source_path | test(\"^/\") | not) and .value.text == null) | .key" "$workspace_manifest.tmp"); do
+    yq eval -i "${prefix}[$idx].source_path = \"/manifest-work/\" + (${prefix}[$idx].source_path // \"\")" "$workspace_manifest.tmp"
   done
 
-  sp_indices=$(yq eval '.qm.content.add_files | to_entries | .[] | select(.value.source_path != null and (.value.source_path | test("^/") | not) and .value.text == null) | .key' "$workspace_manifest.tmp")
-  for idx in $sp_indices; do
-    yq eval -i ".qm.content.add_files[$idx].source_path = \"/manifest-work/\" + (.qm.content.add_files[$idx].source_path // \"\")" "$workspace_manifest.tmp"
-  done
-fi
+  # source_glob: do NOT rewrite to absolute paths.
+  # AIB's absolute glob handler strips one extra directory component via
+  # dirname(), which breaks preserve_path (e.g. /etc/etc/ instead of /etc/).
+  # Since files are already copied into /manifest-work/ and the manifest lives
+  # there too, relative globs resolve correctly without rewriting.
+}
+
+rewrite_add_files_paths ".content.add_files"
+rewrite_add_files_paths ".qm.content.add_files"
 
 # Replace original with processed file
 mv "$workspace_manifest.tmp" "$workspace_manifest"


### PR DESCRIPTION
Support uploads with source_glob


## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] Manifests are up to date (`make manifests generate`)
- [x] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for glob patterns in manifests so multiple files can be referenced with wildcards.

* **Improvements**
  * Relative paths are resolved against the manifest’s directory for more reliable handling.
  * Build requests now detect and mark presence of local files earlier so uploads are determined correctly.
  * Manifest preprocessing no longer rewrites glob entries to absolute paths.

* **Tests**
  * Added tests covering glob expansion, recursive ** patterns, matching rules, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->