### PR TITLE
fix: reconfigure local e2e suite for CRC OpenShift compatibility

### DIFF
--- a/hack/crc/01-prep-host.sh
+++ b/hack/crc/01-prep-host.sh
@@ -22,6 +22,7 @@ set -euo pipefail
 CRC_PRESET="openshift"          # [ openshift | microshift | okd ]
 CRC_VERSION="${CRC_VERSION:-2.58.0}"
 CRC_BASE_URL="https://mirror.openshift.com/pub/openshift-v4/clients/crc/${CRC_VERSION}"
+CRC_API_URL="https://api.crc.testing:6443"
 TELEMETRY="no"
 PULL_SECRET="${PULL_SECRET:-${1:-pull-secret.txt}}"
 CRC_CUSTOM_ARGS="${CRC_CUSTOM_ARGS:---cpus 4 --memory 12288 --disk-size 50}"
@@ -371,6 +372,6 @@ echo "  Useful commands:"
 echo "    crc console                # open the web console URL"
 echo "    crc console --credentials  # show kubeadmin password"
 echo "    eval \$(crc oc-env)         # configure oc CLI"
-echo "    oc login -u kubeadmin -p \$(crc console --credentials | grep kubeadmin | awk -F\"'\" '{print \$2}') https://api.crc.testing:6443"
+echo "    oc login -u kubeadmin -p \$(crc console --credentials | grep kubeadmin | awk -F\"'\" '{print \$2}') $CRC_API_URL"
 echo ""
 line

--- a/hack/crc/02-deploy-operator.sh
+++ b/hack/crc/02-deploy-operator.sh
@@ -17,6 +17,7 @@ set -euo pipefail
 ###############################################################################
 NAMESPACE="automotive-dev-operator-system"
 IMAGE_NAME="automotive-dev-operator"
+CRC_API_URL="https://api.crc.testing:6443"
 
 OS="$(uname -s)"
 
@@ -77,7 +78,7 @@ export KUBECONFIG="$CRC_KUBECONFIG"
 
 KUBE_PASS=$(get_kubeadmin_pass)
 [[ -n "$KUBE_PASS" ]] || fail "Could not extract kubeadmin password from 'crc console --credentials'."
-oc login -u kubeadmin -p "$KUBE_PASS" https://api.crc.testing:6443 || fail "Failed to login to cluster."
+oc login -u kubeadmin -p "$KUBE_PASS" "$CRC_API_URL" || fail "Failed to login to cluster."
 ok "Logged in as kubeadmin (KUBECONFIG=$KUBECONFIG)."
 
 ###############################################################################

--- a/hack/crc/04-expose-default-registry.sh
+++ b/hack/crc/04-expose-default-registry.sh
@@ -6,18 +6,20 @@ set -euo pipefail
 # Works on both macOS (podman machine VM) and Linux (native podman).
 # Run this after CRC is ready and before deploy-catalog.sh.
 #
-# Linux:  sudo bash hack/crc/04-expose-default-registry.sh
+# Linux:  bash hack/crc/04-expose-default-registry.sh   (run as crcusr, NOT as root)
 # macOS:  bash hack/crc/04-expose-default-registry.sh
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; CYAN='\033[0;36m'; YELLOW='\033[1;33m'; NC='\033[0m'
+OS="$(uname -s)"
+CRC_API_URL="${CRC_API_URL:-https://api.crc.testing:6443}"
+CRC_USER_HOME="$HOME"
+
 info()  { echo -e "${CYAN}>>> $*${NC}"; }
 ok()    { echo -e "${GREEN}✓ $*${NC}"; }
 warn()  { echo -e "${YELLOW}⚠ $*${NC}"; }
 fail()  { echo -e "${RED}✗ $*${NC}"; exit 1; }
 
-OS="$(uname -s)"
 
-CRC_USER_HOME="$HOME"
 if [[ "$OS" == "Linux" && $EUID -eq 0 ]]; then
     CRC_USER="${CRC_USER:-${SUDO_USER:-}}"
     if [[ -n "$CRC_USER" ]]; then
@@ -85,8 +87,8 @@ ok "Registry host: $HOST"
 ###############################################################################
 # Extract ingress certificate
 ###############################################################################
-CERT_DIR="/tmp/registry-certs"
-mkdir -p "$CERT_DIR"
+CERT_DIR="$(mktemp -d -t registry-certs.XXXXXX)"
+trap 'rm -rf "$CERT_DIR"' EXIT
 
 CERT_SECRET="$(oc get ingresscontroller -n openshift-ingress-operator default -o jsonpath='{.spec.defaultCertificate.name}')"
 CERT_SECRET="${CERT_SECRET:-router-certs-default}"
@@ -173,7 +175,7 @@ if command -v podman >/dev/null 2>&1; then
             KUBE_PASS=$(run_as_user "crc console --credentials 2>/dev/null" | grep kubeadmin | sed "s/.*-p \([^ ]*\) .*/\1/" | head -1)
         fi
         [[ -n "$KUBE_PASS" ]] || fail "Cannot obtain kubeadmin password from 'crc console --credentials'."
-        oc login -u kubeadmin -p "$KUBE_PASS" "https://api.crc.testing:6443" --insecure-skip-tls-verify >/dev/null
+        oc login -u kubeadmin -p "$KUBE_PASS" "$CRC_API_URL" --insecure-skip-tls-verify >/dev/null
         OC_TOKEN="$(oc whoami -t)"
     fi
     SAFE_TOKEN=$(printf '%q' "$OC_TOKEN")

--- a/hack/crc/README.md
+++ b/hack/crc/README.md
@@ -54,11 +54,11 @@ This runs three phases:
 
 ### Step by step
 
-**Linux** (run as the CRC user, use `sudo` where indicated):
+**Linux** (run as the CRC user; some steps may prompt for `sudo` where indicated):
 ```bash
 sudo bash hack/crc/01-prep-host.sh /path/to/pull-secret.txt
-sudo bash hack/crc/04-expose-default-registry.sh
 eval "$(crc oc-env)" && export PATH=$PATH:/usr/local/go/bin
+bash hack/crc/04-expose-default-registry.sh        # may prompt for sudo on Linux to install certs and update /etc/hosts
 bash hack/crc/02-deploy-operator.sh
 bash hack/crc/03-crc-operator-sanity.sh            # validate
 bash hack/crc/03-crc-operator-sanity.sh --sanity   # + build test
@@ -82,7 +82,7 @@ bash hack/crc/03-crc-operator-sanity.sh
 | `01-prep-host.sh` | `sudo` (Linux) / user (macOS) | System prep, CRC install, `crc setup`, `crc start` |
 | `02-deploy-operator.sh` | non-root | Deploy operator via OLM catalog, configure OperatorConfig |
 | `03-crc-operator-sanity.sh` | non-root | Validate cluster, operator, Build API, Tekton. `--sanity` for build test |
-| `04-expose-default-registry.sh` | `sudo` (Linux) / user (macOS) | Expose internal registry via external route for podman push/pull |
+| `04-expose-default-registry.sh` | CRC user (Linux & macOS) | Expose internal registry via external route for podman push/pull. On Linux, it may prompt for `sudo` only to install the registry cert and update `/etc/hosts`. |
 | `crc-cleanup.sh` | `sudo` (Linux) / user (macOS) | Stop and delete CRC VM. `--full` removes binary, cache, sudoers |
 
 ### `01-prep-host.sh`
@@ -152,8 +152,7 @@ Use `--arch arm64` on Apple Silicon Macs, `--arch amd64` on Intel/Linux x86_64.
 
 **Step 1 -- Expose the external registry (one-time):**
 ```bash
-sudo bash hack/crc/04-expose-default-registry.sh     # Linux
-bash hack/crc/04-expose-default-registry.sh           # macOS
+bash hack/crc/04-expose-default-registry.sh     # Linux and macOS (may prompt for sudo on Linux to install certs and update /etc/hosts)
 ```
 
 **Step 2 -- Deploy:**
@@ -169,8 +168,7 @@ The internal registry (`image-registry.openshift-image-registry.svc:5000`) is on
 
 **Step 1 -- Expose the registry (one-time):**
 ```bash
-bash hack/crc/04-expose-default-registry.sh          # macOS
-sudo bash hack/crc/04-expose-default-registry.sh     # Linux
+bash hack/crc/04-expose-default-registry.sh     # Linux and macOS (may prompt for sudo on Linux to install certs and update /etc/hosts)
 ```
 
 **Step 2 -- Pull:**

--- a/hack/run-e2e-local.sh
+++ b/hack/run-e2e-local.sh
@@ -1,290 +1,187 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
-# Configuration
-CLUSTER_NAME="automotive-dev-e2e"
-REGISTRY_NAME="kind-registry"
-REGISTRY_PORT="5001"
+CRC_API_URL="https://api.crc.testing:6443"
 REGISTRY_HOST="image-registry.openshift-image-registry.svc"
-KIND_NETWORK="kind"
-TEKTON_VERSION="v1.9.1"
-INGRESS_NGINX_VERSION="v1.14.3"
+CONTAINER_TOOL="${CONTAINER_TOOL:-podman}"
+REGISTRY_TLS_VERIFY="${REGISTRY_TLS_VERIFY:-false}"
+SCRIPT_PATH="$(realpath "$0")"
+REPO_ROOT="$(cd "$(dirname "$SCRIPT_PATH")/.." && pwd)"
 
-# Ownership flags: only tear down resources this invocation created
-CREATED_REGISTRY=false
-CREATED_HOSTS_ENTRY=false
-CREATED_REGISTRIES_CONF=false
-REGISTRIES_CONF_BACKUP=""
-
-# Diagnostics and Cleanup
-cleanup() {
-  local exit_code=$?
-  local CONF_FILE="${HOME}/.config/containers/registries.conf.d/kind-e2e-registry.conf"
-  if [ $exit_code -ne 0 ]; then
-    echo ""
-    echo "!!! Script exited/failed. Keeping cluster for debugging. !!!"
-    echo "To clean up, run:"
-    echo "  kind delete cluster --name $CLUSTER_NAME"
-    [ "$CREATED_REGISTRY" = "true" ] && echo "  docker rm -f $REGISTRY_NAME"
-    [ "$CREATED_HOSTS_ENTRY" = "true" ] && echo "  sudo sed -i '/${REGISTRY_HOST}/d' /etc/hosts"
-    [ "$CREATED_REGISTRIES_CONF" = "true" ] && echo "  rm -f $CONF_FILE"
-    [ -n "$REGISTRIES_CONF_BACKUP" ] && echo "  mv $REGISTRIES_CONF_BACKUP $CONF_FILE  # restore original"
-  else
-    echo ""
-    echo "Cleaning up..."
-    kind delete cluster --name "$CLUSTER_NAME"
-    [ "$CREATED_REGISTRY" = "true" ] && docker rm -f "$REGISTRY_NAME"
-    [ "$CREATED_HOSTS_ENTRY" = "true" ] && sudo sed -i "/${REGISTRY_HOST}/d" /etc/hosts 2>/dev/null || true
-    if [ "$CREATED_REGISTRIES_CONF" = "true" ]; then
-      rm -f "$CONF_FILE"
-    elif [ -n "$REGISTRIES_CONF_BACKUP" ]; then
-      mv "$REGISTRIES_CONF_BACKUP" "$CONF_FILE"
-    fi
-    echo "Cleanup complete."
-  fi
+info() {
+  printf '[INFO] %s\n' "$*"
 }
-trap cleanup EXIT
+
+fail() {
+  printf '[ERROR] %s\n' "$*" >&2
+  exit 1
+}
+
+get_kubeadmin_pass() {
+  local pass=""
+  local json=""
+
+  json="$(crc console --credentials -o json 2>/dev/null || true)"
+  if [[ -n "$json" ]]; then
+    pass="$(jq -r '.adminCredentials.password // empty' <<<"$json" 2>/dev/null || true)"
+  fi
+  if [[ -z "$pass" ]]; then
+    pass="$(crc console --credentials 2>/dev/null | sed -n 's/.*-p \([^ ]*\) .*/\1/p' | head -1)"
+  fi
+  printf '%s' "$pass"
+}
+
+ensure_crc_login() {
+  local server=""
+  local user=""
+  server="$(oc whoami --show-server 2>/dev/null || true)"
+  user="$(oc whoami 2>/dev/null || true)"
+  if [[ "$server" == "$CRC_API_URL" ]] && [[ "$user" == "kubeadmin" ]]; then
+    return
+  fi
+
+  local kube_pass
+  kube_pass="$(get_kubeadmin_pass)"
+  [[ -n "$kube_pass" ]] || fail "Could not determine kubeadmin password from CRC."
+
+  info "Logging into CRC as kubeadmin..."
+  oc login -u kubeadmin -p "$kube_pass" "$CRC_API_URL" --insecure-skip-tls-verify >/dev/null
+}
+
+ensure_tekton() {
+  local crds_ready=true
+  local crd
+
+  for crd in tasks.tekton.dev pipelines.tekton.dev pipelineruns.tekton.dev taskruns.tekton.dev; do
+    if ! oc get crd "$crd" >/dev/null 2>&1; then
+      crds_ready=false
+      break
+    fi
+  done
+
+  if [[ "$crds_ready" == "false" ]]; then
+    info "Installing OpenShift Pipelines subscription..."
+    cat <<EOF | oc apply -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-pipelines-operator-rh
+  namespace: openshift-operators
+spec:
+  channel: latest
+  name: openshift-pipelines-operator-rh
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+  fi
+
+  # Always verify the CSV is Succeeded — CRDs can exist while the operator
+  # is still rolling out or in a degraded state.
+  info "Waiting for OpenShift Pipelines CSV to be Succeeded..."
+  local csv_name=""
+  local csv_phase=""
+  local csv_snapshot=""
+  for _ in {1..90}; do
+    csv_name="$(oc get csv -n openshift-operators \
+      -o jsonpath='{range .items[?(@.status.phase=="Succeeded")]}{.metadata.name}{"\n"}{end}' 2>/dev/null \
+      | awk '/^openshift-pipelines-operator-rh/{print; exit}' || true)"
+    if [[ -n "$csv_name" ]]; then
+      csv_phase="Succeeded"
+      break
+    fi
+
+    csv_snapshot="$(oc get csv -n openshift-operators \
+      -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.phase}{"\n"}{end}' 2>/dev/null || true)"
+    csv_name="$(printf '%s\n' "$csv_snapshot" | awk -F'\t' '$1 ~ /^openshift-pipelines-operator-rh/ {print $1; exit}')"
+    csv_phase="$(printf '%s\n' "$csv_snapshot" | awk -F'\t' '$1 ~ /^openshift-pipelines-operator-rh/ {print $2; exit}')"
+    [[ "$csv_phase" == "Succeeded" ]] && break
+    sleep 10
+  done
+  [[ "$csv_phase" == "Succeeded" ]] || fail "OpenShift Pipelines CSV not ready (csv: ${csv_name:-unknown}, phase: ${csv_phase:-unknown})."
+  info "OpenShift Pipelines is ready."
+}
 
 set_build_platform() {
-  local host_arch
-  host_arch=$(uname -m)
-  case "$host_arch" in
-    x86_64)
-      export BUILD_PLATFORM=linux/amd64
-      export ARCH=amd64
-      ;;
-    arm64|aarch64)
-      export BUILD_PLATFORM=linux/arm64
-      export ARCH=arm64
+  local cluster_arch
+  cluster_arch="$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.architecture}')"
+
+  case "$cluster_arch" in
+    amd64|arm64)
+      export BUILD_PLATFORM="linux/${cluster_arch}"
+      export ARCH="${cluster_arch}"
       ;;
     *)
-      echo "Unsupported architecture: $host_arch (supported: x86_64, arm64, aarch64)"
-      exit 1
+      fail "Unsupported cluster architecture: ${cluster_arch}"
       ;;
   esac
 }
 
-echo "========================================="
-echo "   Initializing Local Dev Environment    "
-echo "========================================="
+printf '=========================================\n'
+printf '   Running local e2e on CRC/OpenShift    \n'
+printf '=========================================\n'
 
-for bin in docker kind kubectl jq make; do
-  command -v "$bin" >/dev/null 2>&1 || {
-    echo "Missing required dependency: $bin" >&2
-    exit 1
-  }
+# CRC machines are owned by the user who started them.
+# Running as root would use /root as HOME and miss ~/.crc_env / oc / kubeconfig.
+# If invoked via sudo, re-exec transparently as the original user.
+if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+  if [[ -n "${SUDO_USER:-}" ]]; then
+    info "Detected root via sudo. Re-executing as '${SUDO_USER}'..."
+    exec sudo -H -u "$SUDO_USER" bash -lc 'cd "$1" && shift && exec bash "$@"' bash "$REPO_ROOT" "$SCRIPT_PATH" "$@"
+  else
+    fail "Do not run this script as root. Run it directly as the CRC user, e.g.:
+      bash hack/run-e2e-local.sh"
+  fi
+fi
+
+cd "$REPO_ROOT"
+
+for bin in crc jq make "$CONTAINER_TOOL"; do
+  command -v "$bin" >/dev/null 2>&1 || fail "Missing required dependency: $bin"
 done
 
-# ------------------------------------------------------------------
-# [1/5] Ensure Local Registry Exists (Docker Container)
-# ------------------------------------------------------------------
-echo "[1/5] Setting up local registry..."
-verify_registry_ports() {
-  docker inspect -f '{{json .NetworkSettings.Ports}}' "${REGISTRY_NAME}" 2>/dev/null |
-    jq -e --arg rp "${REGISTRY_PORT}" '
-      (."5000/tcp" // []) |
-      (any(.[]; .HostIp == "127.0.0.1" and .HostPort == $rp)) and
-      (any(.[]; .HostIp == "127.0.0.1" and .HostPort == "5000"))
-    ' >/dev/null 2>&1
-}
-
-create_registry() {
-  CREATED_REGISTRY=true
-  docker run \
-    -d --restart=always \
-    -p "127.0.0.1:${REGISTRY_PORT}:5000" \
-    -p "127.0.0.1:5000:5000" \
-    --name "${REGISTRY_NAME}" \
-    registry:2
-}
-
-REGISTRY_STATE="$(docker inspect -f '{{.State.Running}}' "${REGISTRY_NAME}" 2>/dev/null || echo "missing")"
-if [ "$REGISTRY_STATE" = "true" ]; then
-  if verify_registry_ports; then
-    echo "Registry container '${REGISTRY_NAME}' is already running with correct ports."
-  else
-    echo "Registry container '${REGISTRY_NAME}' has wrong port bindings. Recreating..."
-    docker rm -f "${REGISTRY_NAME}"
-    create_registry
-  fi
-elif [ "$REGISTRY_STATE" = "false" ]; then
-  if verify_registry_ports; then
-    echo "Registry container '${REGISTRY_NAME}' exists but is stopped. Starting..."
-    docker start "${REGISTRY_NAME}"
-  else
-    echo "Registry container '${REGISTRY_NAME}' has wrong port bindings. Recreating..."
-    docker rm -f "${REGISTRY_NAME}"
-    create_registry
-  fi
-else
-  create_registry
+if [[ -f "$HOME/.crc_env" ]]; then
+  # shellcheck disable=SC1090,SC1091
+  source "$HOME/.crc_env"
 fi
 
-# Make the in-cluster registry hostname resolvable from the host.
-# This allows caib (running on the host) to pull artifacts using the same
-# URL that the in-cluster builds push to.
-if ! grep -q "${REGISTRY_HOST}" /etc/hosts; then
-  echo "127.0.0.1 ${REGISTRY_HOST}" | sudo tee -a /etc/hosts >/dev/null
-  echo "Added ${REGISTRY_HOST} to /etc/hosts"
-  CREATED_HOSTS_ENTRY=true
-fi
+eval "$(crc oc-env)" >/dev/null
+export KUBECONFIG="${CRC_KUBECONFIG:-$HOME/.crc/machines/crc/kubeconfig}"
 
-# Configure containers/image (used by caib) to use HTTP for the local registry.
-# Per-user config avoids requiring sudo for system-wide /etc/containers paths.
-REGISTRIES_CONF_DIR="${HOME}/.config/containers/registries.conf.d"
-REGISTRIES_CONF_FILE="${REGISTRIES_CONF_DIR}/kind-e2e-registry.conf"
-EXPECTED_CONF="[[registry]]
-location = \"${REGISTRY_HOST}:5000\"
-insecure = true"
-if [ -e "$REGISTRIES_CONF_FILE" ] && [ "$(cat "$REGISTRIES_CONF_FILE")" = "$EXPECTED_CONF" ]; then
-  echo "Registries config already matches, skipping write."
-else
-  if [ ! -e "$REGISTRIES_CONF_FILE" ]; then
-    CREATED_REGISTRIES_CONF=true
-  else
-    REGISTRIES_CONF_BACKUP="$(mktemp)"
-    cp "$REGISTRIES_CONF_FILE" "$REGISTRIES_CONF_BACKUP"
-    echo "Backed up existing registries config to $REGISTRIES_CONF_BACKUP"
-  fi
-  mkdir -p "$REGISTRIES_CONF_DIR"
-  tee "$REGISTRIES_CONF_FILE" >/dev/null <<EOF
-[[registry]]
-location = "${REGISTRY_HOST}:5000"
-insecure = true
-EOF
-fi
-
-# ------------------------------------------------------------------
-# [2/5] Create Kind Cluster with Registry Config
-# ------------------------------------------------------------------
-echo "[2/5] Creating Kind cluster..."
-
-# Check if cluster exists
-if kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
-  echo "Found existing cluster, deleting..."
-  kind delete cluster --name "$CLUSTER_NAME"
-fi
-
-kind create cluster --name "$CLUSTER_NAME" --wait 5m
-echo "Verifying cluster is up..."
-kubectl cluster-info --context "kind-$CLUSTER_NAME"
-# Label node for OperatorConfig nodeSelector
-kubectl label nodes --all aib=true
-kubectl get nodes --show-labels
-
-
-
-# Connect the registry to the cluster network if not already connected
-echo "Connecting registry to Kind network..."
-if [ "$(docker inspect -f='{{json .NetworkSettings.Networks.'"${KIND_NETWORK}"'}}' "${REGISTRY_NAME}")" = 'null' ]; then
-  docker network connect "${KIND_NETWORK}" "${REGISTRY_NAME}"
-fi
-
-# Map the registry in the nodes to the docker container
-for node in $(kind get nodes --name "${CLUSTER_NAME}"); do
-  kubectl annotate node "${node}" "kind.x-k8s.io/registry=localhost:${REGISTRY_PORT}" --overwrite
+for bin in oc kubectl; do
+  command -v "$bin" >/dev/null 2>&1 || fail "Missing required dependency: $bin"
 done
 
-echo "Waiting for node ready..."
-kubectl wait --for=condition=Ready nodes --all --timeout=60s
+crc status >/dev/null 2>&1 || fail "CRC is not running. Start it with 'crc start'."
+ensure_crc_login
 
-# ------------------------------------------------------------------
-# [3/5] Setup Internal DNS for Registry (The OpenShift spoof)
-# ------------------------------------------------------------------
-echo "[3/5] Configuring internal registry DNS..."
+info "Checking cluster connectivity..."
+oc cluster-info >/dev/null
+oc wait --for=condition=Ready nodes --all --timeout=60s >/dev/null
 
-# 1. Document the local registry (standard Kind practice)
-cat <<EOF | kubectl apply -f -
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: local-registry-hosting
-  namespace: kube-public
-data:
-  localRegistryHosting.v1: |
-    host: "localhost:${REGISTRY_PORT}"
-    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
-EOF
+info "Labeling nodes for e2e scheduling..."
+oc label nodes --all aib=true --overwrite >/dev/null
+oc get nodes --show-labels
 
-# 2. Create the Namespace
-kubectl create namespace openshift-image-registry --dry-run=client -o yaml | kubectl apply -f -
+info "Ensuring external registry route and client trust are configured..."
+bash hack/crc/04-expose-default-registry.sh
 
-# 3. ROBUST IP FETCHING
-# Wait until the registry has an IP on the 'kind' network
-echo "Waiting for registry IP assignment..."
-REGISTRY_IP=""
-for i in $(seq 1 30); do
-  REGISTRY_IP=$(docker inspect -f '{{.NetworkSettings.Networks.'"${KIND_NETWORK}"'.IPAddress}}' "${REGISTRY_NAME}" 2>/dev/null || true)
-  if [ -n "$REGISTRY_IP" ]; then
-    echo "Registry Internal IP found: $REGISTRY_IP"
-    break
-  fi
-  echo "Waiting for IP... (attempt $i/30)"
-  sleep 1
-done
-if [ -z "$REGISTRY_IP" ]; then
-  echo "Failed to discover a Kind-network IP for '${REGISTRY_NAME}' after 30 attempts" >&2
-  exit 1
-fi
-
-# 4. Create Service and Endpoints manually
-cat <<EOF | kubectl apply -f -
-apiVersion: v1
-kind: Service
-metadata:
-  name: image-registry
-  namespace: openshift-image-registry
-spec:
-  ports:
-  - port: 5000
-    protocol: TCP
-    targetPort: 5000
-  clusterIP: None
----
-apiVersion: v1
-kind: Endpoints
-metadata:
-  name: image-registry
-  namespace: openshift-image-registry
-subsets:
-- addresses:
-  - ip: ${REGISTRY_IP}
-  ports:
-  - port: 5000
-    name: registry
-    protocol: TCP
-EOF
-
-# ------------------------------------------------------------------
-# [4/5] Install Infrastructure (Tekton & Ingress)
-# ------------------------------------------------------------------
-echo "[4/5] Installing Infrastructure..."
-
-# Tekton
-kubectl apply --filename "https://infra.tekton.dev/tekton-releases/pipeline/previous/${TEKTON_VERSION}/release.yaml"
-# Ingress NGINX
-kubectl apply -f "https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-${INGRESS_NGINX_VERSION}/deploy/static/provider/kind/deploy.yaml"
-
-echo "Waiting for Infrastructure..."
-kubectl wait --for=condition=ready pod --all -n tekton-pipelines --timeout=5m
-kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=3m
-make build-caib
-# ------------------------------------------------------------------
-# [5/5] Run E2E Tests (self-contained: deploys operator, tests, tears down)
-# ------------------------------------------------------------------
-echo "[5/5] Running E2E Tests..."
+ensure_tekton
 set_build_platform
-export CONTAINER_TOOL=docker
-export KIND_CLUSTER="$CLUSTER_NAME"
-export CAIB_SERVER=http://localhost:8080
-export REGISTRY_USERNAME=kind
-export REGISTRY_PASSWORD=kind
+
+info "Building caib CLI..."
+make build-caib
+
+info "Running e2e suite against CRC..."
+export CONTAINER_TOOL
+export REGISTRY_TLS_VERIFY
 export REGISTRY_HOST
-export CLUSTER_NAME
+export OPENSHIFT_INTERNAL_REGISTRY="${OPENSHIFT_INTERNAL_REGISTRY:-image-registry.openshift-image-registry.svc:5000}"
+export OPENSHIFT_CLUSTER=true
+export CAIB_INSECURE=true
+unset KIND_CLUSTER
 make test-e2e
 
+printf '\n=========================================\n'
+printf ' Local CRC e2e run completed successfully \n'
+printf '=========================================\n'
 
-echo ""
-echo "========================================="
-echo "[5/5] All Tests Complete!"
-echo "========================================="

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -35,43 +35,21 @@ import (
 )
 
 const (
-	namespace = "automotive-dev-operator-system"
-	archARM64 = "arm64"
-	aarch64   = "aarch64"
+	namespace                      = "automotive-dev-operator-system"
+	archARM64                      = "arm64"
+	aarch64                        = "aarch64"
+	statusRunning                  = "Running"
+	tektonTaskPushArtifactRegistry = "push-artifact-registry"
+	artifactImageRepo              = "automotive-os-test1"
+	artifactImageName              = artifactImageRepo + ":latest"
+	kindPushNamespace              = "myorg"
 )
-
-// hasOpenShiftRouteCRD returns true when the OpenShift Route CRD exists (OpenShift cluster).
-// On Kind there is no Route CRD, so OIDC suite can skip before creating any resources.
-func hasOpenShiftRouteCRD() bool {
-	cmd := exec.Command("kubectl", "get", "crd", "routes.route.openshift.io")
-	_, err := utils.Run(cmd)
-	return err == nil
-}
-
-// getBuildAPIURL returns the Build API URL when an OpenShift Route exists, or "" otherwise.
-// OIDC e2e tests that need to call the API run only on OpenShift (when Route exists).
-func getBuildAPIURL() string {
-	cmd := exec.Command("kubectl", "get", "route", "ado-build-api",
-		"-n", namespace, "-o", "jsonpath={.spec.host}")
-	output, err := utils.Run(cmd)
-	if err != nil || strings.TrimSpace(string(output)) == "" {
-		return ""
-	}
-	return "https://" + strings.TrimSpace(string(output))
-}
 
 var _ = Describe("controller", Ordered, func() {
 	BeforeAll(func() {
-		By("waiting for namespace to not exist (in case previous suite left it terminating)")
-		waitForNamespaceGone := func() error {
-			cmd := exec.Command("kubectl", "get", "ns", namespace)
-			_, err := utils.Run(cmd)
-			if err != nil {
-				return nil // namespace gone, we can create it
-			}
-			return fmt.Errorf("namespace still exists or terminating")
-		}
-		Eventually(waitForNamespaceGone, 3*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("removing manager namespace")
+		utils.CleanupNamespace(namespace)
 
 		By("creating manager namespace")
 		cmd := exec.Command("kubectl", "create", "ns", namespace)
@@ -79,13 +57,8 @@ var _ = Describe("controller", Ordered, func() {
 	})
 
 	AfterAll(func() {
-		By("deleting OperatorConfig resources")
-		cmd := exec.Command("kubectl", "delete", "operatorconfig", "--all", "-n", namespace, "--timeout=30s")
-		_, _ = utils.Run(cmd)
-
 		By("removing manager namespace")
-		cmd = exec.Command("kubectl", "delete", "ns", namespace, "--timeout=60s")
-		_, _ = utils.Run(cmd)
+		utils.CleanupNamespace(namespace)
 	})
 
 	Context("Operator", func() {
@@ -94,23 +67,15 @@ var _ = Describe("controller", Ordered, func() {
 			var err error
 
 			var projectimage = "example.com/automotive-dev-operator:v0.0.1"
-
-			By("building the manager(Operator) image")
-			cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectimage))
-			_, err = utils.Run(cmd)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-			By("loading the the manager(Operator) image on Kind")
-			err = utils.LoadImageToKindClusterWithName(projectimage)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			deployedImage := utils.PrepareOperatorImage(projectimage, namespace)
 
 			By("installing CRDs")
-			cmd = exec.Command("make", "install")
+			cmd := exec.Command("make", "install")
 			_, err = utils.Run(cmd)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 			By("deploying the operator")
-			cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectimage))
+			cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", deployedImage))
 			_, err = utils.Run(cmd)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
@@ -143,7 +108,7 @@ var _ = Describe("controller", Ordered, func() {
 				)
 				status, err := utils.Run(cmd)
 				ExpectWithOffset(2, err).NotTo(HaveOccurred())
-				if string(status) != "Running" {
+				if string(status) != statusRunning {
 					return fmt.Errorf("controller pod in %s status", status)
 				}
 				return nil
@@ -169,8 +134,8 @@ var _ = Describe("controller", Ordered, func() {
 					logs, _ := utils.Run(logCmd)
 					return fmt.Errorf("build-automotive-image task not found, got: %s\nController logs:\n%s", tasks, string(logs))
 				}
-				if !strings.Contains(tasks, "push-artifact-registry") {
-					return fmt.Errorf("push-artifact-registry task not found, got: %s", tasks)
+				if !strings.Contains(tasks, tektonTaskPushArtifactRegistry) {
+					return fmt.Errorf("%s task not found, got: %s", tektonTaskPushArtifactRegistry, tasks)
 				}
 				return nil
 			}
@@ -209,9 +174,12 @@ var _ = Describe("controller", Ordered, func() {
 
 		Context("caib image build", func() {
 			var portForwardCmd *exec.Cmd
+			var caibServer string
 			var registryHost string
 			var arch string
 			var caibToken string
+			var openShiftCluster bool
+			var caibEnv []string
 			var projectimage = "automotive-dev-operator:test"
 			var caibBuildTimeout = 45 * time.Minute // max timeout for caib builds
 
@@ -245,14 +213,7 @@ var _ = Describe("controller", Ordered, func() {
 					"pod-security.kubernetes.io/warn=privileged", "--overwrite")
 				_, _ = utils.Run(cmd)
 
-				By("building the manager(Operator) image")
-				cmd = exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectimage))
-				_, err = utils.Run(cmd)
-				ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-				By("loading the the manager(Operator) image on Kind")
-				err = utils.LoadImageToKindClusterWithName(projectimage)
-				ExpectWithOffset(1, err).NotTo(HaveOccurred())
+				deployedImage := utils.PrepareOperatorImage(projectimage, namespace)
 
 				By("installing CRDs")
 				cmd = exec.Command("make", "install")
@@ -260,7 +221,7 @@ var _ = Describe("controller", Ordered, func() {
 				ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 				By("deploying the operator")
-				cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectimage))
+				cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", deployedImage))
 				_, err = utils.Run(cmd)
 				ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
@@ -282,69 +243,120 @@ var _ = Describe("controller", Ordered, func() {
 				_, err = utils.Run(cmd)
 				ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
-				By("patching OperatorConfig for Kind registry")
+				By("patching OperatorConfig registry route")
 				cmd = exec.Command("kubectl", "patch", "operatorconfig", "config",
 					"-n", namespace, "--type=merge",
 					"-p", fmt.Sprintf(`{"spec":{"osBuilds":{"clusterRegistryRoute":"%s:5000"}}}`, registryHost))
 				_, err = utils.Run(cmd)
 				ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
-				By("waiting for push-artifact-registry Task to be created")
+				By("waiting for " + tektonTaskPushArtifactRegistry + " Task to be created")
 				waitForPushTask := func() error {
-					taskCmd := exec.Command("kubectl", "get", "task", "push-artifact-registry", "-n", namespace)
+					taskCmd := exec.Command("kubectl", "get", "task", tektonTaskPushArtifactRegistry, "-n", namespace)
 					_, taskErr := utils.Run(taskCmd)
 					return taskErr
 				}
 				EventuallyWithOffset(1, waitForPushTask, 2*time.Minute, 5*time.Second).Should(Succeed(),
-					"push-artifact-registry Task was not created in time")
+					tektonTaskPushArtifactRegistry+" Task was not created in time")
 
-				// Kind-specific workaround: the local registry uses plain HTTP (no TLS),
-				// so oras push needs --plain-http. On OpenShift the internal registry has
-				// TLS and this flag is not required.
-				// runAsUser: 0 is needed because plain Kubernetes lacks OpenShift's SCC
-				// (Security Context Constraints) that would grant the push step access to
-				// root-owned build artifacts in the shared workspace.
-				By("patching push-artifact-registry Task for Kind (plain-http + runAsUser 0)")
-				cmd = exec.Command("kubectl", "annotate", "task", "push-artifact-registry",
-					"-n", namespace, "automotive.sdv.cloud.redhat.com/unmanaged=true", "--overwrite")
-				_, err = utils.Run(cmd)
-				ExpectWithOffset(1, err).NotTo(HaveOccurred())
+				openShiftCluster = utils.IsOpenShiftCluster()
+				if openShiftCluster {
+					By("patching " + tektonTaskPushArtifactRegistry + " Task for OpenShift (insecure TLS)")
+					cmd = exec.Command("kubectl", "annotate", "task", tektonTaskPushArtifactRegistry,
+						"-n", namespace, "automotive.sdv.cloud.redhat.com/unmanaged=true", "--overwrite")
+					_, err = utils.Run(cmd)
+					ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
-				cmd = exec.Command("bash", "-c",
-					`kubectl get task push-artifact-registry -n `+namespace+` -o json `+
-						`| jq '.spec.steps[0].script |= gsub("push --disable-path-validation"; "push --plain-http --disable-path-validation")' `+
-						`| jq '.spec.steps[0].securityContext = {"runAsUser": 0}' `+
-						`| kubectl replace -f -`)
-				_, err = utils.Run(cmd)
-				ExpectWithOffset(1, err).NotTo(HaveOccurred())
+					err = utils.PatchTektonTaskStep(namespace, tektonTaskPushArtifactRegistry, 0,
+						map[string]string{
+							"push --disable-path-validation": "push --insecure --disable-path-validation",
+							"--image-spec v1.1":              "--image-spec v1.0",
+							`oras" attach`:                   `oras" attach --insecure --distribution-spec v1.1-referrers-tag`,
+						}, nil)
+					ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
-				By("ensuring port 8080 is free before starting port-forward")
-				if conn, dialErr := net.DialTimeout("tcp", "localhost:8080", 500*time.Millisecond); dialErr == nil {
-					_ = conn.Close()
-					Fail("port 8080 is already in use; cannot set up port-forward to Build API")
-				}
+					// Pre-create the ImageStream so the internal registry can handle manifest
+					// HEAD checks properly. Without it the registry returns 500 instead of
+					// 404 for missing manifests, which causes oras push to abort.
+					By("pre-creating artifact ImageStream on OpenShift")
+					cmd = exec.Command("oc", "create", "imagestream", artifactImageRepo, "-n", namespace)
+					_, _ = utils.Run(cmd)
 
-				By("setting up port-forward to Build API")
-				portForwardCmd = exec.Command("kubectl", "port-forward",
-					"-n", namespace, "svc/ado-build-api", "8080:8080")
-				err = portForwardCmd.Start()
-				ExpectWithOffset(1, err).NotTo(HaveOccurred())
+					By("waiting for Build API route")
+					EventuallyWithOffset(1, func() string {
+						caibServer = utils.GetBuildAPIURL(namespace)
+						return caibServer
+					}, 2*time.Minute, 5*time.Second).ShouldNot(BeEmpty())
 
-				By("waiting for Build API to respond on port-forward")
-				httpClient := &http.Client{Timeout: 2 * time.Second}
-				waitForBuildAPI := func() error {
-					resp, httpErr := httpClient.Get("http://localhost:8080/v1/healthz")
-					if httpErr != nil {
-						return httpErr
+					By("waiting for Build API route to respond")
+					httpClient := &http.Client{
+						Timeout: 2 * time.Second,
+						Transport: &http.Transport{
+							TLSClientConfig: &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12},
+						},
 					}
-					_ = resp.Body.Close()
-					if resp.StatusCode == http.StatusOK {
-						return nil
+					waitForBuildAPI := func() error {
+						resp, httpErr := httpClient.Get(caibServer + "/v1/healthz")
+						if httpErr != nil {
+							return httpErr
+						}
+						_ = resp.Body.Close()
+						if resp.StatusCode == http.StatusOK {
+							return nil
+						}
+						return fmt.Errorf("unexpected status %d from Build API /v1/healthz", resp.StatusCode)
 					}
-					return fmt.Errorf("unexpected status %d from Build API /v1/healthz", resp.StatusCode)
+					EventuallyWithOffset(1, waitForBuildAPI, 2*time.Minute, 5*time.Second).Should(Succeed(),
+						"Build API route did not become ready")
+				} else {
+					// Kind-specific workaround: the local registry uses plain HTTP (no TLS),
+					// so oras push needs --plain-http. On OpenShift the internal registry has
+					// TLS and this flag is not required.
+					// runAsUser: 0 is needed because plain Kubernetes lacks OpenShift's SCC
+					// (Security Context Constraints) that would grant the push step access to
+					// root-owned build artifacts in the shared workspace.
+					By("patching " + tektonTaskPushArtifactRegistry + " Task for Kind (plain-http + runAsUser 0)")
+					cmd = exec.Command("kubectl", "annotate", "task", tektonTaskPushArtifactRegistry,
+						"-n", namespace, "automotive.sdv.cloud.redhat.com/unmanaged=true", "--overwrite")
+					_, err = utils.Run(cmd)
+					ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+					err = utils.PatchTektonTaskStep(namespace, tektonTaskPushArtifactRegistry, 0,
+						map[string]string{
+							"push --disable-path-validation": "push --plain-http --disable-path-validation",
+						},
+						map[string]any{"securityContext": map[string]any{"runAsUser": 0}})
+					ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+					By("ensuring port 8080 is free before starting port-forward")
+					if conn, dialErr := net.DialTimeout("tcp", "localhost:8080", 500*time.Millisecond); dialErr == nil {
+						_ = conn.Close()
+						Fail("port 8080 is already in use; cannot set up port-forward to Build API")
+					}
+
+					By("setting up port-forward to Build API")
+					portForwardCmd = exec.Command("kubectl", "port-forward",
+						"-n", namespace, "svc/ado-build-api", "8080:8080")
+					err = portForwardCmd.Start()
+					ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+					By("waiting for Build API to respond on port-forward")
+					httpClient := &http.Client{Timeout: 2 * time.Second}
+					waitForBuildAPI := func() error {
+						resp, httpErr := httpClient.Get("http://localhost:8080/v1/healthz")
+						if httpErr != nil {
+							return httpErr
+						}
+						_ = resp.Body.Close()
+						if resp.StatusCode == http.StatusOK {
+							return nil
+						}
+						return fmt.Errorf("unexpected status %d from Build API /v1/healthz", resp.StatusCode)
+					}
+					EventuallyWithOffset(1, waitForBuildAPI, 30*time.Second, 1*time.Second).Should(Succeed(),
+						"Build API on localhost:8080 did not become ready")
+					caibServer = "http://localhost:8080"
 				}
-				EventuallyWithOffset(1, waitForBuildAPI, 30*time.Second, 1*time.Second).Should(Succeed(),
-					"Build API on localhost:8080 did not become ready")
 
 				By("creating service account and token")
 				cmd = exec.Command("kubectl", "create", "serviceaccount", "caib",
@@ -363,24 +375,48 @@ var _ = Describe("controller", Ordered, func() {
 				ExpectWithOffset(1, tokenErr).NotTo(HaveOccurred())
 				caibToken = strings.TrimSpace(string(tokenOutput))
 				ExpectWithOffset(1, caibToken).NotTo(BeEmpty(), "CAIB_TOKEN must not be empty")
-				prevToken, hadPrevToken := os.LookupEnv("CAIB_TOKEN")
-				prevServer, hadPrevServer := os.LookupEnv("CAIB_SERVER")
-				DeferCleanup(func() {
-					if hadPrevToken {
-						_ = os.Setenv("CAIB_TOKEN", prevToken)
-					} else {
-						_ = os.Unsetenv("CAIB_TOKEN")
+
+				By("setting caib environment variables")
+				caibEnv = append([]string{}, os.Environ()...)
+				setEnv := func(key, value string) {
+					prefix := key + "="
+					filtered := caibEnv[:0]
+					for _, entry := range caibEnv {
+						if !strings.HasPrefix(entry, prefix) {
+							filtered = append(filtered, entry)
+						}
 					}
-					if hadPrevServer {
-						_ = os.Setenv("CAIB_SERVER", prevServer)
-					} else {
-						_ = os.Unsetenv("CAIB_SERVER")
-					}
-				})
-				setErr := os.Setenv("CAIB_TOKEN", caibToken)
-				ExpectWithOffset(1, setErr).NotTo(HaveOccurred())
-				setErr = os.Setenv("CAIB_SERVER", "http://localhost:8080")
-				ExpectWithOffset(1, setErr).NotTo(HaveOccurred())
+					caibEnv = append(filtered, prefix+value)
+				}
+				setEnv("CAIB_TOKEN", caibToken)
+				setEnv("CAIB_SERVER", caibServer)
+				if openShiftCluster {
+					setEnv("CAIB_INSECURE", "true")
+				}
+
+				By("setting registry credentials")
+				registryUsername := os.Getenv("REGISTRY_USERNAME")
+				registryPassword := os.Getenv("REGISTRY_PASSWORD")
+				if openShiftCluster {
+					// Registry tokens must be passed only via process env (caib / REGISTRY_* for
+					// subprocesses) or stdin (e.g. podman --password-stdin in test utils), never
+					// as CLI args, so Ginkgo/Run logs cannot leak them.
+					ocUser, ocErr := utils.Run(exec.Command("oc", "whoami"))
+					ExpectWithOffset(1, ocErr).NotTo(HaveOccurred())
+					ocToken, ocErr := utils.Run(exec.Command("oc", "whoami", "-t"))
+					ExpectWithOffset(1, ocErr).NotTo(HaveOccurred())
+					registryUsername = strings.TrimSpace(string(ocUser))
+					registryPassword = strings.TrimSpace(string(ocToken))
+				} else if registryUsername == "" {
+					registryUsername = "kind"
+					registryPassword = "kind"
+				}
+				if registryUsername != "" {
+					setEnv("REGISTRY_USERNAME", registryUsername)
+				}
+				if registryPassword != "" {
+					setEnv("REGISTRY_PASSWORD", registryPassword)
+				}
 			})
 
 			AfterAll(func() {
@@ -393,7 +429,8 @@ var _ = Describe("controller", Ordered, func() {
 			})
 
 			verifyCaibList := func(caibBuildName string) {
-				listCmd := exec.Command("bin/caib", "image", "list")
+				listCmd := utils.NewCaibCommand(context.Background(), caibEnv,
+					"image", "list")
 				listOutput, listErr := utils.Run(listCmd)
 				ExpectWithOffset(2, listErr).NotTo(HaveOccurred())
 				lines := strings.Split(string(listOutput), "\n")
@@ -422,12 +459,19 @@ var _ = Describe("controller", Ordered, func() {
 
 				containerCh := make(chan buildResult, 1)
 
+				pushNamespace := kindPushNamespace
+				if openShiftCluster {
+					pushNamespace = namespace
+				}
+
 				By("launching bootc container build")
 				go func() {
-					cmd := exec.CommandContext(ctx, "bin/caib", "image", "build-dev", "test/config/test-manifest.aib.yml",
+					cmd := utils.NewCaibCommand(ctx, caibEnv,
+						"image", "build-dev",
+						"test/config/test-manifest.aib.yml",
 						"--name", containerBuildName,
 						"--arch", arch,
-						"--push", fmt.Sprintf("%s:5000/myorg/automotive-os-test1:latest", registryHost),
+						"--push", fmt.Sprintf("%s:5000/%s/%s", registryHost, pushNamespace, artifactImageName),
 						"--follow")
 					out, err := utils.RunSafe(cmd)
 					containerCh <- buildResult{output: out, err: err}
@@ -457,23 +501,22 @@ var _ = Describe("OIDC Authentication", Ordered, func() {
 		var err error
 		var projectimage = "example.com/automotive-dev-operator:v0.0.1"
 
-		if !hasOpenShiftRouteCRD() {
+		if !utils.IsOpenShiftCluster() {
 			Skip("OIDC e2e requires OpenShift (Route CRD); skipping on kind")
 		}
 		oidcSuiteCreatedNamespace = true
 
+		// The controller suite's AfterAll may have just deleted this namespace.
+		// Wait for it to be fully gone before creating it again — otherwise the
+		// registry storage backend is in a torn-down state and podman push gets 500.
+		By("waiting for namespace to be fully gone before creating it")
+		utils.CleanupNamespace(namespace)
+
 		By("creating manager namespace")
 		cmd := exec.Command("kubectl", "create", "ns", namespace)
-		_, _ = utils.Run(cmd) // Ignore error if namespace already exists
+		_, _ = utils.Run(cmd)
 
-		By("building the manager(Operator) image")
-		cmd = exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectimage))
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred())
-
-		By("loading the manager(Operator) image on Kind")
-		err = utils.LoadImageToKindClusterWithName(projectimage)
-		Expect(err).NotTo(HaveOccurred())
+		deployedImage := utils.PrepareOperatorImage(projectimage, namespace)
 
 		By("installing CRDs")
 		cmd = exec.Command("make", "install")
@@ -481,7 +524,7 @@ var _ = Describe("OIDC Authentication", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("deploying the operator")
-		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectimage))
+		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", deployedImage))
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -511,7 +554,7 @@ var _ = Describe("OIDC Authentication", Ordered, func() {
 			if err != nil {
 				return err
 			}
-			if string(status) != "Running" {
+			if string(status) != statusRunning {
 				return fmt.Errorf("controller pod in %s status", status)
 			}
 			return nil
@@ -538,7 +581,7 @@ var _ = Describe("OIDC Authentication", Ordered, func() {
 		}
 		Eventually(verifyBuildAPIDeployment, 3*time.Minute, 5*time.Second).Should(Succeed())
 
-		if getBuildAPIURL() == "" {
+		if utils.GetBuildAPIURL(namespace) == "" {
 			Skip("OIDC e2e requires OpenShift Route (ado-build-api); skipping on kind")
 		}
 	})
@@ -566,29 +609,19 @@ var _ = Describe("OIDC Authentication", Ordered, func() {
 		Eventually(waitForOperatorConfigGone, 2*time.Minute, 5*time.Second).Should(Succeed())
 
 		By("removing manager namespace")
-		cmd = exec.Command("kubectl", "delete", "ns", namespace, "--timeout=120s")
-		_, _ = utils.Run(cmd)
-		By("waiting for namespace deletion to complete before next suite")
-		waitForNamespaceGone := func() error {
-			cmd := exec.Command("kubectl", "get", "ns", namespace)
-			_, err := utils.Run(cmd)
-			if err != nil {
-				return nil // namespace gone
-			}
-			return fmt.Errorf("namespace still exists or terminating")
-		}
-		Eventually(waitForNamespaceGone, 5*time.Minute, 10*time.Second).Should(Succeed())
+		utils.CleanupNamespace(namespace)
 	})
 
 	Context("Build API OIDC Configuration", func() {
 		It("should return 404 when OIDC is not configured", func() {
 			By("getting Build API URL")
-			apiURL := getBuildAPIURL()
+			apiURL := utils.GetBuildAPIURL(namespace)
 
 			By("checking /v1/auth/config endpoint returns 404 when OIDC not configured")
 			client := &http.Client{
+				Timeout: 5 * time.Second,
 				Transport: &http.Transport{
-					TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+					TLSClientConfig: &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12},
 				},
 			}
 			resp, err := client.Get(apiURL + "/v1/auth/config")
@@ -602,54 +635,51 @@ var _ = Describe("OIDC Authentication", Ordered, func() {
 		})
 
 		It("should handle OIDC configuration when provided", func() {
-			By("creating OperatorConfig with OIDC authentication")
-			operatorConfigYAML := `
-apiVersion: automotive.sdv.cloud.redhat.com/v1alpha1
-kind: OperatorConfig
-metadata:
-  name: config
-  namespace: automotive-dev-operator-system
-spec:
-  buildAPI:
-    authentication:
-      clientId: test-client-id
-      jwt:
-        - issuer:
-            url: https://issuer.example.com
-            audiences:
-              - test-audience
-          claimMappings:
-            username:
-              claim: preferred_username
-              prefix: ""
-`
-			cmd := exec.Command("kubectl", "apply", "-f", "-")
-			cmd.Stdin = strings.NewReader(operatorConfigYAML)
+			By("patching OperatorConfig to add OIDC authentication")
+			// Use merge-patch so existing spec fields (osBuilds, etc.) are preserved.
+			// A full kubectl apply with only buildAPI would strip osBuilds, triggering
+			// cleanupOSBuilds in the reconciler which deletes the Route and deployment.
+			oidcPatch := `{"spec":{"buildAPI":{"authentication":{"clientId":"test-client-id","jwt":[{"issuer":{"url":"https://issuer.example.com","audiences":["test-audience"]},"claimMappings":{"username":{"claim":"preferred_username","prefix":""}}}]}}}}`
+			cmd := exec.Command("kubectl", "patch", "operatorconfig", "config",
+				"-n", namespace, "--type=merge", "-p", oidcPatch)
 			_, err := utils.Run(cmd)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
-			By("waiting for operator to reconcile and Build API to reload configuration")
-			time.Sleep(10 * time.Second)
-
 			By("checking /v1/auth/config endpoint returns OIDC config")
-			apiURL := getBuildAPIURL()
+			apiURL := utils.GetBuildAPIURL(namespace)
 			if apiURL == "" {
 				Skip("Build API Route not found (OpenShift required)")
 			}
-			client := &http.Client{
+			httpClient := &http.Client{
+				Timeout: 5 * time.Second,
 				Transport: &http.Transport{
-					TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+					TLSClientConfig: &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12},
 				},
 			}
-			resp, err := client.Get(apiURL + "/v1/auth/config")
-			Expect(err).NotTo(HaveOccurred())
-			defer func() {
-				_ = resp.Body.Close()
-			}()
-			Expect(resp.StatusCode).To(Equal(200))
-			body, err := io.ReadAll(resp.Body)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(body)).To(And(ContainSubstring("jwt"), ContainSubstring("clientId")))
+			// The Build API pod restarts after the OperatorConfig patch; poll until the
+			// new OIDC config is served (up to 2 minutes).
+			var authBody string
+			EventuallyWithOffset(1, func() error {
+				resp, httpErr := httpClient.Get(apiURL + "/v1/auth/config")
+				if httpErr != nil {
+					return httpErr
+				}
+				defer func() { _ = resp.Body.Close() }()
+				if resp.StatusCode != 200 {
+					return fmt.Errorf("unexpected status %d from /v1/auth/config", resp.StatusCode)
+				}
+				b, readErr := io.ReadAll(resp.Body)
+				if readErr != nil {
+					return readErr
+				}
+				if !strings.Contains(string(b), "jwt") || !strings.Contains(string(b), "clientId") {
+					return fmt.Errorf("OIDC config not yet reflected: %s", string(b))
+				}
+				authBody = string(b)
+				return nil
+			}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+				"Build API did not serve OIDC config in time")
+			Expect(authBody).To(And(ContainSubstring("jwt"), ContainSubstring("clientId")))
 
 			By("cleaning up OIDC configuration from OperatorConfig")
 			cmd = exec.Command("kubectl", "patch", "operatorconfig", "config",
@@ -660,15 +690,20 @@ spec:
 
 	Context("Internal JWT Validation", func() {
 		It("should have Build API pod running", func() {
-			// Verify the Build API pod is running
 			By("verifying Build API pod is running")
-			cmd := exec.Command("kubectl", "get", "pod", "-l", "app.kubernetes.io/component=build-api",
-				"-n", namespace, "-o", "jsonpath={.items[0].status.phase}")
-			output, err := utils.Run(cmd)
-			if err != nil {
-				Skip("Build API pod not found")
-			}
-			Expect(strings.TrimSpace(string(output))).To(Equal("Running"))
+			EventuallyWithOffset(1, func() error {
+				cmd := exec.Command("kubectl", "get", "pod", "-l", "app.kubernetes.io/component=build-api",
+					"-n", namespace, "-o", "jsonpath={.items[0].status.phase}")
+				output, err := utils.Run(cmd)
+				if err != nil {
+					return fmt.Errorf("build-api pod not found: %w", err)
+				}
+				phase := strings.TrimSpace(string(output))
+				if phase != statusRunning {
+					return fmt.Errorf("build-api pod in %q phase", phase)
+				}
+				return nil
+			}, 2*time.Minute, 5*time.Second).Should(Succeed())
 		})
 	})
 })

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -18,16 +18,43 @@ limitations under the License.
 package testutils
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck // Dot import is standard for Ginkgo
+	. "github.com/onsi/gomega"    //nolint:revive,staticcheck // Dot import is standard for Ginkgo tests
 )
+
+const (
+	openshiftInternalRegistryDefault = "image-registry.openshift-image-registry.svc:5000"
+	buildToolPodman                  = "podman"
+	buildToolDocker                  = "docker"
+)
+
+func getOpenshiftInternalRegistry() string {
+	if v := strings.TrimSpace(os.Getenv("OPENSHIFT_INTERNAL_REGISTRY")); v != "" {
+		return v
+	}
+	return openshiftInternalRegistryDefault
+}
+
+var namespaceFinalizerResources = []string{
+	"operatorconfig",
+	"taskruns",
+	"pipelineruns",
+	"persistentvolumeclaims",
+}
 
 // Run executes the provided command within this context.
 // Not goroutine-safe due to os.Chdir; use RunSafe for concurrent execution.
+// If cmd.Env is non-empty it is used as the base environment (callers must include
+// PATH, HOME, etc.); GO111MODULE=on is always appended.
 func Run(cmd *exec.Cmd) ([]byte, error) {
 	dir, _ := GetProjectDir()
 	cmd.Dir = dir
@@ -36,7 +63,10 @@ func Run(cmd *exec.Cmd) ([]byte, error) {
 		_, _ = fmt.Fprintf(GinkgoWriter, "chdir dir: %s\n", err)
 	}
 
-	cmd.Env = append(os.Environ(), "GO111MODULE=on")
+	if len(cmd.Env) == 0 {
+		cmd.Env = append([]string{}, os.Environ()...)
+	}
+	cmd.Env = append(cmd.Env, "GO111MODULE=on")
 	command := strings.Join(cmd.Args, " ")
 	_, _ = fmt.Fprintf(GinkgoWriter, "running: %s\n", command)
 	output, err := cmd.CombinedOutput()
@@ -49,11 +79,16 @@ func Run(cmd *exec.Cmd) ([]byte, error) {
 
 // RunSafe executes the provided command using cmd.Dir only (no os.Chdir).
 // Safe to call from multiple goroutines concurrently.
+// If cmd.Env is non-empty it is used as the base environment (callers must include
+// PATH, HOME, etc.); GO111MODULE=on is always appended.
 func RunSafe(cmd *exec.Cmd) ([]byte, error) {
 	dir, _ := GetProjectDir()
 	cmd.Dir = dir
 
-	cmd.Env = append(os.Environ(), "GO111MODULE=on")
+	if len(cmd.Env) == 0 {
+		cmd.Env = append([]string{}, os.Environ()...)
+	}
+	cmd.Env = append(cmd.Env, "GO111MODULE=on")
 	command := strings.Join(cmd.Args, " ")
 	_, _ = fmt.Fprintf(GinkgoWriter, "running: %s\n", command)
 	output, err := cmd.CombinedOutput()
@@ -63,6 +98,141 @@ func RunSafe(cmd *exec.Cmd) ([]byte, error) {
 	}
 
 	return output, nil
+}
+
+// IsOpenShiftCluster returns true when the target cluster is OpenShift.
+// It checks the OPENSHIFT_CLUSTER env var first (set explicitly by run-e2e-local.sh),
+// then falls back to probing the Route CRD dynamically.
+// Prefer this over HasOpenShiftRouteCRD for branching on cluster type.
+func IsOpenShiftCluster() bool {
+	v := strings.TrimSpace(os.Getenv("OPENSHIFT_CLUSTER"))
+	if strings.EqualFold(v, "true") || v == "1" {
+		return true
+	}
+	return HasOpenShiftRouteCRD()
+}
+
+// HasOpenShiftRouteCRD returns true when the cluster exposes the OpenShift Route CRD.
+func HasOpenShiftRouteCRD() bool {
+	cmd := exec.Command("kubectl", "get", "crd", "routes.route.openshift.io")
+	_, err := Run(cmd)
+	return err == nil
+}
+
+// GetBuildAPIURL returns the Build API URL when an OpenShift Route exists, or "" otherwise.
+func GetBuildAPIURL(namespace string) string {
+	cmd := exec.Command("kubectl", "get", "route", "ado-build-api",
+		"-n", namespace, "-o", "jsonpath={.spec.host}")
+	output, err := Run(cmd)
+	if err != nil || strings.TrimSpace(string(output)) == "" {
+		return ""
+	}
+	return "https://" + strings.TrimSpace(string(output))
+}
+
+// CleanupNamespace removes the target namespace and repeatedly strips finalizers
+// from common blocking resources until the namespace is fully deleted.
+func CleanupNamespace(targetNamespace string) {
+	cmd := exec.Command("kubectl", "delete", "ns", targetNamespace, "--ignore-not-found=true", "--timeout=60s")
+	_, _ = Run(cmd)
+	stripNamespaceFinalizers(targetNamespace)
+	waitForNamespaceGone := func() error {
+		cmd := exec.Command("kubectl", "get", "ns", targetNamespace, "--ignore-not-found")
+		output, err := Run(cmd)
+		if err != nil {
+			return fmt.Errorf("check namespace %q deletion: %w", targetNamespace, err)
+		}
+		if strings.TrimSpace(string(output)) == "" {
+			return nil // namespace is gone
+		}
+		stripNamespaceFinalizers(targetNamespace)
+		return fmt.Errorf("namespace still exists or terminating")
+	}
+	Eventually(waitForNamespaceGone, 5*time.Minute, 5*time.Second).Should(Succeed())
+}
+
+// PatchTektonTaskStep fetches a Tekton Task, applies script replacements and optional
+// field overrides on step[stepIndex], then runs kubectl replace.
+func PatchTektonTaskStep(namespace, taskName string, stepIndex int, scriptReplacements map[string]string, stepFields map[string]any) error {
+	raw, err := Run(exec.Command("kubectl", "get", "task", taskName, "-n", namespace, "-o", "json"))
+	if err != nil {
+		return err
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return fmt.Errorf("task %s: invalid json: %w", taskName, err)
+	}
+	step, err := getTektonTaskStep(obj, taskName, stepIndex)
+	if err != nil {
+		return err
+	}
+	script, ok := step["script"].(string)
+	if !ok {
+		return fmt.Errorf("task %s: step[%d] has no script field", taskName, stepIndex)
+	}
+	for old, repl := range scriptReplacements {
+		script = strings.ReplaceAll(script, old, repl)
+	}
+	step["script"] = script
+	for k, v := range stepFields {
+		step[k] = v
+	}
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("task %s: marshal patched task: %w", taskName, err)
+	}
+	rep := exec.Command("kubectl", "replace", "-f", "-")
+	rep.Stdin = bytes.NewReader(out)
+	_, err = Run(rep)
+	return err
+}
+
+func getTektonTaskStep(obj map[string]any, taskName string, stepIndex int) (map[string]any, error) {
+	if obj == nil {
+		return nil, fmt.Errorf("task %s: nil object", taskName)
+	}
+	spec, ok := obj["spec"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("task %s: missing or invalid spec", taskName)
+	}
+	steps, ok := spec["steps"].([]any)
+	if !ok || len(steps) == 0 {
+		return nil, fmt.Errorf("task %s: missing or empty spec.steps", taskName)
+	}
+	if stepIndex < 0 || stepIndex >= len(steps) {
+		return nil, fmt.Errorf("task %s: step %d out of range (%d steps)", taskName, stepIndex, len(steps))
+	}
+	step, ok := steps[stepIndex].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("task %s: step[%d] is not an object", taskName, stepIndex)
+	}
+	return step, nil
+}
+
+// NewCaibCommand builds a `bin/caib` command with the provided environment.
+// Pass a non-nil context to enable cancellation/timeout control.
+func NewCaibCommand(ctx context.Context, env []string, args ...string) *exec.Cmd {
+	var cmd *exec.Cmd
+	if ctx != nil {
+		cmd = exec.CommandContext(ctx, "bin/caib", args...)
+	} else {
+		cmd = exec.Command("bin/caib", args...)
+	}
+	cmd.Env = append([]string{}, env...)
+	return cmd
+}
+
+// PrepareOperatorImage builds the operator image and makes it available to the target cluster.
+func PrepareOperatorImage(projectImage, namespace string) string {
+	By("building the manager(Operator) image")
+	cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectImage))
+	_, err := Run(cmd)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	By("making the manager(Operator) image available to the cluster")
+	deployedImage, err := LoadImageToClusterWithName(projectImage, namespace)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	return deployedImage
 }
 
 // LoadImageToKindClusterWithName loads a local docker image to the kind cluster
@@ -75,6 +245,134 @@ func LoadImageToKindClusterWithName(name string) error {
 	cmd := exec.Command("kind", kindOptions...)
 	_, err := Run(cmd)
 	return err
+}
+
+// LoadImageToClusterWithName makes a locally built image available to the target cluster.
+// On Kind this uses `kind load`; on OpenShift it tags and pushes into the cluster registry.
+func LoadImageToClusterWithName(name, namespace string) (string, error) {
+	if IsOpenShiftCluster() {
+		return pushImageToOpenShiftRegistry(name, namespace)
+	}
+	return name, LoadImageToKindClusterWithName(name)
+}
+
+func pushImageToOpenShiftRegistry(localImage, namespace string) (string, error) {
+	if namespace == "" {
+		return "", fmt.Errorf("namespace is required to push image %q to OpenShift", localImage)
+	}
+
+	routeHost, err := getOpenShiftRegistryRoute()
+	if err != nil {
+		return "", err
+	}
+
+	username, err := getCommandOutput("oc", "whoami")
+	if err != nil {
+		return "", fmt.Errorf("resolve OpenShift registry username: %w", err)
+	}
+	token, err := getCommandOutput("oc", "whoami", "-t")
+	if err != nil {
+		return "", fmt.Errorf("resolve OpenShift registry token: %w", err)
+	}
+
+	repo, tag := splitImageName(localImage)
+	externalRef := fmt.Sprintf("%s/%s/%s%s", routeHost, namespace, repo, tag)
+	internalRef := fmt.Sprintf("%s/%s/%s%s", getOpenshiftInternalRegistry(), namespace, repo, tag)
+	tool := resolveContainerTool()
+
+	loginArgs := []string{"login", "-u", username, "--password-stdin"}
+	if tool == buildToolPodman {
+		loginArgs = append(loginArgs, tlsVerifyArgs()...)
+	}
+	loginArgs = append(loginArgs, routeHost)
+	loginCmd := exec.Command(tool, loginArgs...)
+	loginCmd.Stdin = strings.NewReader(token)
+	loginOutput, err := loginCmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("%s login failed: %v: %s", tool, err, strings.TrimSpace(string(loginOutput)))
+	}
+
+	if _, err := Run(exec.Command(tool, "tag", localImage, externalRef)); err != nil {
+		return "", fmt.Errorf("%s tag failed: %w", tool, err)
+	}
+
+	// Pre-create the ImageStream so the registry has a repository entry before
+	// the push. Without this the OpenShift internal registry returns HTTP 500
+	// when the namespace storage backend is not yet initialised.
+	createImageStreamCmd := exec.Command("oc", "create", "imagestream", repo, "-n", namespace)
+	createImageStreamOut, createImageStreamErr := Run(createImageStreamCmd)
+	if createImageStreamErr != nil && !strings.Contains(string(createImageStreamOut), "AlreadyExists") {
+		return "", fmt.Errorf("create OpenShift imagestream %q: %w", repo, createImageStreamErr)
+	}
+
+	pushArgs := []string{"push"}
+	if tool == buildToolPodman {
+		pushArgs = append(pushArgs, tlsVerifyArgs()...)
+	}
+	pushArgs = append(pushArgs, externalRef)
+
+	if _, err := Run(exec.Command(tool, pushArgs...)); err != nil {
+		return "", fmt.Errorf("%s push failed: %w", tool, err)
+	}
+
+	return internalRef, nil
+}
+
+func getOpenShiftRegistryRoute() (string, error) {
+	routeHost, err := getCommandOutput("kubectl", "get", "route", "default-route",
+		"-n", "openshift-image-registry", "-o", "jsonpath={.spec.host}")
+	if err != nil {
+		return "", fmt.Errorf("resolve OpenShift registry route: %w", err)
+	}
+	if routeHost == "" {
+		return "", fmt.Errorf("OpenShift registry route is empty")
+	}
+	return routeHost, nil
+}
+
+func getCommandOutput(command string, args ...string) (string, error) {
+	output, err := Run(exec.Command(command, args...))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func resolveContainerTool() string {
+	if tool := strings.TrimSpace(os.Getenv("CONTAINER_TOOL")); tool != "" {
+		return tool
+	}
+	if _, err := exec.LookPath(buildToolPodman); err == nil {
+		return buildToolPodman
+	}
+	return buildToolDocker
+}
+
+func tlsVerifyArgs() []string {
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("REGISTRY_TLS_VERIFY")), "true") {
+		return []string{"--tls-verify=true"}
+	}
+	return []string{"--tls-verify=false"}
+}
+
+func splitImageName(image string) (string, string) {
+	lastSlash := strings.LastIndex(image, "/")
+	name := image
+	tag := ":latest"
+	if lastAt := strings.LastIndex(image, "@"); lastAt >= 0 {
+		tag = image[lastAt:]
+		name = image[:lastAt]
+	} else if lastColon := strings.LastIndex(image, ":"); lastColon > lastSlash {
+		tag = image[lastColon:]
+		name = image[:lastColon]
+	}
+
+	repo := name
+	if lastSlash >= 0 {
+		repo = name[lastSlash+1:]
+	}
+
+	return repo, tag
 }
 
 // GetNonEmptyLines converts given command output string into individual objects
@@ -99,4 +397,21 @@ func GetProjectDir() (string, error) {
 	}
 	wd = strings.ReplaceAll(wd, "/test/e2e", "")
 	return wd, nil
+}
+
+func stripNamespaceFinalizers(targetNamespace string) {
+	for _, resource := range namespaceFinalizerResources {
+		output, err := Run(exec.Command("kubectl", "get", resource, "-n", targetNamespace, "-o", "name"))
+		if err != nil {
+			continue
+		}
+		for _, name := range GetNonEmptyLines(string(output)) {
+			_, _ = Run(exec.Command(
+				"kubectl", "patch", name,
+				"-n", targetNamespace,
+				"--type=merge",
+				"-p", `{"metadata":{"finalizers":[]}}`,
+			))
+		}
+	}
 }


### PR DESCRIPTION
## Summary
Leverage CRC OpenShift cluster into local E2e Test execution, instead of using `kind` cluster.
while keeping `E2E Tests` workflow in Github Actions using `kind` cluster.

## Related Issues
Relates to https://github.com/centos-automotive-suite/automotive-dev-operator/pull/176

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] CI/CD improvement
- [x] Refactoring

## Testing
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized CRC registry-exposure instructions: unified CRC-user invocation on Linux/macOS and clarified when Linux may prompt for sudo.

* **Chores**
  * Safer CRC scripts: central CRC API URL, prefer running as CRC user, use per-run temporary dirs with automatic cleanup, and consolidated cross-platform command snippets.
  * E2E workflow migrated from Kind/Docker to CRC/OpenShift with updated operator and registry setup.

* **Tests**
  * Hardened E2E tests and utilities: improved OpenShift detection, namespace cleanup, build/image publish flow, auth handling, and readiness polling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->