### PR TITLE
fix: add oci:// prefix to default flash command and preserve flashCmd

### DIFF
--- a/internal/buildapi/flash_helpers.go
+++ b/internal/buildapi/flash_helpers.go
@@ -25,9 +25,11 @@ type httpError struct {
 func resolveFlashTargetConfig(req FlashRequest, operatorConfig *automotivev1alpha1.OperatorConfig) (string, string) {
 	exporterSelector := req.ExporterSelector
 	flashCmd := req.FlashCmd
-	if req.Target != "" && exporterSelector == "" && operatorConfig.Spec.Jumpstarter != nil {
+	if req.Target != "" && operatorConfig.Spec.Jumpstarter != nil {
 		if mapping, ok := operatorConfig.Spec.Jumpstarter.TargetMappings[req.Target]; ok {
-			exporterSelector = mapping.Selector
+			if exporterSelector == "" {
+				exporterSelector = mapping.Selector
+			}
 			if flashCmd == "" {
 				flashCmd = mapping.FlashCmd
 			}

--- a/internal/common/tasks/scripts/flash_image.sh
+++ b/internal/common/tasks/scripts/flash_image.sh
@@ -19,7 +19,7 @@ echo "Using client config: ${JMP_CLIENT_CONFIG}"
 echo "refreshing jumpstarter token"
 jmp login --client-config "${JMP_CLIENT_CONFIG}"
 
-FLASH_CMD="${FLASH_CMD:-j storage flash \{image_uri\}}"
+FLASH_CMD="${FLASH_CMD:-j storage flash oci://{image_uri}}"
 FLASH_CMD=$(echo "${FLASH_CMD}" | sed "s|{image_uri}|${IMAGE_REF}|g")
 
 

--- a/internal/common/tasks/tasks.go
+++ b/internal/common/tasks/tasks.go
@@ -844,7 +844,7 @@ func GenerateTektonPipeline(name, namespace string, buildConfig *BuildConfig) *t
 				{
 					Name:        "flash-cmd",
 					Type:        tektonv1.ParamTypeString,
-					Description: "Custom flash command (default: j storage flash ${IMAGE_REF})",
+					Description: "Custom flash command (default: j storage flash oci://{image_uri})",
 					Default: &tektonv1.ParamValue{
 						Type:      tektonv1.ParamTypeString,
 						StringVal: "",
@@ -1546,7 +1546,7 @@ func GenerateFlashTask(namespace string, buildConfig *BuildConfig) *tektonv1.Tas
 				{
 					Name:        "flash-cmd",
 					Type:        tektonv1.ParamTypeString,
-					Description: "Command to run for flashing (default: j storage flash ${IMAGE_REF})",
+					Description: "Command to run for flashing (default: j storage flash oci://{image_uri})",
 					Default: &tektonv1.ParamValue{
 						Type:      tektonv1.ParamTypeString,
 						StringVal: "",

--- a/internal/controller/imagebuild/controller.go
+++ b/internal/controller/imagebuild/controller.go
@@ -692,21 +692,21 @@ func (r *ImageBuildReconciler) createBuildTaskRun(
 	// Add flash params if flash is enabled
 	var flashExporterSelector, flashCmd, flashOCIAuthSecretName string
 	if imageBuild.Spec.IsFlashEnabled() {
-		// User-specified exporter selector bypasses target lookup entirely
 		flashExporterSelector = imageBuild.Spec.GetFlashExporterSelector()
-		if flashExporterSelector == "" {
-			target := imageBuild.Spec.GetTarget()
-			if operatorConfig.Spec.Jumpstarter != nil {
-				if mapping, ok := operatorConfig.Spec.Jumpstarter.TargetMappings[target]; ok {
+		target := imageBuild.Spec.GetTarget()
+		// Look up target mapping for selector (if not overridden) and flash command
+		if operatorConfig.Spec.Jumpstarter != nil {
+			if mapping, ok := operatorConfig.Spec.Jumpstarter.TargetMappings[target]; ok {
+				if flashExporterSelector == "" {
 					flashExporterSelector = mapping.Selector
-					flashCmd = mapping.FlashCmd
 				}
+				flashCmd = mapping.FlashCmd
 			}
-			if flashExporterSelector == "" {
-				return fmt.Errorf("flash enabled but no Jumpstarter target mapping found for target %q; "+
-					"configure OperatorConfig.spec.jumpstarter.targetMappings[%q] with selector and flashCmd, "+
-					"or set flash.exporterSelector directly", target, target)
-			}
+		}
+		if flashExporterSelector == "" {
+			return fmt.Errorf("flash enabled but no Jumpstarter target mapping found for target %q; "+
+				"configure OperatorConfig.spec.jumpstarter.targetMappings[%q] with selector and flashCmd, "+
+				"or set flash.exporterSelector directly", target, target)
 		}
 		// User-specified flash command overrides OperatorConfig
 		if userCmd := imageBuild.Spec.GetFlashCmd(); userCmd != "" {


### PR DESCRIPTION
The default flash command was missing the oci:// scheme prefix

Additionally, passing --exporter to override the exporter selector was skipping the entire target mapping lookup, silently dropping the configured flashCmd (and its flags like --fls-version, --no-power-off). Now --exporter only overrides the selector while still inheriting flashCmd from the target mapping.

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Flash operations now default to using the oci:// URI scheme for image references when no custom flash command is provided, ensuring consistent image addressing.
  * Target mapping resolution for flash tasks has been made more reliable: mappings that provide flash commands are consulted more broadly, and explicit exporter selector values are preserved unless absent, reducing unexpected overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->