### PR TITLE
refactor: extract registry from server.go

### DIFF
--- a/api/v1alpha1/operatorconfig_types.go
+++ b/api/v1alpha1/operatorconfig_types.go
@@ -63,6 +63,9 @@ const (
 	// DefaultBuildTTL is the default time-to-live for builds (all phases, including in-progress).
 	DefaultBuildTTL = "24h"
 
+	// DefaultRegistryTokenLifetimeSeconds is the default SA token lifetime for internal registry auth.
+	DefaultRegistryTokenLifetimeSeconds int64 = 4 * 3600 // 4 hours
+
 	// NoExpireAnnotation prevents automatic expiry when set to "true" on an ImageBuild
 	NoExpireAnnotation = "automotive.sdv.cloud.redhat.com/no-expire"
 
@@ -562,6 +565,13 @@ type OSBuildsConfig struct {
 	// Set to "0" for no maximum. Uses Go duration format (e.g. "168h" for 1 week).
 	// +optional
 	MaxBuildTTL string `json:"maxBuildTTL,omitempty"`
+
+	// RegistryTokenLifetimeSeconds is the lifetime in seconds for service account tokens
+	// used for internal registry authentication during builds.
+	// Default: 14400 (4 hours)
+	// +kubebuilder:validation:Minimum=1
+	// +optional
+	RegistryTokenLifetimeSeconds int64 `json:"registryTokenLifetimeSeconds,omitempty"`
 }
 
 // CertificateSourceRef references a Secret or ConfigMap that contains trusted CA certificates.
@@ -611,6 +621,14 @@ func (c *OSBuildsConfig) GetMaxBuildTTL() string {
 		return c.MaxBuildTTL
 	}
 	return ""
+}
+
+// GetRegistryTokenLifetimeSeconds returns the SA token lifetime for internal registry auth
+func (c *OSBuildsConfig) GetRegistryTokenLifetimeSeconds() int64 {
+	if c != nil && c.RegistryTokenLifetimeSeconds > 0 {
+		return c.RegistryTokenLifetimeSeconds
+	}
+	return DefaultRegistryTokenLifetimeSeconds
 }
 
 // GetUsePVCScratchVolumes returns whether to use PVC-backed scratch volumes (default: true)

--- a/config/crd/bases/automotive.sdv.cloud.redhat.com_operatorconfigs.yaml
+++ b/config/crd/bases/automotive.sdv.cloud.redhat.com_operatorconfigs.yaml
@@ -765,6 +765,14 @@ spec:
                       PVCSize specifies the size for persistent volume claims created for build workspaces
                       Default: "8Gi"
                     type: string
+                  registryTokenLifetimeSeconds:
+                    description: |-
+                      RegistryTokenLifetimeSeconds is the lifetime in seconds for service account tokens
+                      used for internal registry authentication during builds.
+                      Default: 14400 (4 hours)
+                    format: int64
+                    minimum: 1
+                    type: integer
                   runtimeClassName:
                     description: |-
                       RuntimeClassName specifies the runtime class to use for the build pod

--- a/internal/buildapi/client_tokens.go
+++ b/internal/buildapi/client_tokens.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/labels"
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
 	corev1 "k8s.io/api/core/v1"
@@ -77,12 +78,12 @@ func (a *APIServer) ensureClientTokenSecret(c *gin.Context, username string, oid
 			Name:      secretName,
 			Namespace: resolveNamespace(),
 			Labels: map[string]string{
-				"app.kubernetes.io/name":                        "automotive-dev-operator",
-				"app.kubernetes.io/component":                   "build-api",
-				"automotive.sdv.cloud.redhat.com/resource-type": "client-token",
+				labels.Name:         labels.ValueOperator,
+				labels.Component:    labels.ValueBuildAPI,
+				labels.ResourceType: "client-token",
 			},
 			Annotations: map[string]string{
-				"automotive.sdv.cloud.redhat.com/username": username,
+				labels.Username: username,
 			},
 		},
 		Type: corev1.SecretTypeOpaque,

--- a/internal/buildapi/container_builds.go
+++ b/internal/buildapi/container_builds.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/labels"
 )
 
 // --- Container Build Handlers ---
@@ -262,7 +263,8 @@ func (a *APIServer) createContainerBuild(c *gin.Context) {
 			return
 		}
 
-		secretName, err := createInternalRegistrySecretFn(ctx, restCfg, namespace, req.Name)
+		tokenLifetime := resolveTokenLifetime(ctx, k8sClient, namespace)
+		secretName, err := createInternalRegistrySecretFn(ctx, restCfg, namespace, req.Name, tokenLifetime)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to create internal registry secret: %v", err)})
 			return
@@ -309,12 +311,12 @@ func (a *APIServer) createContainerBuild(c *gin.Context) {
 			Name:      req.Name,
 			Namespace: namespace,
 			Labels: map[string]string{
-				"app.kubernetes.io/managed-by": "build-api",
-				"app.kubernetes.io/part-of":    "automotive-dev",
-				"app.kubernetes.io/created-by": "automotive-dev-build-api",
+				labels.ManagedBy: labels.ValueBuildAPI,
+				labels.PartOf:    labels.ValueAutomotiveDev,
+				labels.CreatedBy: labels.ValueBuildAPICreator,
 			},
 			Annotations: map[string]string{
-				"automotive.sdv.cloud.redhat.com/requested-by": requestedBy,
+				labels.RequestedBy: requestedBy,
 			},
 		},
 		Spec: automotivev1alpha1.ContainerBuildSpec{
@@ -396,7 +398,7 @@ func listContainerBuilds(c *gin.Context) {
 			CreatedAt:   cb.CreationTimestamp.Format(time.RFC3339),
 			OutputImage: cb.Spec.Output,
 		}
-		if v, ok := cb.Annotations["automotive.sdv.cloud.redhat.com/requested-by"]; ok {
+		if v, ok := cb.Annotations[labels.RequestedBy]; ok {
 			item.RequestedBy = v
 		}
 		if cb.Status.CompletionTime != nil {
@@ -443,7 +445,7 @@ func (a *APIServer) getContainerBuild(c *gin.Context, name string) {
 		OutputImage: outputImage,
 		ImageDigest: cb.Status.ImageDigest,
 	}
-	if v, ok := cb.Annotations["automotive.sdv.cloud.redhat.com/requested-by"]; ok {
+	if v, ok := cb.Annotations[labels.RequestedBy]; ok {
 		resp.RequestedBy = v
 	}
 	if cb.Status.StartTime != nil {
@@ -456,11 +458,12 @@ func (a *APIServer) getContainerBuild(c *gin.Context, name string) {
 	// Mint a fresh registry token for completed/failed internal registry builds
 	// that belong to the requesting user
 	requester := a.resolveRequester(c)
-	buildOwner := cb.Annotations["automotive.sdv.cloud.redhat.com/requested-by"]
+	buildOwner := cb.Annotations[labels.RequestedBy]
 	if requester == buildOwner &&
 		cb.Spec.UseServiceAccountAuth &&
 		isTerminalPhase(cb.Status.Phase) {
-		token, _, tokenErr := a.mintRegistryToken(ctx, c, namespace)
+		tokenLifetime := resolveTokenLifetime(ctx, k8sClient, namespace)
+		token, _, tokenErr := a.mintRegistryToken(ctx, c, namespace, tokenLifetime)
 		if tokenErr != nil {
 			a.log.Error(tokenErr, "failed to mint registry token for container build", "build", name)
 		} else {

--- a/internal/buildapi/flash.go
+++ b/internal/buildapi/flash.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/labels"
 	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/tasks"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 )
@@ -188,14 +189,14 @@ func (a *APIServer) createFlash(c *gin.Context) {
 			Name:      req.Name,
 			Namespace: namespace,
 			Labels: map[string]string{
-				"app.kubernetes.io/managed-by": "build-api",
-				"app.kubernetes.io/part-of":    "automotive-dev",
-				"app.kubernetes.io/name":       "flash-taskrun",
-				flashTaskRunLabel:              req.Name,
+				labels.ManagedBy:    labels.ValueBuildAPI,
+				labels.PartOf:       labels.ValueAutomotiveDev,
+				labels.Name:         "flash-taskrun",
+				labels.FlashTaskRun: req.Name,
 			},
 			Annotations: map[string]string{
-				"automotive.sdv.cloud.redhat.com/requested-by": requestedBy,
-				"automotive.sdv.cloud.redhat.com/image-ref":    req.ImageRef,
+				labels.RequestedBy: requestedBy,
+				labels.ImageRef:    req.ImageRef,
 			},
 		},
 		Spec: tektonv1.TaskRunSpec{
@@ -267,7 +268,7 @@ func (a *APIServer) listFlash(c *gin.Context) {
 
 	// List TaskRuns with flash label
 	taskRunList := &tektonv1.TaskRunList{}
-	if err := k8sClient.List(ctx, taskRunList, client.InNamespace(namespace), client.HasLabels{flashTaskRunLabel}); err != nil {
+	if err := k8sClient.List(ctx, taskRunList, client.InNamespace(namespace), client.HasLabels{labels.FlashTaskRun}); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to list flash TaskRuns: %v", err)})
 		return
 	}
@@ -290,7 +291,7 @@ func (a *APIServer) listFlash(c *gin.Context) {
 			Name:           tr.Name,
 			Phase:          phase,
 			Message:        message,
-			RequestedBy:    tr.Annotations["automotive.sdv.cloud.redhat.com/requested-by"],
+			RequestedBy:    tr.Annotations[labels.RequestedBy],
 			CreatedAt:      tr.CreationTimestamp.Format(time.RFC3339),
 			CompletionTime: compStr,
 		})
@@ -319,7 +320,7 @@ func (a *APIServer) getFlash(c *gin.Context, name string) {
 	}
 
 	// Verify it's a flash TaskRun
-	if taskRun.Labels[flashTaskRunLabel] == "" {
+	if taskRun.Labels[labels.FlashTaskRun] == "" {
 		c.JSON(http.StatusNotFound, gin.H{"error": "flash TaskRun not found"})
 		return
 	}
@@ -337,7 +338,7 @@ func (a *APIServer) getFlash(c *gin.Context, name string) {
 		Name:           taskRun.Name,
 		Phase:          phase,
 		Message:        message,
-		RequestedBy:    taskRun.Annotations["automotive.sdv.cloud.redhat.com/requested-by"],
+		RequestedBy:    taskRun.Annotations[labels.RequestedBy],
 		StartTime:      startStr,
 		CompletionTime: compStr,
 		TaskRunName:    taskRun.Name,
@@ -399,7 +400,7 @@ func (a *APIServer) streamFlashLogs(c *gin.Context, name string) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to get flash TaskRun: %v", err)})
 		return
 	}
-	if taskRun.Labels[flashTaskRunLabel] == "" {
+	if taskRun.Labels[labels.FlashTaskRun] == "" {
 		c.JSON(http.StatusNotFound, gin.H{"error": "flash TaskRun not found"})
 		return
 	}

--- a/internal/buildapi/flash_helpers.go
+++ b/internal/buildapi/flash_helpers.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/labels"
 	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/registryutil"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -52,10 +53,10 @@ func createFlashClientConfigSecret(
 			Name:      secretName,
 			Namespace: namespace,
 			Labels: map[string]string{
-				"app.kubernetes.io/managed-by":                  "build-api",
-				"app.kubernetes.io/part-of":                     "automotive-dev",
-				flashTaskRunLabel:                               req.Name,
-				"automotive.sdv.cloud.redhat.com/resource-type": "jumpstarter-client",
+				labels.ManagedBy:    labels.ValueBuildAPI,
+				labels.PartOf:       labels.ValueAutomotiveDev,
+				labels.FlashTaskRun: req.Name,
+				labels.ResourceType: "jumpstarter-client",
 			},
 		},
 		Type: corev1.SecretTypeOpaque,
@@ -95,11 +96,11 @@ func createFlashOCIAuthSecret(
 			Name:      secretName,
 			Namespace: namespace,
 			Labels: map[string]string{
-				"app.kubernetes.io/managed-by":                  "build-api",
-				"app.kubernetes.io/part-of":                     "automotive-dev",
-				flashTaskRunLabel:                               flashName,
-				"automotive.sdv.cloud.redhat.com/transient":     "true",
-				"automotive.sdv.cloud.redhat.com/resource-type": "flash-oci-auth",
+				labels.ManagedBy:    labels.ValueBuildAPI,
+				labels.PartOf:       labels.ValueAutomotiveDev,
+				labels.FlashTaskRun: flashName,
+				labels.Transient:    labels.ValueTrue,
+				labels.ResourceType: "flash-oci-auth",
 			},
 		},
 		Type: corev1.SecretTypeOpaque,

--- a/internal/buildapi/flash_test.go
+++ b/internal/buildapi/flash_test.go
@@ -17,6 +17,7 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/labels"
 	"github.com/gin-gonic/gin"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // Dot import is standard for Ginkgo
@@ -49,10 +50,10 @@ var _ = Describe("Flash", func() {
 				Name:      name,
 				Namespace: "test-ns",
 				Labels: map[string]string{
-					flashTaskRunLabel: name,
+					labels.FlashTaskRun: name,
 				},
 				Annotations: map[string]string{
-					"automotive.sdv.cloud.redhat.com/requested-by": requestedBy,
+					labels.RequestedBy: requestedBy,
 				},
 				CreationTimestamp: metav1.NewTime(time.Now()),
 			},

--- a/internal/buildapi/progress.go
+++ b/internal/buildapi/progress.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/labels"
 )
 
 const (
@@ -77,8 +78,6 @@ type taskProgress struct {
 	marker   BuildStep
 }
 
-const progressAnnotation = "automotive.sdv.cloud.redhat.com/progress"
-
 // parseProgressAnnotation parses a pod annotation value with the format
 // "stage|done|total" (pipe-delimited) into a BuildStep.
 func parseProgressAnnotation(value string) (*BuildStep, bool) {
@@ -137,7 +136,7 @@ func readTaskProgressFromPods(ctx context.Context, cs *kubernetes.Clientset, pip
 	for _, pod := range pods.Items {
 		taskName := pod.Labels["tekton.dev/pipelineTask"]
 
-		if ann, ok := pod.Annotations[progressAnnotation]; ok {
+		if ann, ok := pod.Annotations[labels.Progress]; ok {
 			if step, parsed := parseProgressAnnotation(ann); parsed {
 				results = append(results, taskProgress{taskName: taskName, marker: *step})
 				continue

--- a/internal/buildapi/registry.go
+++ b/internal/buildapi/registry.go
@@ -1,0 +1,264 @@
+package buildapi
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	authnv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/labels"
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/tasks"
+)
+
+// defaultInternalRegistryURL is an alias for the shared constant.
+const defaultInternalRegistryURL = tasks.DefaultInternalRegistryURL
+
+func generateRegistryImageRef(host, namespace, imageName, tag string) string {
+	return fmt.Sprintf("%s/%s/%s:%s", host, namespace, imageName, tag)
+}
+
+func translateToExternalURL(internalURL, externalRouteHost string) string {
+	return strings.Replace(internalURL, defaultInternalRegistryURL, externalRouteHost, 1)
+}
+
+func getExternalRegistryRoute(ctx context.Context, k8sClient client.Client, namespace string) (string, error) {
+	operatorConfig := &automotivev1alpha1.OperatorConfig{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: "config", Namespace: namespace}, operatorConfig); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return "", fmt.Errorf("error reading OperatorConfig: %w", err)
+		}
+		// OperatorConfig not found, fall through to auto-detection
+	} else if operatorConfig.Spec.OSBuilds != nil && operatorConfig.Spec.OSBuilds.ClusterRegistryRoute != "" {
+		return operatorConfig.Spec.OSBuilds.ClusterRegistryRoute, nil
+	}
+
+	// Auto-detect from OpenShift Route
+	route := &unstructured.Unstructured{}
+	route.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "route.openshift.io",
+		Version: "v1",
+		Kind:    "Route",
+	})
+	if err := k8sClient.Get(ctx, types.NamespacedName{
+		Name:      "default-route",
+		Namespace: "openshift-image-registry",
+	}, route); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return "", fmt.Errorf("cannot determine external registry route: set clusterRegistryRoute in OperatorConfig or expose default-route in openshift-image-registry")
+		}
+		return "", fmt.Errorf("cannot determine external registry route: %w", err)
+	}
+
+	host, _, _ := unstructured.NestedString(route.Object, "spec", "host")
+	if host == "" {
+		return "", fmt.Errorf("default-route exists but has no host")
+	}
+	return host, nil
+}
+
+// resolveTokenLifetime loads the registry token lifetime from OperatorConfig.
+func resolveTokenLifetime(ctx context.Context, k8sClient client.Client, namespace string) int64 {
+	operatorCfg, err := loadOperatorConfigFn(ctx, k8sClient, namespace)
+	if err != nil || operatorCfg == nil || operatorCfg.Spec.OSBuilds == nil {
+		return automotivev1alpha1.DefaultRegistryTokenLifetimeSeconds
+	}
+	return operatorCfg.Spec.OSBuilds.GetRegistryTokenLifetimeSeconds()
+}
+
+func createInternalRegistrySecret(ctx context.Context, restCfg *rest.Config, namespace, buildName string, tokenLifetimeSeconds int64) (string, error) {
+	clientset, err := kubernetes.NewForConfig(restCfg)
+	if err != nil {
+		return "", fmt.Errorf("error creating clientset: %w", err)
+	}
+
+	expSeconds := tokenLifetimeSeconds
+	tokenReq := &authnv1.TokenRequest{
+		Spec: authnv1.TokenRequestSpec{
+			ExpirationSeconds: &expSeconds,
+		},
+	}
+	tokenResp, err := clientset.CoreV1().ServiceAccounts(namespace).
+		CreateToken(ctx, automotivev1alpha1.BuildServiceAccountName, tokenReq, metav1.CreateOptions{})
+	if err != nil {
+		return "", fmt.Errorf("error creating SA token: %w", err)
+	}
+
+	// Build dockerconfigjson
+	auth := base64.StdEncoding.EncodeToString([]byte("serviceaccount:" + tokenResp.Status.Token))
+	dockerConfig := fmt.Sprintf(`{"auths":{"%s":{"auth":"%s"}}}`, defaultInternalRegistryURL, auth)
+
+	secretName := buildName + "-registry-auth"
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				labels.ManagedBy:    labels.ValueBuildAPI,
+				labels.PartOf:       labels.ValueAutomotiveDev,
+				labels.ResourceType: "registry-auth",
+				labels.BuildName:    buildName,
+				labels.Transient:    labels.ValueTrue,
+			},
+		},
+		Type: corev1.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{
+			".dockerconfigjson": []byte(dockerConfig),
+		},
+	}
+
+	if _, err := clientset.CoreV1().Secrets(namespace).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
+		return "", fmt.Errorf("error creating internal registry secret: %w", err)
+	}
+	return secretName, nil
+}
+
+// ensureImageStream creates an ImageStream if it doesn't already exist.
+// The OpenShift internal registry requires an ImageStream before oras can push to it.
+func ensureImageStream(ctx context.Context, k8sClient client.Client, namespace, name string) (bool, error) {
+	is := &unstructured.Unstructured{}
+	is.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "image.openshift.io",
+		Version: "v1",
+		Kind:    "ImageStream",
+	})
+
+	// Check if it already exists
+	err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, is)
+	if err == nil {
+		return false, nil // already exists
+	}
+	if !k8serrors.IsNotFound(err) {
+		return false, fmt.Errorf("error checking ImageStream %s: %w", name, err)
+	}
+
+	// Create it
+	newIS := &unstructured.Unstructured{}
+	newIS.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "image.openshift.io",
+		Version: "v1",
+		Kind:    "ImageStream",
+	})
+	newIS.SetName(name)
+	newIS.SetNamespace(namespace)
+	newIS.SetLabels(map[string]string{
+		labels.ManagedBy: labels.ValueBuildAPI,
+		labels.PartOf:    labels.ValueAutomotiveDev,
+		labels.Transient: labels.ValueTrue,
+	})
+
+	if err := k8sClient.Create(ctx, newIS); err != nil {
+		if k8serrors.IsAlreadyExists(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("error creating ImageStream %s: %w", name, err)
+	}
+	return true, nil
+}
+
+func deleteImageStream(ctx context.Context, k8sClient client.Client, namespace, name string) error {
+	is := &unstructured.Unstructured{}
+	is.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "image.openshift.io",
+		Version: "v1",
+		Kind:    "ImageStream",
+	})
+	is.SetName(name)
+	is.SetNamespace(namespace)
+	return k8sClient.Delete(ctx, is)
+}
+
+func deleteImageStreamTag(ctx context.Context, k8sClient client.Client, namespace, stream, tag string) error {
+	ist := &unstructured.Unstructured{}
+	ist.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "image.openshift.io",
+		Version: "v1",
+		Kind:    "ImageStreamTag",
+	})
+	ist.SetName(stream + ":" + tag)
+	ist.SetNamespace(namespace)
+	return k8sClient.Delete(ctx, ist)
+}
+
+// imageStreamHasTags checks whether an ImageStream still has any tags.
+func imageStreamHasTags(ctx context.Context, k8sClient client.Client, namespace, name string) (bool, error) {
+	is := &unstructured.Unstructured{}
+	is.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "image.openshift.io",
+		Version: "v1",
+		Kind:    "ImageStream",
+	})
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, is); err != nil {
+		return false, err
+	}
+	tags, _, _ := unstructured.NestedSlice(is.Object, "status", "tags")
+	return len(tags) > 0, nil
+}
+
+// mintRegistryToken creates a fresh short-lived token for the pipeline SA
+// so the caller can pull images from the internal registry.
+func (a *APIServer) mintRegistryToken(ctx context.Context, c *gin.Context, namespace string, tokenLifetimeSeconds int64) (string, metav1.Time, error) {
+	restCfg, err := getRESTConfigFromRequest(c)
+	if err != nil {
+		return "", metav1.Time{}, fmt.Errorf("error getting REST config for token mint: %w", err)
+	}
+	clientset, err := kubernetes.NewForConfig(restCfg)
+	if err != nil {
+		return "", metav1.Time{}, fmt.Errorf("error creating clientset for token mint: %w", err)
+	}
+	expSeconds := tokenLifetimeSeconds
+	tokenReq := &authnv1.TokenRequest{
+		Spec: authnv1.TokenRequestSpec{
+			ExpirationSeconds: &expSeconds,
+		},
+	}
+	tokenResp, err := clientset.CoreV1().ServiceAccounts(namespace).
+		CreateToken(ctx, automotivev1alpha1.BuildServiceAccountName, tokenReq, metav1.CreateOptions{})
+	if err != nil {
+		return "", metav1.Time{}, fmt.Errorf("error creating token for SA %s in %s: %w", automotivev1alpha1.BuildServiceAccountName, namespace, err)
+	}
+	return tokenResp.Status.Token, tokenResp.Status.ExpirationTimestamp, nil
+}
+
+// resolveImageStreamRefs extracts the ImageStream name and the set of tags
+// this build pushed to from its internal registry URLs.
+// URL pattern: image-registry.openshift-image-registry.svc:5000/{namespace}/{stream}:{tag}
+func resolveImageStreamRefs(build *automotivev1alpha1.ImageBuild) (string, []string) {
+	prefix := defaultInternalRegistryURL + "/"
+	var streamName string
+	var tags []string
+	for _, ref := range []string{build.Spec.GetContainerPush(), build.Spec.GetExportOCI()} {
+		after, ok := strings.CutPrefix(ref, prefix)
+		if !ok {
+			continue
+		}
+		// "ns/name:tag" -> ["ns", "name:tag"]
+		parts := strings.SplitN(after, "/", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		// "name:tag" -> name, tag
+		nameTag := strings.SplitN(parts[1], ":", 2)
+		name := nameTag[0]
+		if name == "" {
+			continue
+		}
+		streamName = name
+		if len(nameTag) == 2 && nameTag[1] != "" {
+			tags = append(tags, nameTag[1])
+		}
+	}
+	return streamName, tags
+}

--- a/internal/buildapi/registry_test.go
+++ b/internal/buildapi/registry_test.go
@@ -1,0 +1,275 @@
+package buildapi
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // Dot import is standard for Ginkgo
+	. "github.com/onsi/gomega"    //nolint:revive // Dot import is standard for Gomega
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/labels"
+)
+
+var imageStreamGVK = schema.GroupVersionKind{
+	Group:   "image.openshift.io",
+	Version: "v1",
+	Kind:    "ImageStream",
+}
+
+var imageStreamTagGVK = schema.GroupVersionKind{
+	Group:   "image.openshift.io",
+	Version: "v1",
+	Kind:    "ImageStreamTag",
+}
+
+func newRegistryTestScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	Expect(automotivev1alpha1.AddToScheme(scheme)).To(Succeed())
+	Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	return scheme
+}
+
+func newRegistryTestClient(scheme *runtime.Scheme, objs ...client.Object) client.Client {
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+}
+
+func newUnstructuredImageStream(namespace, name string) *unstructured.Unstructured {
+	is := &unstructured.Unstructured{}
+	is.SetGroupVersionKind(imageStreamGVK)
+	is.SetName(name)
+	is.SetNamespace(namespace)
+	return is
+}
+
+func newUnstructuredImageStreamTag(namespace, stream, tag string) *unstructured.Unstructured {
+	ist := &unstructured.Unstructured{}
+	ist.SetGroupVersionKind(imageStreamTagGVK)
+	ist.SetName(stream + ":" + tag)
+	ist.SetNamespace(namespace)
+	return ist
+}
+
+var _ = Describe("Registry", func() {
+
+	Describe("ensureImageStream", func() {
+		It("creates ImageStream when it does not exist", func() {
+			scheme := newRegistryTestScheme()
+			k8sClient := newRegistryTestClient(scheme)
+
+			created, err := ensureImageStream(context.Background(), k8sClient, "ns", "my-stream")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(created).To(BeTrue())
+
+			// Verify it exists
+			is := &unstructured.Unstructured{}
+			is.SetGroupVersionKind(imageStreamGVK)
+			err = k8sClient.Get(context.Background(), types.NamespacedName{Name: "my-stream", Namespace: "ns"}, is)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(is.GetLabels()).To(HaveKeyWithValue(labels.ManagedBy, labels.ValueBuildAPI))
+			Expect(is.GetLabels()).To(HaveKeyWithValue(labels.Transient, labels.ValueTrue))
+		})
+
+		It("returns false when ImageStream already exists", func() {
+			scheme := newRegistryTestScheme()
+			existing := newUnstructuredImageStream("ns", "existing-stream")
+			k8sClient := newRegistryTestClient(scheme, existing)
+
+			created, err := ensureImageStream(context.Background(), k8sClient, "ns", "existing-stream")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(created).To(BeFalse())
+		})
+	})
+
+	Describe("deleteImageStream", func() {
+		It("deletes an existing ImageStream", func() {
+			scheme := newRegistryTestScheme()
+			existing := newUnstructuredImageStream("other-ns", "to-delete")
+			k8sClient := newRegistryTestClient(scheme, existing)
+
+			err := deleteImageStream(context.Background(), k8sClient, "other-ns", "to-delete")
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify deleted
+			is := &unstructured.Unstructured{}
+			is.SetGroupVersionKind(imageStreamGVK)
+			err = k8sClient.Get(context.Background(), types.NamespacedName{Name: "to-delete", Namespace: "other-ns"}, is)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns error when ImageStream does not exist", func() {
+			scheme := newRegistryTestScheme()
+			k8sClient := newRegistryTestClient(scheme)
+
+			err := deleteImageStream(context.Background(), k8sClient, "ns", "nonexistent")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("deleteImageStreamTag", func() {
+		It("deletes an existing ImageStreamTag", func() {
+			scheme := newRegistryTestScheme()
+			existing := newUnstructuredImageStreamTag("ns", "my-stream", "v1")
+			k8sClient := newRegistryTestClient(scheme, existing)
+
+			err := deleteImageStreamTag(context.Background(), k8sClient, "ns", "my-stream", "v1")
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify deleted
+			ist := &unstructured.Unstructured{}
+			ist.SetGroupVersionKind(imageStreamTagGVK)
+			err = k8sClient.Get(context.Background(), types.NamespacedName{Name: "my-stream:v1", Namespace: "ns"}, ist)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns error when ImageStreamTag does not exist", func() {
+			scheme := newRegistryTestScheme()
+			k8sClient := newRegistryTestClient(scheme)
+
+			err := deleteImageStreamTag(context.Background(), k8sClient, "ns", "my-stream", "v1")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("imageStreamHasTags", func() {
+		It("returns true when ImageStream has tags", func() {
+			scheme := newRegistryTestScheme()
+			is := newUnstructuredImageStream("ns", "tagged-stream")
+			// Set status.tags via unstructured
+			Expect(unstructured.SetNestedSlice(is.Object, []interface{}{
+				map[string]interface{}{"tag": "v1"},
+			}, "status", "tags")).To(Succeed())
+			k8sClient := newRegistryTestClient(scheme, is)
+
+			hasTags, err := imageStreamHasTags(context.Background(), k8sClient, "ns", "tagged-stream")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hasTags).To(BeTrue())
+		})
+
+		It("returns false when ImageStream has no tags", func() {
+			scheme := newRegistryTestScheme()
+			is := newUnstructuredImageStream("ns", "empty-stream")
+			k8sClient := newRegistryTestClient(scheme, is)
+
+			hasTags, err := imageStreamHasTags(context.Background(), k8sClient, "ns", "empty-stream")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hasTags).To(BeFalse())
+		})
+
+		It("returns error when ImageStream does not exist", func() {
+			scheme := newRegistryTestScheme()
+			k8sClient := newRegistryTestClient(scheme)
+
+			_, err := imageStreamHasTags(context.Background(), k8sClient, "ns", "missing")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("getExternalRegistryRoute", func() {
+		It("returns route from OperatorConfig when set", func() {
+			scheme := newRegistryTestScheme()
+			opConfig := &automotivev1alpha1.OperatorConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "config", Namespace: "ns"},
+				Spec: automotivev1alpha1.OperatorConfigSpec{
+					OSBuilds: &automotivev1alpha1.OSBuildsConfig{
+						ClusterRegistryRoute: "registry.apps.example.com",
+					},
+				},
+			}
+			k8sClient := newRegistryTestClient(scheme, opConfig)
+
+			route, err := getExternalRegistryRoute(context.Background(), k8sClient, "ns")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(route).To(Equal("registry.apps.example.com"))
+		})
+
+		It("returns error when no OperatorConfig and no Route", func() {
+			scheme := newRegistryTestScheme()
+			k8sClient := newRegistryTestClient(scheme)
+
+			_, err := getExternalRegistryRoute(context.Background(), k8sClient, "ns")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot determine external registry route"))
+		})
+	})
+
+	Describe("generateRegistryImageRef", func() {
+		It("formats host/namespace/image:tag", func() {
+			ref := generateRegistryImageRef("registry.example.com", "my-ns", "my-image", "v1")
+			Expect(ref).To(Equal("registry.example.com/my-ns/my-image:v1"))
+		})
+	})
+
+	Describe("translateToExternalURL", func() {
+		It("replaces internal registry URL with external route host", func() {
+			internal := "image-registry.openshift-image-registry.svc:5000/ns/stream:tag"
+			result := translateToExternalURL(internal, "registry.apps.example.com")
+			Expect(result).To(Equal("registry.apps.example.com/ns/stream:tag"))
+		})
+
+		It("returns unchanged URL when internal prefix not present", func() {
+			external := "quay.io/org/image:latest"
+			result := translateToExternalURL(external, "registry.apps.example.com")
+			Expect(result).To(Equal("quay.io/org/image:latest"))
+		})
+	})
+
+	Describe("resolveTokenLifetime", func() {
+		var originalFn func(ctx context.Context, c client.Client, ns string) (*automotivev1alpha1.OperatorConfig, error)
+
+		BeforeEach(func() {
+			originalFn = loadOperatorConfigFn
+		})
+
+		AfterEach(func() {
+			loadOperatorConfigFn = originalFn
+		})
+
+		It("returns default when loadOperatorConfigFn errors", func() {
+			loadOperatorConfigFn = func(_ context.Context, _ client.Client, _ string) (*automotivev1alpha1.OperatorConfig, error) {
+				return nil, fmt.Errorf("not found")
+			}
+			lifetime := resolveTokenLifetime(context.Background(), nil, "ns")
+			Expect(lifetime).To(Equal(automotivev1alpha1.DefaultRegistryTokenLifetimeSeconds))
+		})
+
+		It("returns default when OSBuilds is nil", func() {
+			loadOperatorConfigFn = func(_ context.Context, _ client.Client, _ string) (*automotivev1alpha1.OperatorConfig, error) {
+				return &automotivev1alpha1.OperatorConfig{}, nil
+			}
+			lifetime := resolveTokenLifetime(context.Background(), nil, "ns")
+			Expect(lifetime).To(Equal(automotivev1alpha1.DefaultRegistryTokenLifetimeSeconds))
+		})
+
+		It("returns custom value when set", func() {
+			loadOperatorConfigFn = func(_ context.Context, _ client.Client, _ string) (*automotivev1alpha1.OperatorConfig, error) {
+				return &automotivev1alpha1.OperatorConfig{
+					Spec: automotivev1alpha1.OperatorConfigSpec{
+						OSBuilds: &automotivev1alpha1.OSBuildsConfig{
+							RegistryTokenLifetimeSeconds: 7200,
+						},
+					},
+				}, nil
+			}
+			lifetime := resolveTokenLifetime(context.Background(), nil, "ns")
+			Expect(lifetime).To(Equal(int64(7200)))
+		})
+
+		It("returns default when config is nil", func() {
+			loadOperatorConfigFn = func(_ context.Context, _ client.Client, _ string) (*automotivev1alpha1.OperatorConfig, error) {
+				return nil, nil
+			}
+			lifetime := resolveTokenLifetime(context.Background(), nil, "ns")
+			Expect(lifetime).To(Equal(automotivev1alpha1.DefaultRegistryTokenLifetimeSeconds))
+		})
+	})
+
+})

--- a/internal/buildapi/secrets.go
+++ b/internal/buildapi/secrets.go
@@ -1,0 +1,246 @@
+package buildapi
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/labels"
+)
+
+const (
+	authTypeUsernamePassword = "username-password"
+	authTypeToken            = "token"
+	authTypeDockerConfig     = "docker-config"
+)
+
+var errRegistryCredentialsRequiredForPush = errors.New("registry credentials are required when push repository is specified")
+
+func setSecretOwnerRef(
+	ctx context.Context,
+	c client.Client,
+	namespace, secretName string,
+	owner *automotivev1alpha1.ImageBuild,
+) error {
+	secret := &corev1.Secret{}
+	if err := c.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, secret); err != nil {
+		return err
+	}
+	secret.OwnerReferences = []metav1.OwnerReference{
+		*metav1.NewControllerRef(owner, automotivev1alpha1.GroupVersion.WithKind("ImageBuild")),
+	}
+	return c.Update(ctx, secret)
+}
+
+// createFlashClientSecret creates a secret containing the Jumpstarter client config
+func createFlashClientSecret(
+	ctx context.Context,
+	c client.Client,
+	namespace, secretName, base64Config string,
+) error {
+	configBytes, err := base64.StdEncoding.DecodeString(base64Config)
+	if err != nil {
+		return fmt.Errorf("failed to decode client config: %w", err)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				labels.ManagedBy: labels.ValueBuildAPI,
+				labels.PartOf:    labels.ValueAutomotiveDev,
+				labels.Component: "jumpstarter-client",
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"client.yaml": configBytes,
+		},
+	}
+
+	return c.Create(ctx, secret)
+}
+
+func createRegistrySecret(
+	ctx context.Context, k8sClient client.Client, namespace, buildName string, creds *RegistryCredentials,
+) (string, error) {
+	if creds == nil || !creds.Enabled {
+		return "", nil
+	}
+
+	secretName := fmt.Sprintf("%s-external-registry-auth", buildName)
+	secretData := make(map[string][]byte)
+
+	switch creds.AuthType {
+	case authTypeUsernamePassword:
+		if creds.RegistryURL == "" || creds.Username == "" || creds.Password == "" {
+			return "", fmt.Errorf("registry URL, username, and password are required for username-password authentication")
+		}
+		secretData["REGISTRY_URL"] = []byte(creds.RegistryURL)
+		secretData["REGISTRY_USERNAME"] = []byte(creds.Username)
+		secretData["REGISTRY_PASSWORD"] = []byte(creds.Password)
+
+		// Also create dockerconfigjson format for tools that need it (oras, skopeo, etc.)
+		auth := base64.StdEncoding.EncodeToString([]byte(creds.Username + ":" + creds.Password))
+		dockerConfig, err := json.Marshal(map[string]interface{}{
+			"auths": map[string]interface{}{
+				creds.RegistryURL: map[string]string{
+					"auth": auth,
+				},
+			},
+		})
+		if err != nil {
+			return "", fmt.Errorf("failed to create docker config: %w", err)
+		}
+		secretData[".dockerconfigjson"] = dockerConfig
+	case authTypeToken:
+		if creds.RegistryURL == "" || creds.Token == "" {
+			return "", fmt.Errorf("registry URL and token are required for token authentication")
+		}
+		secretData["REGISTRY_URL"] = []byte(creds.RegistryURL)
+		secretData["REGISTRY_TOKEN"] = []byte(creds.Token)
+	case authTypeDockerConfig:
+		if creds.DockerConfig == "" {
+			return "", fmt.Errorf("docker config is required for docker-config authentication")
+		}
+		secretData["REGISTRY_AUTH_FILE_CONTENT"] = []byte(creds.DockerConfig)
+		secretData[".dockerconfigjson"] = []byte(creds.DockerConfig)
+	default:
+		return "", fmt.Errorf("unsupported authentication type: %s", creds.AuthType)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				labels.ManagedBy:    labels.ValueBuildAPI,
+				labels.PartOf:       labels.ValueAutomotiveDev,
+				labels.CreatedBy:    labels.ValueBuildAPICreator,
+				labels.ResourceType: "registry-auth",
+				labels.BuildName:    buildName,
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: secretData,
+	}
+
+	if err := k8sClient.Create(ctx, secret); err != nil {
+		return "", fmt.Errorf("failed to create registry secret: %w", err)
+	}
+
+	return secretName, nil
+}
+
+// createPushSecret creates a kubernetes.io/dockerconfigjson secret for pushing artifacts to a registry
+func createPushSecret(
+	ctx context.Context, k8sClient client.Client, namespace, buildName string, creds *RegistryCredentials,
+) (string, error) {
+	if creds == nil || !creds.Enabled {
+		return "", fmt.Errorf("registry credentials are required for push")
+	}
+
+	secretName := fmt.Sprintf("%s-push-auth", buildName)
+
+	var dockerConfigJSON []byte
+	var err error
+
+	switch creds.AuthType {
+	case authTypeUsernamePassword:
+		if creds.RegistryURL == "" || creds.Username == "" || creds.Password == "" {
+			return "", fmt.Errorf("registry URL, username, and password are required for push")
+		}
+		auth := base64.StdEncoding.EncodeToString([]byte(creds.Username + ":" + creds.Password))
+		dockerConfigJSON, err = json.Marshal(map[string]interface{}{
+			"auths": map[string]interface{}{
+				creds.RegistryURL: map[string]string{
+					"auth": auth,
+				},
+			},
+		})
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal docker config: %w", err)
+		}
+	case authTypeToken:
+		if creds.RegistryURL == "" || creds.Token == "" {
+			return "", fmt.Errorf("registry URL and token are required for push with token auth")
+		}
+		auth := base64.StdEncoding.EncodeToString([]byte(":" + creds.Token))
+		dockerConfigJSON, err = json.Marshal(map[string]interface{}{
+			"auths": map[string]interface{}{
+				creds.RegistryURL: map[string]string{
+					"auth": auth,
+				},
+			},
+		})
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal docker config: %w", err)
+		}
+	case authTypeDockerConfig:
+		if creds.DockerConfig == "" {
+			return "", fmt.Errorf("docker config is required for push with docker-config auth")
+		}
+		dockerConfigJSON = []byte(creds.DockerConfig)
+	default:
+		return "", fmt.Errorf("unsupported authentication type for push: %s", creds.AuthType)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				labels.ManagedBy:    labels.ValueBuildAPI,
+				labels.PartOf:       labels.ValueAutomotiveDev,
+				labels.CreatedBy:    labels.ValueBuildAPICreator,
+				labels.ResourceType: "push-auth",
+				labels.BuildName:    buildName,
+				labels.Transient:    labels.ValueTrue,
+			},
+		},
+		Type: corev1.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{
+			".dockerconfigjson": dockerConfigJSON,
+		},
+	}
+
+	if err := k8sClient.Create(ctx, secret); err != nil {
+		return "", fmt.Errorf("failed to create push secret: %w", err)
+	}
+
+	return secretName, nil
+}
+
+// setupBuildSecrets creates necessary secrets for the build
+func setupBuildSecrets(
+	ctx context.Context, k8sClient client.Client,
+	namespace string, req *BuildRequest,
+) (envSecretRef, pushSecretName string, err error) {
+	if req.RegistryCredentials != nil && req.RegistryCredentials.Enabled {
+		envSecretRef, err = createRegistrySecret(ctx, k8sClient, namespace, req.Name, req.RegistryCredentials)
+		if err != nil {
+			return "", "", fmt.Errorf("error creating registry secret: %w", err)
+		}
+	}
+
+	if req.PushRepository != "" || req.ExportOCI != "" {
+		if req.RegistryCredentials == nil || !req.RegistryCredentials.Enabled {
+			return "", "", errRegistryCredentialsRequiredForPush
+		}
+		pushSecretName, err = createPushSecret(ctx, k8sClient, namespace, req.Name, req.RegistryCredentials)
+		if err != nil {
+			return "", "", fmt.Errorf("error creating push secret: %w", err)
+		}
+	}
+
+	return envSecretRef, pushSecretName, nil
+}

--- a/internal/buildapi/secrets_test.go
+++ b/internal/buildapi/secrets_test.go
@@ -1,0 +1,82 @@
+package buildapi
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // Dot import is standard for Ginkgo
+	. "github.com/onsi/gomega"    //nolint:revive // Dot import is standard for Gomega
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/labels"
+)
+
+var _ = Describe("Secrets", func() {
+
+	Describe("setSecretOwnerRef", func() {
+		It("sets owner reference on secret", func() {
+			scheme := newRegistryTestScheme()
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret",
+					Namespace: "ns",
+				},
+			}
+			build := &automotivev1alpha1.ImageBuild{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-build",
+					Namespace: "ns",
+					UID:       "abc-123",
+				},
+			}
+			k8sClient := newRegistryTestClient(scheme, secret, build)
+
+			err := setSecretOwnerRef(context.Background(), k8sClient, "ns", "test-secret", build)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify owner ref was set
+			updated := &corev1.Secret{}
+			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: "test-secret", Namespace: "ns"}, updated)).To(Succeed())
+			Expect(updated.OwnerReferences).To(HaveLen(1))
+			Expect(updated.OwnerReferences[0].Name).To(Equal("my-build"))
+		})
+
+		It("returns error when secret does not exist", func() {
+			scheme := newRegistryTestScheme()
+			k8sClient := newRegistryTestClient(scheme)
+			build := &automotivev1alpha1.ImageBuild{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-build", Namespace: "ns"},
+			}
+
+			err := setSecretOwnerRef(context.Background(), k8sClient, "ns", "missing-secret", build)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("createFlashClientSecret", func() {
+		It("creates secret with decoded base64 config", func() {
+			scheme := newRegistryTestScheme()
+			k8sClient := newRegistryTestClient(scheme)
+
+			// "hello world" in base64
+			err := createFlashClientSecret(context.Background(), k8sClient, "ns", "flash-secret", "aGVsbG8gd29ybGQ=")
+			Expect(err).NotTo(HaveOccurred())
+
+			secret := &corev1.Secret{}
+			Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: "flash-secret", Namespace: "ns"}, secret)).To(Succeed())
+			Expect(secret.Data["client.yaml"]).To(Equal([]byte("hello world")))
+			Expect(secret.Labels).To(HaveKeyWithValue(labels.Component, "jumpstarter-client"))
+		})
+
+		It("returns error for invalid base64", func() {
+			scheme := newRegistryTestScheme()
+			k8sClient := newRegistryTestClient(scheme)
+
+			err := createFlashClientSecret(context.Background(), k8sClient, "ns", "bad-secret", "not-valid-base64!!!")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("decode"))
+		})
+	})
+})

--- a/internal/buildapi/server.go
+++ b/internal/buildapi/server.go
@@ -29,9 +29,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	apiserverv1beta1 "k8s.io/apiserver/pkg/apis/apiserver/v1beta1"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
@@ -44,7 +42,7 @@ import (
 
 	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
 	"github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi/catalog"
-	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/tasks"
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/labels"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	authnv1 "k8s.io/api/authentication/v1"
 )
@@ -70,17 +68,9 @@ const (
 	statusMissing  = "MISSING"
 	buildAPIName   = "ado-build-api"
 
-	// Flash TaskRun constants
-	flashTaskRunLabel = "automotive.sdv.cloud.redhat.com/flash-taskrun"
-
 	// maxManifestSize is the maximum allowed manifest size in bytes.
 	// Manifests are stored in ConfigMaps, which are limited by etcd's ~1MB object size.
 	maxManifestSize = 900 * 1024
-
-	// Registry auth type constants
-	authTypeUsernamePassword = "username-password"
-	authTypeToken            = "token"
-	authTypeDockerConfig     = "docker-config"
 )
 
 var getClientFromRequestFn = getClientFromRequest
@@ -106,7 +96,6 @@ var newPodExecExecutorFn = func(
 		}, kscheme.ParameterCodec)
 	return remotecommand.NewSPDYExecutor(config, http.MethodPost, req.URL())
 }
-var errRegistryCredentialsRequiredForPush = errors.New("registry credentials are required when push repository is specified")
 var loadOperatorConfigFn = func(
 	ctx context.Context,
 	k8sClient client.Client,
@@ -160,204 +149,6 @@ var loadTargetDefaultsFn = func(
 		}
 	}
 	return result, nil
-}
-
-// defaultInternalRegistryURL is an alias for the shared constant.
-const defaultInternalRegistryURL = tasks.DefaultInternalRegistryURL
-
-func generateRegistryImageRef(host, namespace, imageName, tag string) string {
-	return fmt.Sprintf("%s/%s/%s:%s", host, namespace, imageName, tag)
-}
-
-func translateToExternalURL(internalURL, externalRouteHost string) string {
-	return strings.Replace(internalURL, defaultInternalRegistryURL, externalRouteHost, 1)
-}
-
-func getExternalRegistryRoute(ctx context.Context, k8sClient client.Client, namespace string) (string, error) {
-	operatorConfig := &automotivev1alpha1.OperatorConfig{}
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: "config", Namespace: namespace}, operatorConfig); err != nil {
-		if !k8serrors.IsNotFound(err) {
-			return "", fmt.Errorf("error reading OperatorConfig: %w", err)
-		}
-		// OperatorConfig not found, fall through to auto-detection
-	} else if operatorConfig.Spec.OSBuilds != nil && operatorConfig.Spec.OSBuilds.ClusterRegistryRoute != "" {
-		return operatorConfig.Spec.OSBuilds.ClusterRegistryRoute, nil
-	}
-
-	// Auto-detect from OpenShift Route
-	route := &unstructured.Unstructured{}
-	route.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "route.openshift.io",
-		Version: "v1",
-		Kind:    "Route",
-	})
-	if err := k8sClient.Get(ctx, types.NamespacedName{
-		Name:      "default-route",
-		Namespace: "openshift-image-registry",
-	}, route); err != nil {
-		return "", fmt.Errorf("cannot determine external registry route: set clusterRegistryRoute in OperatorConfig or expose default-route in openshift-image-registry")
-	}
-
-	host, _, _ := unstructured.NestedString(route.Object, "spec", "host")
-	if host == "" {
-		return "", fmt.Errorf("default-route exists but has no host")
-	}
-	return host, nil
-}
-
-func createInternalRegistrySecret(ctx context.Context, restCfg *rest.Config, namespace, buildName string) (string, error) {
-	clientset, err := kubernetes.NewForConfig(restCfg)
-	if err != nil {
-		return "", fmt.Errorf("error creating clientset: %w", err)
-	}
-
-	// Request a 4-hour token for the pipeline SA (covers build + push duration)
-	expSeconds := int64(4 * 3600)
-	tokenReq := &authnv1.TokenRequest{
-		Spec: authnv1.TokenRequestSpec{
-			ExpirationSeconds: &expSeconds,
-		},
-	}
-	tokenResp, err := clientset.CoreV1().ServiceAccounts(namespace).
-		CreateToken(ctx, automotivev1alpha1.BuildServiceAccountName, tokenReq, metav1.CreateOptions{})
-	if err != nil {
-		return "", fmt.Errorf("error creating SA token: %w", err)
-	}
-
-	// Build dockerconfigjson
-	auth := base64.StdEncoding.EncodeToString([]byte("serviceaccount:" + tokenResp.Status.Token))
-	dockerConfig := fmt.Sprintf(`{"auths":{"%s":{"auth":"%s"}}}`, defaultInternalRegistryURL, auth)
-
-	secretName := buildName + "-registry-auth"
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretName,
-			Namespace: namespace,
-			Labels: map[string]string{
-				"app.kubernetes.io/managed-by":                  "build-api",
-				"app.kubernetes.io/part-of":                     "automotive-dev",
-				"automotive.sdv.cloud.redhat.com/resource-type": "registry-auth",
-				"automotive.sdv.cloud.redhat.com/build-name":    buildName,
-				"automotive.sdv.cloud.redhat.com/transient":     "true",
-			},
-		},
-		Type: corev1.SecretTypeDockerConfigJson,
-		Data: map[string][]byte{
-			".dockerconfigjson": []byte(dockerConfig),
-		},
-	}
-
-	if _, err := clientset.CoreV1().Secrets(namespace).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
-		return "", fmt.Errorf("error creating internal registry secret: %w", err)
-	}
-	return secretName, nil
-}
-
-// ensureImageStream creates an ImageStream if it doesn't already exist.
-// The OpenShift internal registry requires an ImageStream before oras can push to it.
-func ensureImageStream(ctx context.Context, k8sClient client.Client, namespace, name string) (bool, error) {
-	is := &unstructured.Unstructured{}
-	is.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "image.openshift.io",
-		Version: "v1",
-		Kind:    "ImageStream",
-	})
-
-	// Check if it already exists
-	err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, is)
-	if err == nil {
-		return false, nil // already exists
-	}
-	if !k8serrors.IsNotFound(err) {
-		return false, fmt.Errorf("error checking ImageStream %s: %w", name, err)
-	}
-
-	// Create it
-	newIS := &unstructured.Unstructured{}
-	newIS.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "image.openshift.io",
-		Version: "v1",
-		Kind:    "ImageStream",
-	})
-	newIS.SetName(name)
-	newIS.SetNamespace(namespace)
-	newIS.SetLabels(map[string]string{
-		"app.kubernetes.io/managed-by":              "build-api",
-		"app.kubernetes.io/part-of":                 "automotive-dev",
-		"automotive.sdv.cloud.redhat.com/transient": "true",
-	})
-
-	if err := k8sClient.Create(ctx, newIS); err != nil {
-		if k8serrors.IsAlreadyExists(err) {
-			return false, nil
-		}
-		return false, fmt.Errorf("error creating ImageStream %s: %w", name, err)
-	}
-	return true, nil
-}
-
-func deleteImageStream(ctx context.Context, k8sClient client.Client, namespace, name string) error {
-	is := &unstructured.Unstructured{}
-	is.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "image.openshift.io",
-		Version: "v1",
-		Kind:    "ImageStream",
-	})
-	is.SetName(name)
-	is.SetNamespace(namespace)
-	return k8sClient.Delete(ctx, is)
-}
-
-func deleteImageStreamTag(ctx context.Context, k8sClient client.Client, namespace, stream, tag string) error {
-	ist := &unstructured.Unstructured{}
-	ist.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "image.openshift.io",
-		Version: "v1",
-		Kind:    "ImageStreamTag",
-	})
-	ist.SetName(stream + ":" + tag)
-	ist.SetNamespace(namespace)
-	return k8sClient.Delete(ctx, ist)
-}
-
-// imageStreamHasTags checks whether an ImageStream still has any tags.
-func imageStreamHasTags(ctx context.Context, k8sClient client.Client, namespace, name string) (bool, error) {
-	is := &unstructured.Unstructured{}
-	is.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "image.openshift.io",
-		Version: "v1",
-		Kind:    "ImageStream",
-	})
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, is); err != nil {
-		return false, err
-	}
-	tags, _, _ := unstructured.NestedSlice(is.Object, "status", "tags")
-	return len(tags) > 0, nil
-}
-
-// mintRegistryToken creates a fresh short-lived token for the pipeline SA
-// so the caller can pull images from the internal registry.
-func (a *APIServer) mintRegistryToken(ctx context.Context, c *gin.Context, namespace string) (string, metav1.Time, error) {
-	restCfg, err := getRESTConfigFromRequest(c)
-	if err != nil {
-		return "", metav1.Time{}, fmt.Errorf("error getting REST config for token mint: %w", err)
-	}
-	clientset, err := kubernetes.NewForConfig(restCfg)
-	if err != nil {
-		return "", metav1.Time{}, fmt.Errorf("error creating clientset for token mint: %w", err)
-	}
-	expSeconds := int64(4 * 3600)
-	tokenReq := &authnv1.TokenRequest{
-		Spec: authnv1.TokenRequestSpec{
-			ExpirationSeconds: &expSeconds,
-		},
-	}
-	tokenResp, err := clientset.CoreV1().ServiceAccounts(namespace).
-		CreateToken(ctx, automotivev1alpha1.BuildServiceAccountName, tokenReq, metav1.CreateOptions{})
-	if err != nil {
-		return "", metav1.Time{}, fmt.Errorf("error creating token for SA %s in %s: %w", automotivev1alpha1.BuildServiceAccountName, namespace, err)
-	}
-	return tokenResp.Status.Token, tokenResp.Status.ExpirationTimestamp, nil
 }
 
 // APILimits holds configurable limits for the API server
@@ -736,7 +527,7 @@ func (a *APIServer) handleCreateBuildToken(c *gin.Context) {
 
 	// Verify the requesting user owns this build
 	requester := a.resolveRequester(c)
-	owner := build.Annotations["automotive.sdv.cloud.redhat.com/requested-by"]
+	owner := build.Annotations[labels.RequestedBy]
 	if owner != requester {
 		c.JSON(http.StatusForbidden, gin.H{"error": "you can only request tokens for your own builds"})
 		return
@@ -762,7 +553,8 @@ func (a *APIServer) handleCreateBuildToken(c *gin.Context) {
 		return
 	}
 
-	token, expiresAt, err := a.mintRegistryToken(ctx, c, namespace)
+	tokenLifetime := resolveTokenLifetime(ctx, k8sClient, namespace)
+	token, expiresAt, err := a.mintRegistryToken(ctx, c, namespace, tokenLifetime)
 	if err != nil {
 		a.log.Error(err, "failed to mint registry token", "build", name)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to mint registry token: %v", err)})
@@ -814,7 +606,7 @@ func (a *APIServer) deleteBuild(c *gin.Context, name string) {
 	}
 
 	requester := a.resolveRequester(c)
-	owner := build.Annotations["automotive.sdv.cloud.redhat.com/requested-by"]
+	owner := build.Annotations[labels.RequestedBy]
 	if owner != requester {
 		c.JSON(http.StatusForbidden, gin.H{"error": "you can only delete your own builds"})
 		return
@@ -886,7 +678,7 @@ func (a *APIServer) cancelBuild(c *gin.Context, name string) {
 	}
 
 	requester := a.resolveRequester(c)
-	owner := build.Annotations["automotive.sdv.cloud.redhat.com/requested-by"]
+	owner := build.Annotations[labels.RequestedBy]
 	if owner != requester {
 		c.JSON(http.StatusForbidden, gin.H{"error": "you can only cancel your own builds"})
 		return
@@ -943,37 +735,6 @@ func (a *APIServer) cancelBuild(c *gin.Context, name string) {
 	c.JSON(http.StatusOK, gin.H{"message": fmt.Sprintf("build %q cancelled", name)})
 }
 
-// resolveImageStreamRefs extracts the ImageStream name and the set of tags
-// this build pushed to from its internal registry URLs.
-// URL pattern: image-registry.openshift-image-registry.svc:5000/{namespace}/{stream}:{tag}
-func resolveImageStreamRefs(build *automotivev1alpha1.ImageBuild) (string, []string) {
-	prefix := defaultInternalRegistryURL + "/"
-	var streamName string
-	var tags []string
-	for _, ref := range []string{build.Spec.GetContainerPush(), build.Spec.GetExportOCI()} {
-		after, ok := strings.CutPrefix(ref, prefix)
-		if !ok {
-			continue
-		}
-		// "ns/name:tag" -> ["ns", "name:tag"]
-		parts := strings.SplitN(after, "/", 2)
-		if len(parts) < 2 {
-			continue
-		}
-		// "name:tag" -> name, tag
-		nameTag := strings.SplitN(parts[1], ":", 2)
-		name := nameTag[0]
-		if name == "" {
-			continue
-		}
-		streamName = name
-		if len(nameTag) == 2 && nameTag[1] != "" {
-			tags = append(tags, nameTag[1])
-		}
-	}
-	return streamName, tags
-}
-
 func (a *APIServer) handleStreamLogs(c *gin.Context) {
 	name := c.Param("name")
 	a.log.Info("logs requested", "build", name, "reqID", c.GetString("reqID"))
@@ -990,158 +751,6 @@ func (a *APIServer) handleUploadFiles(c *gin.Context) {
 	name := c.Param("name")
 	a.log.Info("uploads", "build", name, "reqID", c.GetString("reqID"))
 	a.uploadFiles(c, name)
-}
-
-func createRegistrySecret(
-	ctx context.Context, k8sClient client.Client, namespace, buildName string, creds *RegistryCredentials,
-) (string, error) {
-	if creds == nil || !creds.Enabled {
-		return "", nil
-	}
-
-	secretName := fmt.Sprintf("%s-external-registry-auth", buildName)
-	secretData := make(map[string][]byte)
-
-	switch creds.AuthType {
-	case authTypeUsernamePassword:
-		if creds.RegistryURL == "" || creds.Username == "" || creds.Password == "" {
-			return "", fmt.Errorf("registry URL, username, and password are required for username-password authentication")
-		}
-		secretData["REGISTRY_URL"] = []byte(creds.RegistryURL)
-		secretData["REGISTRY_USERNAME"] = []byte(creds.Username)
-		secretData["REGISTRY_PASSWORD"] = []byte(creds.Password)
-
-		// Also create dockerconfigjson format for tools that need it (oras, skopeo, etc.)
-		auth := base64.StdEncoding.EncodeToString([]byte(creds.Username + ":" + creds.Password))
-		dockerConfig, err := json.Marshal(map[string]interface{}{
-			"auths": map[string]interface{}{
-				creds.RegistryURL: map[string]string{
-					"auth": auth,
-				},
-			},
-		})
-		if err != nil {
-			return "", fmt.Errorf("failed to create docker config: %w", err)
-		}
-		secretData[".dockerconfigjson"] = dockerConfig
-	case authTypeToken:
-		if creds.RegistryURL == "" || creds.Token == "" {
-			return "", fmt.Errorf("registry URL and token are required for token authentication")
-		}
-		secretData["REGISTRY_URL"] = []byte(creds.RegistryURL)
-		secretData["REGISTRY_TOKEN"] = []byte(creds.Token)
-	case authTypeDockerConfig:
-		if creds.DockerConfig == "" {
-			return "", fmt.Errorf("docker config is required for docker-config authentication")
-		}
-		secretData["REGISTRY_AUTH_FILE_CONTENT"] = []byte(creds.DockerConfig)
-		secretData[".dockerconfigjson"] = []byte(creds.DockerConfig)
-	default:
-		return "", fmt.Errorf("unsupported authentication type: %s", creds.AuthType)
-	}
-
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretName,
-			Namespace: namespace,
-			Labels: map[string]string{
-				"app.kubernetes.io/managed-by":                  "build-api",
-				"app.kubernetes.io/part-of":                     "automotive-dev",
-				"app.kubernetes.io/created-by":                  "automotive-dev-build-api",
-				"automotive.sdv.cloud.redhat.com/resource-type": "registry-auth",
-				"automotive.sdv.cloud.redhat.com/build-name":    buildName,
-			},
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: secretData,
-	}
-
-	if err := k8sClient.Create(ctx, secret); err != nil {
-		return "", fmt.Errorf("failed to create registry secret: %w", err)
-	}
-
-	return secretName, nil
-}
-
-// createPushSecret creates a kubernetes.io/dockerconfigjson secret for pushing artifacts to a registry
-func createPushSecret(
-	ctx context.Context, k8sClient client.Client, namespace, buildName string, creds *RegistryCredentials,
-) (string, error) {
-	if creds == nil || !creds.Enabled {
-		return "", fmt.Errorf("registry credentials are required for push")
-	}
-
-	secretName := fmt.Sprintf("%s-push-auth", buildName)
-
-	var dockerConfigJSON []byte
-	var err error
-
-	switch creds.AuthType {
-	case authTypeUsernamePassword:
-		if creds.RegistryURL == "" || creds.Username == "" || creds.Password == "" {
-			return "", fmt.Errorf("registry URL, username, and password are required for push")
-		}
-		// Create dockerconfigjson format
-		auth := base64.StdEncoding.EncodeToString([]byte(creds.Username + ":" + creds.Password))
-		dockerConfigJSON, err = json.Marshal(map[string]interface{}{
-			"auths": map[string]interface{}{
-				creds.RegistryURL: map[string]string{
-					"auth": auth,
-				},
-			},
-		})
-		if err != nil {
-			return "", fmt.Errorf("failed to marshal docker config: %w", err)
-		}
-	case authTypeToken:
-		if creds.RegistryURL == "" || creds.Token == "" {
-			return "", fmt.Errorf("registry URL and token are required for push with token auth")
-		}
-		// For token auth, use the token as password with empty username
-		auth := base64.StdEncoding.EncodeToString([]byte(":" + creds.Token))
-		dockerConfigJSON, err = json.Marshal(map[string]interface{}{
-			"auths": map[string]interface{}{
-				creds.RegistryURL: map[string]string{
-					"auth": auth,
-				},
-			},
-		})
-		if err != nil {
-			return "", fmt.Errorf("failed to marshal docker config: %w", err)
-		}
-	case authTypeDockerConfig:
-		if creds.DockerConfig == "" {
-			return "", fmt.Errorf("docker config is required for push with docker-config auth")
-		}
-		dockerConfigJSON = []byte(creds.DockerConfig)
-	default:
-		return "", fmt.Errorf("unsupported authentication type for push: %s", creds.AuthType)
-	}
-
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretName,
-			Namespace: namespace,
-			Labels: map[string]string{
-				"app.kubernetes.io/managed-by":                  "build-api",
-				"app.kubernetes.io/part-of":                     "automotive-dev",
-				"app.kubernetes.io/created-by":                  "automotive-dev-build-api",
-				"automotive.sdv.cloud.redhat.com/resource-type": "push-auth",
-				"automotive.sdv.cloud.redhat.com/build-name":    buildName,
-				"automotive.sdv.cloud.redhat.com/transient":     "true",
-			},
-		},
-		Type: corev1.SecretTypeDockerConfigJson,
-		Data: map[string][]byte{
-			".dockerconfigjson": dockerConfigJSON,
-		},
-	}
-
-	if err := k8sClient.Create(ctx, secret); err != nil {
-		return "", fmt.Errorf("failed to create push secret: %w", err)
-	}
-
-	return secretName, nil
 }
 
 // validateBuildRequest validates the build request, sanitizes the name, and applies defaults
@@ -1260,32 +869,6 @@ func applyBuildDefaults(req *BuildRequest) error {
 	return nil
 }
 
-// setupBuildSecrets creates necessary secrets for the build
-func setupBuildSecrets(
-	ctx context.Context, k8sClient client.Client,
-	namespace string, req *BuildRequest,
-) (envSecretRef, pushSecretName string, err error) {
-	if req.RegistryCredentials != nil && req.RegistryCredentials.Enabled {
-		envSecretRef, err = createRegistrySecret(ctx, k8sClient, namespace, req.Name, req.RegistryCredentials)
-		if err != nil {
-			return "", "", fmt.Errorf("error creating registry secret: %w", err)
-		}
-	}
-
-	// Create push secret if pushing to registry (PushRepository for bootc, ExportOCI for disk images)
-	if req.PushRepository != "" || req.ExportOCI != "" {
-		if req.RegistryCredentials == nil || !req.RegistryCredentials.Enabled {
-			return "", "", errRegistryCredentialsRequiredForPush
-		}
-		pushSecretName, err = createPushSecret(ctx, k8sClient, namespace, req.Name, req.RegistryCredentials)
-		if err != nil {
-			return "", "", fmt.Errorf("error creating push secret: %w", err)
-		}
-	}
-
-	return envSecretRef, pushSecretName, nil
-}
-
 // resolveRegistryForBuild handles registry setup for both internal and external registry builds.
 // It returns envSecretRef, pushSecretName, and an error (non-nil means the response was already written).
 func (a *APIServer) resolveRegistryForBuild(
@@ -1401,7 +984,8 @@ func (a *APIServer) setupInternalRegistryBuild(
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("error getting REST config: %v", err)})
 		return "", "", err
 	}
-	secretName, err := createInternalRegistrySecret(ctx, restCfg, namespace, req.Name)
+	tokenLifetime := resolveTokenLifetime(ctx, k8sClient, namespace)
+	secretName, err := createInternalRegistrySecret(ctx, restCfg, namespace, req.Name, tokenLifetime)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return "", "", err
@@ -1565,8 +1149,8 @@ func (a *APIServer) resolveWorkspaceForBuild(ctx context.Context, k8sClient clie
 
 	// Find existing build-cache PVC via labels, or create a new one
 	buildCacheLabels := map[string]string{
-		"automotive.sdv.cloud.redhat.com/workspace": wsName,
-		"app.kubernetes.io/component":               "build-cache",
+		labels.Workspace: wsName,
+		labels.Component: "build-cache",
 	}
 	pvcList := &corev1.PersistentVolumeClaimList{}
 	if err := k8sClient.List(ctx, pvcList,
@@ -1757,13 +1341,13 @@ func (a *APIServer) createBuild(c *gin.Context) {
 		return
 	}
 
-	labels := map[string]string{
-		"app.kubernetes.io/managed-by":                 "build-api",
-		"app.kubernetes.io/part-of":                    "automotive-dev",
-		"app.kubernetes.io/created-by":                 "automotive-dev-build-api",
-		"automotive.sdv.cloud.redhat.com/distro":       string(req.Distro),
-		"automotive.sdv.cloud.redhat.com/target":       string(req.Target),
-		"automotive.sdv.cloud.redhat.com/architecture": string(req.Architecture),
+	buildLabels := map[string]string{
+		labels.ManagedBy:    labels.ValueBuildAPI,
+		labels.PartOf:       labels.ValueAutomotiveDev,
+		labels.CreatedBy:    labels.ValueBuildAPICreator,
+		labels.Distro:       string(req.Distro),
+		labels.Target:       string(req.Target),
+		labels.Architecture: string(req.Architecture),
 	}
 
 	envSecretRef, pushSecretName, apiErr := a.resolveRegistryForBuild(ctx, c, k8sClient, namespace, &req)
@@ -1796,9 +1380,9 @@ func (a *APIServer) createBuild(c *gin.Context) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      req.Name,
 			Namespace: namespace,
-			Labels:    labels,
+			Labels:    buildLabels,
 			Annotations: map[string]string{
-				"automotive.sdv.cloud.redhat.com/requested-by": requestedBy,
+				labels.RequestedBy: requestedBy,
 			},
 		},
 		Spec: automotivev1alpha1.ImageBuildSpec{
@@ -1913,7 +1497,7 @@ func listBuilds(c *gin.Context) {
 			Name:           b.Name,
 			Phase:          b.Status.Phase,
 			Message:        b.Status.Message,
-			RequestedBy:    b.Annotations["automotive.sdv.cloud.redhat.com/requested-by"],
+			RequestedBy:    b.Annotations[labels.RequestedBy],
 			CreatedAt:      b.CreationTimestamp.Format(time.RFC3339),
 			StartTime:      startStr,
 			CompletionTime: compStr,
@@ -2003,12 +1587,13 @@ func (a *APIServer) getBuild(c *gin.Context, name string) {
 	// that belong to the requesting user
 	var registryToken string
 	requester := a.resolveRequester(c)
-	buildOwner := build.Annotations["automotive.sdv.cloud.redhat.com/requested-by"]
+	buildOwner := build.Annotations[labels.RequestedBy]
 	if requester == buildOwner &&
 		build.Spec.GetUseServiceAccountAuth() &&
 		isTerminalPhase(build.Status.Phase) {
 		var tokenErr error
-		registryToken, _, tokenErr = a.mintRegistryToken(ctx, c, namespace)
+		tokenLifetime := resolveTokenLifetime(ctx, k8sClient, namespace)
+		registryToken, _, tokenErr = a.mintRegistryToken(ctx, c, namespace, tokenLifetime)
 		if tokenErr != nil {
 			a.log.Error(tokenErr, "failed to mint registry token", "build", name)
 			tokenWarning := fmt.Sprintf("failed to mint registry token: %v", tokenErr)
@@ -2024,7 +1609,7 @@ func (a *APIServer) getBuild(c *gin.Context, name string) {
 		Name:        build.Name,
 		Phase:       build.Status.Phase,
 		Message:     build.Status.Message,
-		RequestedBy: build.Annotations["automotive.sdv.cloud.redhat.com/requested-by"],
+		RequestedBy: build.Annotations[labels.RequestedBy],
 		StartTime: func() string {
 			if build.Status.StartTime != nil {
 				return build.Status.StartTime.Format(time.RFC3339)
@@ -2261,8 +1846,8 @@ func findRunningUploadPod(ctx context.Context, k8sClient client.Client, namespac
 	if err := k8sClient.List(ctx, podList,
 		client.InNamespace(namespace),
 		client.MatchingLabels{
-			"automotive.sdv.cloud.redhat.com/imagebuild-name": buildName,
-			"app.kubernetes.io/name":                          "upload-pod",
+			labels.ImageBuildName: buildName,
+			labels.Name:           "upload-pod",
 		},
 	); err != nil {
 		return nil, fmt.Errorf("error listing upload pods: %w", err)
@@ -2379,7 +1964,7 @@ func (a *APIServer) uploadFiles(c *gin.Context, name string) {
 	if patched.Annotations == nil {
 		patched.Annotations = map[string]string{}
 	}
-	patched.Annotations["automotive.sdv.cloud.redhat.com/uploads-complete"] = "true"
+	patched.Annotations[labels.UploadsComplete] = labels.ValueTrue
 	if err := k8sClient.Patch(c.Request.Context(), patched, client.MergeFrom(original)); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("mark complete failed: %v", err)})
 		return
@@ -2415,53 +2000,6 @@ func copyFileToPod(ctx context.Context, config *rest.Config, namespace, podName,
 		return err
 	}
 	return nil
-}
-
-func setSecretOwnerRef(
-	ctx context.Context,
-	c client.Client,
-	namespace, secretName string,
-	owner *automotivev1alpha1.ImageBuild,
-) error {
-	secret := &corev1.Secret{}
-	if err := c.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, secret); err != nil {
-		return err
-	}
-	secret.OwnerReferences = []metav1.OwnerReference{
-		*metav1.NewControllerRef(owner, automotivev1alpha1.GroupVersion.WithKind("ImageBuild")),
-	}
-	return c.Update(ctx, secret)
-}
-
-// createFlashClientSecret creates a secret containing the Jumpstarter client config
-func createFlashClientSecret(
-	ctx context.Context,
-	c client.Client,
-	namespace, secretName, base64Config string,
-) error {
-	// Decode base64 client config
-	configBytes, err := base64.StdEncoding.DecodeString(base64Config)
-	if err != nil {
-		return fmt.Errorf("failed to decode client config: %w", err)
-	}
-
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretName,
-			Namespace: namespace,
-			Labels: map[string]string{
-				"app.kubernetes.io/managed-by": "build-api",
-				"app.kubernetes.io/part-of":    "automotive-dev",
-				"app.kubernetes.io/component":  "jumpstarter-client",
-			},
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: map[string][]byte{
-			"client.yaml": configBytes,
-		},
-	}
-
-	return c.Create(ctx, secret)
 }
 
 // refreshAuthConfigIfNeeded periodically checks and refreshes authentication configuration from OperatorConfig
@@ -3040,8 +2578,8 @@ func createSealedSecrets(ctx context.Context, clientset kubernetes.Interface, na
 				Name:      secretName,
 				Namespace: namespace,
 				Labels: map[string]string{
-					"automotive.sdv.cloud.redhat.com/imagereseal": req.Name,
-					"automotive.sdv.cloud.redhat.com/transient":   "true",
+					labels.ImageReseal: req.Name,
+					labels.Transient:   labels.ValueTrue,
 				},
 			},
 			Type: corev1.SecretTypeOpaque,
@@ -3060,8 +2598,8 @@ func createSealedSecrets(ctx context.Context, clientset kubernetes.Interface, na
 				Name:      keySecretName,
 				Namespace: namespace,
 				Labels: map[string]string{
-					"automotive.sdv.cloud.redhat.com/imagereseal": req.Name,
-					"automotive.sdv.cloud.redhat.com/transient":   "true",
+					labels.ImageReseal: req.Name,
+					labels.Transient:   labels.ValueTrue,
 				},
 			},
 			Type: corev1.SecretTypeOpaque,
@@ -3082,8 +2620,8 @@ func createSealedSecrets(ctx context.Context, clientset kubernetes.Interface, na
 					Name:      keyPwSecretName,
 					Namespace: namespace,
 					Labels: map[string]string{
-						"automotive.sdv.cloud.redhat.com/imagereseal": req.Name,
-						"automotive.sdv.cloud.redhat.com/transient":   "true",
+						labels.ImageReseal: req.Name,
+						labels.Transient:   labels.ValueTrue,
 					},
 				},
 				Type: corev1.SecretTypeOpaque,
@@ -3173,11 +2711,11 @@ func (a *APIServer) createSealed(c *gin.Context, pathOp SealedOperation) {
 			Name:      req.Name,
 			Namespace: namespace,
 			Labels: map[string]string{
-				"app.kubernetes.io/managed-by": "build-api",
-				"app.kubernetes.io/part-of":    "automotive-dev",
+				labels.ManagedBy: labels.ValueBuildAPI,
+				labels.PartOf:    labels.ValueAutomotiveDev,
 			},
 			Annotations: map[string]string{
-				"automotive.sdv.cloud.redhat.com/requested-by": requestedBy,
+				labels.RequestedBy: requestedBy,
 			},
 		},
 		Spec: automotivev1alpha1.ImageResealSpec{
@@ -3261,7 +2799,7 @@ func (a *APIServer) listSealed(c *gin.Context) {
 			Name:           s.Name,
 			Phase:          s.Status.Phase,
 			Message:        s.Status.Message,
-			RequestedBy:    s.Annotations["automotive.sdv.cloud.redhat.com/requested-by"],
+			RequestedBy:    s.Annotations[labels.RequestedBy],
 			CreatedAt:      s.CreationTimestamp.Format(time.RFC3339),
 			CompletionTime: compStr,
 		})
@@ -3297,7 +2835,7 @@ func (a *APIServer) getSealed(c *gin.Context, name string) {
 		Name:            sealed.Name,
 		Phase:           sealed.Status.Phase,
 		Message:         sealed.Status.Message,
-		RequestedBy:     sealed.Annotations["automotive.sdv.cloud.redhat.com/requested-by"],
+		RequestedBy:     sealed.Annotations[labels.RequestedBy],
 		StartTime:       startStr,
 		CompletionTime:  compStr,
 		TaskRunName:     sealed.Status.TaskRunName,

--- a/internal/buildapi/server_test.go
+++ b/internal/buildapi/server_test.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/labels"
 	"github.com/gin-gonic/gin"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // Dot import is standard for Ginkgo
@@ -136,7 +137,7 @@ var _ = Describe("APIServer", func() {
 			build.Name = name
 			build.Namespace = "test-ns"
 			build.Annotations = map[string]string{
-				"automotive.sdv.cloud.redhat.com/requested-by": owner,
+				labels.RequestedBy: owner,
 			}
 			if useServiceAccountAuth || containerPush != "" || exportOCI != "" {
 				build.Spec.Export = &automotivev1alpha1.ExportSpec{
@@ -323,7 +324,7 @@ var _ = Describe("APIServer", func() {
 			build.Name = "my-build"
 			build.Namespace = testNamespace
 			build.Annotations = map[string]string{
-				"automotive.sdv.cloud.redhat.com/requested-by": "alice",
+				labels.RequestedBy: "alice",
 			}
 			build.Status.Phase = phase
 			build.Status.PipelineRunName = pipelineRunName

--- a/internal/buildapi/workspace.go
+++ b/internal/buildapi/workspace.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/labels"
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 	corev1 "k8s.io/api/core/v1"
@@ -999,7 +1000,7 @@ func (a *APIServer) resolveLeaseFromBuild(ctx context.Context, k8sClient client.
 	if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: buildName}, build); err != nil {
 		return "", fmt.Errorf("ImageBuild %q not found: %w", buildName, err)
 	}
-	if owner := build.Annotations["automotive.sdv.cloud.redhat.com/requested-by"]; owner != requester {
+	if owner := build.Annotations[labels.RequestedBy]; owner != requester {
 		return "", fmt.Errorf("ImageBuild %q is owned by a different user", buildName)
 	}
 	if build.Status.LeaseID == "" {

--- a/internal/common/labels/labels.go
+++ b/internal/common/labels/labels.go
@@ -1,0 +1,43 @@
+// Package labels defines shared label and annotation constants used across
+// the buildapi and controller packages.
+package labels
+
+// RequestedBy and related constants are annotation/label keys in the
+// automotive.sdv.cloud.redhat.com domain.
+const (
+	RequestedBy     = "automotive.sdv.cloud.redhat.com/requested-by"
+	Transient       = "automotive.sdv.cloud.redhat.com/transient"
+	ResourceType    = "automotive.sdv.cloud.redhat.com/resource-type"
+	BuildName       = "automotive.sdv.cloud.redhat.com/build-name"
+	ImageBuildName  = "automotive.sdv.cloud.redhat.com/imagebuild-name"
+	ImageReseal     = "automotive.sdv.cloud.redhat.com/imagereseal"
+	Workspace       = "automotive.sdv.cloud.redhat.com/workspace"
+	UploadsComplete = "automotive.sdv.cloud.redhat.com/uploads-complete"
+	FlashTaskRun    = "automotive.sdv.cloud.redhat.com/flash-taskrun"
+	Progress        = "automotive.sdv.cloud.redhat.com/progress"
+	Username        = "automotive.sdv.cloud.redhat.com/username"
+	TaskType        = "automotive.sdv.cloud.redhat.com/task-type"
+	ContainerBuild  = "automotive.sdv.cloud.redhat.com/containerbuild"
+	ImageRef        = "automotive.sdv.cloud.redhat.com/image-ref"
+	Distro          = "automotive.sdv.cloud.redhat.com/distro"
+	Target          = "automotive.sdv.cloud.redhat.com/target"
+	Architecture    = "automotive.sdv.cloud.redhat.com/architecture"
+)
+
+// ManagedBy and related constants are standard Kubernetes label keys.
+const (
+	ManagedBy = "app.kubernetes.io/managed-by"
+	PartOf    = "app.kubernetes.io/part-of"
+	CreatedBy = "app.kubernetes.io/created-by"
+	Component = "app.kubernetes.io/component"
+	Name      = "app.kubernetes.io/name"
+)
+
+// ValueTrue and related constants are common label values.
+const (
+	ValueTrue            = "true"
+	ValueBuildAPI        = "build-api"
+	ValueAutomotiveDev   = "automotive-dev"
+	ValueBuildAPICreator = "automotive-dev-build-api"
+	ValueOperator        = "automotive-dev-operator"
+)


### PR DESCRIPTION
## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [X] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [X] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Registry token lifetime can now be configured in OperatorConfig (default: 4 hours), allowing customization of authentication token validity duration.

* **Refactor**
  * Registry management functionality has been reorganized into dedicated modules with improved consistency across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->