### PR TITLE
caib: resolve --target default from manifest target field

### DIFF
--- a/cmd/caib/buildcmd/build.go
+++ b/cmd/caib/buildcmd/build.go
@@ -174,6 +174,21 @@ func (h *Handler) applyRegistryCredentialsToRequest(req *buildapitypes.BuildRequ
 	return nil
 }
 
+// resolveTarget determines the build target: --target flag > manifest value > "qemu".
+func (h *Handler) resolveTarget(cmd *cobra.Command, manifestTarget string) {
+	if cmd.Flags().Changed("target") {
+		return
+	}
+
+	if manifestTarget != "" {
+		*h.opts.Target = manifestTarget
+		fmt.Printf("Using target %q from manifest\n", manifestTarget)
+		return
+	}
+
+	*h.opts.Target = "qemu"
+}
+
 // fetchTargetDefaults fetches the operator config once and returns it.
 // If flash is enabled, it also validates that the target has a Jumpstarter mapping.
 func (h *Handler) fetchTargetDefaults(
@@ -406,6 +421,8 @@ func (h *Handler) RunBuild(cmd *cobra.Command, args []string) {
 		return
 	}
 
+	h.resolveTarget(cmd, common.ManifestTarget(manifestBytes))
+
 	req := buildapitypes.BuildRequest{
 		Name:                   *h.opts.BuildName,
 		Manifest:               string(manifestBytes),
@@ -523,6 +540,8 @@ func (h *Handler) RunDisk(cmd *cobra.Command, args []string) {
 		return
 	}
 
+	h.resolveTarget(cmd, "") // no manifest for disk command
+
 	req := buildapitypes.BuildRequest{
 		Name:                   *h.opts.BuildName,
 		ContainerRef:           containerRef,
@@ -628,6 +647,8 @@ func (h *Handler) RunBuildDev(cmd *cobra.Command, args []string) {
 		h.handleError(fmt.Errorf("error reading manifest: %w", err))
 		return
 	}
+
+	h.resolveTarget(cmd, common.ManifestTarget(manifestBytes))
 
 	var parsedMode buildapitypes.Mode
 	switch *h.opts.Mode {

--- a/cmd/caib/common/manifest_artifact_helpers.go
+++ b/cmd/caib/common/manifest_artifact_helpers.go
@@ -11,6 +11,18 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// ManifestTarget extracts the top-level "target" field from a manifest YAML.
+// Returns empty string if the field is absent, blank, or the YAML is invalid.
+func ManifestTarget(manifest []byte) string {
+	var m struct {
+		Target string `yaml:"target"`
+	}
+	if err := yaml.Unmarshal(manifest, &m); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(m.Target)
+}
+
 // FindLocalFileReferences extracts manifest add_files source_path and
 // source_glob references. Glob patterns are expanded locally and each
 // matched file is returned as a separate source_path entry.

--- a/cmd/caib/common/manifest_artifact_helpers_test.go
+++ b/cmd/caib/common/manifest_artifact_helpers_test.go
@@ -6,6 +6,58 @@ import (
 	"testing"
 )
 
+func TestManifestTarget(t *testing.T) {
+	tests := []struct {
+		name     string
+		manifest string
+		want     string
+	}{
+		{
+			name:     "target present",
+			manifest: "name: my-image\ntarget: j784s4evm\n",
+			want:     "j784s4evm",
+		},
+		{
+			name:     "target absent",
+			manifest: "name: my-image\n",
+			want:     "",
+		},
+		{
+			name:     "empty manifest",
+			manifest: "",
+			want:     "",
+		},
+		{
+			name:     "invalid yaml",
+			manifest: ": : :\n",
+			want:     "",
+		},
+		{
+			name:     "target is empty string",
+			manifest: "name: my-image\ntarget: \"\"\n",
+			want:     "",
+		},
+		{
+			name:     "target is whitespace only",
+			manifest: "name: my-image\ntarget: \"  \"\n",
+			want:     "",
+		},
+		{
+			name:     "target with surrounding whitespace",
+			manifest: "name: my-image\ntarget: \" qemu \"\n",
+			want:     "qemu",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ManifestTarget([]byte(tt.manifest))
+			if got != tt.want {
+				t.Errorf("ManifestTarget() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFindLocalFileReferences_SourcePath(t *testing.T) {
 	manifest := `
 content:

--- a/cmd/caib/image/image.go
+++ b/cmd/caib/image/image.go
@@ -116,7 +116,7 @@ func NewImageCmd(opts Options) *cobra.Command {
 	buildCmd.Flags().StringVar(opts.AuthToken, "token", os.Getenv("CAIB_TOKEN"), "Bearer token for authentication")
 	buildCmd.Flags().StringVarP(opts.BuildName, "name", "n", "", "name for the ImageBuild (auto-generated if omitted)")
 	buildCmd.Flags().StringVarP(opts.Distro, "distro", "d", "autosd", "distribution to build")
-	buildCmd.Flags().StringVarP(opts.Target, "target", "t", "qemu", "target platform")
+	buildCmd.Flags().StringVarP(opts.Target, "target", "t", "", "target platform (default: from manifest, or qemu)")
 	buildCmd.Flags().StringVarP(opts.Architecture, "arch", "a", opts.GetDefaultArch(), "architecture (amd64, arm64)")
 	buildCmd.Flags().StringVar(opts.ContainerPush, "push", "", "push bootc container to registry (optional if --disk is used)")
 	buildCmd.Flags().BoolVar(opts.BuildDiskImage, "disk", false, "also build disk image from container")
@@ -191,7 +191,7 @@ func NewImageCmd(opts Options) *cobra.Command {
 		"path to Docker/Podman auth file for push authentication (takes precedence over env vars and auto-discovery)",
 	)
 	diskCmd.Flags().StringVarP(opts.Distro, "distro", "d", "autosd", "distribution")
-	diskCmd.Flags().StringVarP(opts.Target, "target", "t", "qemu", "target platform")
+	diskCmd.Flags().StringVarP(opts.Target, "target", "t", "", "target platform (default: qemu)")
 	diskCmd.Flags().StringVarP(opts.Architecture, "arch", "a", opts.GetDefaultArch(), "architecture (amd64, arm64)")
 	diskCmd.Flags().StringVar(
 		opts.AutomotiveImageBuilder, "aib-image",
@@ -219,7 +219,7 @@ func NewImageCmd(opts Options) *cobra.Command {
 	buildDevCmd.Flags().StringVar(opts.AuthToken, "token", os.Getenv("CAIB_TOKEN"), "Bearer token for authentication")
 	buildDevCmd.Flags().StringVarP(opts.BuildName, "name", "n", "", "name for the ImageBuild")
 	buildDevCmd.Flags().StringVarP(opts.Distro, "distro", "d", "autosd", "distribution to build")
-	buildDevCmd.Flags().StringVarP(opts.Target, "target", "t", "qemu", "target platform")
+	buildDevCmd.Flags().StringVarP(opts.Target, "target", "t", "", "target platform (default: from manifest, or qemu)")
 	buildDevCmd.Flags().StringVarP(opts.Architecture, "arch", "a", opts.GetDefaultArch(), "architecture (amd64, arm64)")
 	buildDevCmd.Flags().StringVar(opts.Mode, "mode", "package", "build mode: image (ostree) or package (package-based)")
 	buildDevCmd.Flags().StringVar(opts.ExportFormat, "format", "", "export format: qcow2, raw, simg, etc.")


### PR DESCRIPTION
When --target is omitted, caib now reads the target field from the AIB manifest YAML. Explicit --target overrides the manifest value, and qemu remains the fallback when neither provides a target.
## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [X] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Target image type can now be specified in the manifest file. The precedence is: explicit `--target` flag → manifest-defined target → default to `qemu`.

* **Tests**
  * Added test coverage for extracting target values from manifest files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->