### PR TITLE
keep ImageBuild when it expires

### DIFF
--- a/api/v1alpha1/imagebuild_types.go
+++ b/api/v1alpha1/imagebuild_types.go
@@ -30,11 +30,13 @@ const (
 	ImageBuildPhaseCompleted = "Completed"
 	ImageBuildPhaseFailed    = "Failed"
 	ImageBuildPhaseCancelled = "Cancelled"
+	ImageBuildPhaseExpired   = "Expired"
 )
 
 // IsTerminalBuildPhase reports whether phase is a final build state.
 func IsTerminalBuildPhase(phase string) bool {
-	return phase == ImageBuildPhaseCompleted || phase == ImageBuildPhaseFailed || phase == ImageBuildPhaseCancelled
+	return phase == ImageBuildPhaseCompleted || phase == ImageBuildPhaseFailed ||
+		phase == ImageBuildPhaseCancelled || phase == ImageBuildPhaseExpired
 }
 
 // ImageBuildSpec defines the desired state of ImageBuild
@@ -94,8 +96,10 @@ type ImageBuildSpec struct {
 	// +optional
 	TaskBundleRef string `json:"taskBundleRef,omitempty"`
 
-	// TTL is the time-to-live for this build. The build is automatically deleted
-	// after this duration past its completion (or creation if still in progress).
+	// TTL is the time-to-live for this build. After this duration past its
+	// completion, the build transitions to the Expired phase and its resources
+	// (PipelineRuns, TaskRuns, PVCs, registry images) are cleaned up.
+	// The ImageBuild CR itself is preserved. In-progress builds never expire.
 	// Uses Go duration format (e.g. "24h", "72h", "168h").
 	// Empty uses the OperatorConfig default. Set to "0" to disable expiry.
 	// +optional
@@ -220,8 +224,8 @@ type ImageBuildStatus struct {
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
-	// Phase represents the current phase of the build (Building, Completed, Failed, Cancelled)
-	// +kubebuilder:validation:Enum=Pending;Uploading;Building;Pushing;Flashing;Completed;Failed;Cancelled
+	// Phase represents the current phase of the build
+	// +kubebuilder:validation:Enum=Pending;Uploading;Building;Pushing;Flashing;Completed;Failed;Cancelled;Expired
 	Phase string `json:"phase,omitempty"`
 
 	// StartTime is when the build started
@@ -264,8 +268,10 @@ type ImageBuildStatus struct {
 	// +optional
 	LeaseID string `json:"leaseId,omitempty"`
 
-	// ExpiresAt is when this build will be automatically deleted.
-	// Nil if expiry is disabled (TTL "0" or no-expire annotation).
+	// ExpiresAt is when this build will transition to the Expired phase
+	// and have its associated resources cleaned up. The ImageBuild CR itself
+	// is preserved. Nil if expiry is disabled (TTL "0", no-expire annotation,
+	// or workspace build).
 	// +optional
 	ExpiresAt *metav1.Time `json:"expiresAt,omitempty"`
 }

--- a/cmd/caib/buildcmd/logs.go
+++ b/cmd/caib/buildcmd/logs.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
 	common "github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/common"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/logstream"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/ui"
@@ -152,6 +153,11 @@ func (h *Handler) waitForBuildCompletion(ctx context.Context, api *buildapiclien
 				pb.Clear()
 				fmt.Println("Build was cancelled.")
 				return fmt.Errorf("build cancelled")
+			}
+			if st.Phase == automotivev1alpha1.ImageBuildPhaseExpired {
+				pb.Clear()
+				fmt.Printf("Build expired: %s\n", st.Message)
+				return fmt.Errorf("build expired")
 			}
 			if st.Phase == phaseFailed {
 				pb.Clear()

--- a/config/crd/bases/automotive.sdv.cloud.redhat.com_imagebuilds.yaml
+++ b/config/crd/bases/automotive.sdv.cloud.redhat.com_imagebuilds.yaml
@@ -217,8 +217,10 @@ spec:
                 type: string
               ttl:
                 description: |-
-                  TTL is the time-to-live for this build. The build is automatically deleted
-                  after this duration past its completion (or creation if still in progress).
+                  TTL is the time-to-live for this build. After this duration past its
+                  completion, the build transitions to the Expired phase and its resources
+                  (PipelineRuns, TaskRuns, PVCs, registry images) are cleaned up.
+                  The ImageBuild CR itself is preserved. In-progress builds never expire.
                   Uses Go duration format (e.g. "24h", "72h", "168h").
                   Empty uses the OperatorConfig default. Set to "0" to disable expiry.
                 type: string
@@ -305,8 +307,10 @@ spec:
                 type: array
               expiresAt:
                 description: |-
-                  ExpiresAt is when this build will be automatically deleted.
-                  Nil if expiry is disabled (TTL "0" or no-expire annotation).
+                  ExpiresAt is when this build will transition to the Expired phase
+                  and have its associated resources cleaned up. The ImageBuild CR itself
+                  is preserved. Nil if expiry is disabled (TTL "0", no-expire annotation,
+                  or workspace build).
                 format: date-time
                 type: string
               flashTaskRunName:
@@ -325,8 +329,7 @@ spec:
                 format: int64
                 type: integer
               phase:
-                description: Phase represents the current phase of the build (Building,
-                  Completed, Failed, Cancelled)
+                description: Phase represents the current phase of the build
                 enum:
                 - Pending
                 - Uploading
@@ -336,6 +339,7 @@ spec:
                 - Completed
                 - Failed
                 - Cancelled
+                - Expired
                 type: string
               pipelineRunName:
                 description: PipelineRunName is the name of the active PipelineRun

--- a/internal/controller/imagebuild/controller.go
+++ b/internal/controller/imagebuild/controller.go
@@ -160,6 +160,8 @@ func (r *ImageBuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		phaseResult, err = r.handleFlashingState(ctx, imageBuild)
 	case phaseCompleted:
 		phaseResult = r.handleCompletedState(ctx, imageBuild)
+	case automotivev1alpha1.ImageBuildPhaseExpired:
+		phaseResult = r.handleExpiredState(ctx, imageBuild)
 	case phaseCancelled, phaseFailed:
 		if shutdownErr := r.shutdownUploadPod(ctx, imageBuild); shutdownErr != nil {
 			log.Error(shutdownErr, "Failed to shutdown upload pod, will retry")
@@ -240,25 +242,37 @@ func (r *ImageBuildReconciler) ensureImageStreamOwnerRef(
 	return nil
 }
 
-// extractImageStreamName extracts the ImageStream name from the ImageBuild's
-// internal registry URLs (GetContainerPush and GetExportOCI).
-func extractImageStreamName(imageBuild *automotivev1alpha1.ImageBuild) string {
+// extractInternalImageStreamTags returns ImageStreamTag names ("name:tag") for
+// any internal registry URLs in the ImageBuild's export configuration.
+func extractInternalImageStreamTags(imageBuild *automotivev1alpha1.ImageBuild) []string {
 	prefix := tasks.DefaultInternalRegistryURL + "/"
-	for _, ref := range []string{imageBuild.Spec.GetContainerPush(), imageBuild.Spec.GetExportOCI()} {
+	refs := []string{imageBuild.Spec.GetContainerPush(), imageBuild.Spec.GetExportOCI()}
+	tags := make([]string, 0, len(refs))
+	for _, ref := range refs {
 		after, ok := strings.CutPrefix(ref, prefix)
 		if !ok {
 			continue
 		}
 		parts := strings.SplitN(after, "/", 2)
-		if len(parts) < 2 {
+		if len(parts) < 2 || parts[1] == "" {
 			continue
 		}
-		nameTag := strings.SplitN(parts[1], ":", 2)
-		if nameTag[0] != "" {
-			return nameTag[0]
+		ist := parts[1]
+		if !strings.Contains(ist, ":") {
+			ist += ":latest"
 		}
+		tags = append(tags, ist)
 	}
-	return ""
+	return tags
+}
+
+func extractImageStreamName(imageBuild *automotivev1alpha1.ImageBuild) string {
+	tags := extractInternalImageStreamTags(imageBuild)
+	if len(tags) == 0 {
+		return ""
+	}
+	name, _, _ := strings.Cut(tags[0], ":")
+	return name
 }
 
 func (r *ImageBuildReconciler) handleInitialState(
@@ -409,7 +423,12 @@ func (r *ImageBuildReconciler) checkExpiry(
 		types.NamespacedName{Name: imageBuild.Name, Namespace: imageBuild.Namespace},
 	)
 
-	if imageBuild.Annotations[automotivev1alpha1.NoExpireAnnotation] == "true" {
+	if imageBuild.Status.Phase == automotivev1alpha1.ImageBuildPhaseExpired {
+		return ctrl.Result{}, false, nil
+	}
+
+	if imageBuild.Annotations[automotivev1alpha1.NoExpireAnnotation] == "true" ||
+		imageBuild.Spec.Workspace != "" {
 		if err := r.updateExpiresAt(ctx, imageBuild, nil); err != nil {
 			return ctrl.Result{}, false, err
 		}
@@ -430,12 +449,10 @@ func (r *ImageBuildReconciler) checkExpiry(
 		return ctrl.Result{}, false, nil
 	}
 
-	var anchor time.Time
-	if imageBuild.Status.CompletionTime != nil {
-		anchor = imageBuild.Status.CompletionTime.Time
-	} else {
-		anchor = imageBuild.CreationTimestamp.Time
+	if imageBuild.Status.CompletionTime == nil {
+		return ctrl.Result{}, false, nil
 	}
+	anchor := imageBuild.Status.CompletionTime.Time
 
 	expiresAt := anchor.Add(ttl)
 	remaining := time.Until(expiresAt)
@@ -449,14 +466,13 @@ func (r *ImageBuildReconciler) checkExpiry(
 		return ctrl.Result{RequeueAfter: remaining}, false, nil
 	}
 
-	log.Info("Build expired, deleting", "ttl", ttl, "anchor", anchor)
+	log.Info("Build expired, transitioning to Expired phase", "ttl", ttl, "anchor", anchor)
 	r.emitEventf(imageBuild, corev1.EventTypeNormal, eventReasonBuildExpired,
-		"Build expired after %s, deleting", ttl)
+		"Build expired after %s, cleaning up resources", ttl)
 
-	if err := r.Delete(ctx, imageBuild); err != nil {
-		if !errors.IsNotFound(err) {
-			return ctrl.Result{}, false, fmt.Errorf("failed to delete expired build: %w", err)
-		}
+	if err := r.updateStatus(ctx, imageBuild, automotivev1alpha1.ImageBuildPhaseExpired,
+		fmt.Sprintf("Build expired after %s", ttl)); err != nil {
+		return ctrl.Result{}, false, fmt.Errorf("failed to transition expired build: %w", err)
 	}
 	return ctrl.Result{}, true, nil
 }
@@ -541,6 +557,104 @@ func (r *ImageBuildReconciler) handleCompletedState(
 		return ctrl.Result{RequeueAfter: secretCleanupRequeue}
 	}
 	return ctrl.Result{}
+}
+
+func (r *ImageBuildReconciler) handleExpiredState(
+	ctx context.Context,
+	imageBuild *automotivev1alpha1.ImageBuild,
+) ctrl.Result {
+	log := r.Log.WithValues(
+		"imagebuild",
+		types.NamespacedName{Name: imageBuild.Name, Namespace: imageBuild.Namespace},
+	)
+
+	var retryNeeded bool
+	deleteObj := func(obj client.Object, kind string) {
+		if err := r.Delete(ctx, obj); err != nil {
+			if !errors.IsNotFound(err) {
+				log.Error(err, "Failed to delete "+kind, "name", obj.GetName())
+				retryNeeded = true
+			}
+		} else {
+			log.Info("Deleted "+kind, "name", obj.GetName())
+		}
+	}
+
+	ns := imageBuild.Namespace
+
+	if err := r.shutdownUploadPod(ctx, imageBuild); err != nil {
+		log.Error(err, "Failed to shutdown upload pod")
+		retryNeeded = true
+	}
+
+	if name := imageBuild.Status.PipelineRunName; name != "" {
+		deleteObj(&tektonv1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}, "PipelineRun")
+	}
+	if name := imageBuild.Status.PushTaskRunName; name != "" {
+		deleteObj(&tektonv1.TaskRun{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}, "push TaskRun")
+	}
+	if name := imageBuild.Status.FlashTaskRunName; name != "" {
+		deleteObj(&tektonv1.TaskRun{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}, "flash TaskRun")
+	}
+	if name := imageBuild.Status.PVCName; name != "" {
+		if name == imageBuild.Spec.BuildCachePVC {
+			log.Info("Skipping PVC deletion: shared build-cache PVC", "pvc", name)
+		} else {
+			deleteObj(&corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}, "PVC")
+		}
+	}
+
+	cmName := safeDerivedName(imageBuild.Name, "-manifest")
+	deleteObj(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: ns}}, "manifest ConfigMap")
+
+	if r.deleteExpiredImageStreams(ctx, imageBuild, log) {
+		retryNeeded = true
+	}
+
+	if err := r.cleanupTransientSecrets(ctx, imageBuild, log); err != nil {
+		retryNeeded = true
+	}
+
+	if retryNeeded {
+		log.Info("Some expired resources could not be cleaned up, will retry",
+			"requeueAfter", secretCleanupRequeue)
+		return ctrl.Result{RequeueAfter: secretCleanupRequeue}
+	}
+	return ctrl.Result{}
+}
+
+func (r *ImageBuildReconciler) deleteExpiredImageStreams(
+	ctx context.Context,
+	imageBuild *automotivev1alpha1.ImageBuild,
+	log logr.Logger,
+) bool {
+	var failed bool
+	tags := extractInternalImageStreamTags(imageBuild)
+	seen := make(map[string]struct{}, len(tags))
+	for _, tag := range tags {
+		name, _, _ := strings.Cut(tag, ":")
+		if _, ok := seen[name]; ok || name == "" {
+			continue
+		}
+		seen[name] = struct{}{}
+
+		is := &unstructured.Unstructured{}
+		is.SetGroupVersionKind(schema.GroupVersionKind{
+			Group: "image.openshift.io", Version: "v1", Kind: "ImageStream",
+		})
+		is.SetName(name)
+		is.SetNamespace(imageBuild.Namespace)
+
+		if err := r.Delete(ctx, is); err != nil {
+			if !errors.IsNotFound(err) {
+				log.Error(err, "Failed to delete ImageStream", "name", name)
+				failed = true
+			}
+		} else {
+			log.Info("Deleted ImageStream", "name", name)
+		}
+	}
+	return failed
 }
 
 func (r *ImageBuildReconciler) checkBuildProgress(
@@ -2293,6 +2407,9 @@ func (r *ImageBuildReconciler) updateStatus(
 	}
 
 	if fresh.Status.Phase == phaseCancelled && phase != phaseCancelled {
+		return nil
+	}
+	if fresh.Status.Phase == automotivev1alpha1.ImageBuildPhaseExpired && phase != automotivev1alpha1.ImageBuildPhaseExpired {
 		return nil
 	}
 

--- a/internal/controller/imagebuild/expiry_test.go
+++ b/internal/controller/imagebuild/expiry_test.go
@@ -6,10 +6,19 @@ import (
 	"time"
 
 	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/tasks"
 	"github.com/go-logr/logr"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -50,7 +59,7 @@ func newTestImageBuild(name string, phase string, ttl string, completedAgo time.
 	return ib
 }
 
-func TestCheckExpiry_ExpiredBuild(t *testing.T) {
+func TestCheckExpiry_ExpiredBuild_TransitionsToExpiredPhase(t *testing.T) {
 	ib := newTestImageBuild("expired-build", phaseCompleted, "1h", 2*time.Hour)
 	r := newExpiryReconciler(ib)
 
@@ -63,9 +72,11 @@ func TestCheckExpiry_ExpiredBuild(t *testing.T) {
 	}
 
 	got := &automotivev1alpha1.ImageBuild{}
-	err = r.Get(context.Background(), types.NamespacedName{Name: "expired-build", Namespace: "test-ns"}, got)
-	if err == nil {
-		t.Fatal("expected build to be deleted, but it still exists")
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "expired-build", Namespace: "test-ns"}, got); err != nil {
+		t.Fatalf("ImageBuild should still exist after expiry: %v", err)
+	}
+	if got.Status.Phase != automotivev1alpha1.ImageBuildPhaseExpired {
+		t.Errorf("expected phase %q, got %q", automotivev1alpha1.ImageBuildPhaseExpired, got.Status.Phase)
 	}
 }
 
@@ -106,6 +117,28 @@ func TestCheckExpiry_NoExpireAnnotation(t *testing.T) {
 	}
 }
 
+func TestCheckExpiry_WorkspaceBuildNeverExpires(t *testing.T) {
+	ib := newTestImageBuild("ws-build", phaseCompleted, "1h", 2*time.Hour)
+	ib.Spec.Workspace = "my-workspace"
+	r := newExpiryReconciler(ib)
+
+	_, expired, err := r.checkExpiry(context.Background(), &ib)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if expired {
+		t.Fatal("workspace build should never expire")
+	}
+
+	got := &automotivev1alpha1.ImageBuild{}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "ws-build", Namespace: "test-ns"}, got); err != nil {
+		t.Fatalf("workspace build should still exist: %v", err)
+	}
+	if got.Status.ExpiresAt != nil {
+		t.Error("workspace build should have nil ExpiresAt")
+	}
+}
+
 func TestCheckExpiry_TTLZeroDisablesExpiry(t *testing.T) {
 	ib := newTestImageBuild("forever-build", phaseCompleted, "0", 999*time.Hour)
 	r := newExpiryReconciler(ib)
@@ -122,17 +155,27 @@ func TestCheckExpiry_TTLZeroDisablesExpiry(t *testing.T) {
 	}
 }
 
-func TestCheckExpiry_InProgressUsesCreationTimestamp(t *testing.T) {
-	ib := newTestImageBuild("building", phaseBuilding, "30m", 0)
-	ib.CreationTimestamp = metav1.NewTime(time.Now().Add(-2 * time.Hour))
-	r := newExpiryReconciler(ib)
+func TestCheckExpiry_InProgressNeverExpires(t *testing.T) {
+	for _, phase := range []string{
+		automotivev1alpha1.ImageBuildPhasePending,
+		automotivev1alpha1.ImageBuildPhaseUploading,
+		automotivev1alpha1.ImageBuildPhaseBuilding,
+		automotivev1alpha1.ImageBuildPhasePushing,
+		automotivev1alpha1.ImageBuildPhaseFlashing,
+	} {
+		t.Run(phase, func(t *testing.T) {
+			ib := newTestImageBuild("build-"+phase, phase, "30m", 0)
+			ib.CreationTimestamp = metav1.NewTime(time.Now().Add(-2 * time.Hour))
+			r := newExpiryReconciler(ib)
 
-	_, expired, err := r.checkExpiry(context.Background(), &ib)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !expired {
-		t.Fatal("in-progress build past TTL from creation should expire")
+			_, expired, err := r.checkExpiry(context.Background(), &ib)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if expired {
+				t.Fatalf("in-progress build (phase %s) should never expire regardless of TTL", phase)
+			}
+		})
 	}
 }
 
@@ -146,6 +189,14 @@ func TestCheckExpiry_FailedBuildExpires(t *testing.T) {
 	}
 	if !expired {
 		t.Fatal("failed build past TTL should expire")
+	}
+
+	got := &automotivev1alpha1.ImageBuild{}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "failed-old", Namespace: "test-ns"}, got); err != nil {
+		t.Fatalf("ImageBuild should still exist: %v", err)
+	}
+	if got.Status.Phase != automotivev1alpha1.ImageBuildPhaseExpired {
+		t.Errorf("expected phase %q, got %q", automotivev1alpha1.ImageBuildPhaseExpired, got.Status.Phase)
 	}
 }
 
@@ -172,6 +223,300 @@ func TestCheckExpiry_SetsExpiresAtInStatus(t *testing.T) {
 	diff := got.Status.ExpiresAt.Sub(expectedExpiry)
 	if diff < -time.Second || diff > time.Second {
 		t.Errorf("ExpiresAt = %v, want ~%v (diff %v)", got.Status.ExpiresAt.Time, expectedExpiry, diff)
+	}
+}
+
+// newExpiredBuildWithResources creates an expired ImageBuild along with its
+// owned child resources (PipelineRun, push TaskRun, PVC, manifest ConfigMap)
+// for testing cleanup behavior.
+func newExpiredBuildWithResources(t *testing.T) (*ImageBuildReconciler, *automotivev1alpha1.ImageBuild) {
+	t.Helper()
+
+	ib := newTestImageBuild("my-build", automotivev1alpha1.ImageBuildPhaseExpired, "1h", 2*time.Hour)
+	ib.Status.PipelineRunName = "my-build-build-abc"
+	ib.Status.PushTaskRunName = "my-build-push-def"
+	ib.Status.PVCName = "my-build-pvc"
+	ib.Spec.Export = &automotivev1alpha1.ExportSpec{
+		Container:             tasks.DefaultInternalRegistryURL + "/test-ns/my-image:latest",
+		UseServiceAccountAuth: true,
+	}
+
+	ownerRefs := testOwnerRef("my-build")
+
+	pipelineRun := &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-build-build-abc", Namespace: "test-ns",
+			OwnerReferences: ownerRefs,
+		},
+	}
+
+	pushTaskRun := &tektonv1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-build-push-def", Namespace: "test-ns",
+			OwnerReferences: ownerRefs,
+		},
+	}
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-build-pvc", Namespace: "test-ns",
+			OwnerReferences: ownerRefs,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+
+	manifestCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: safeDerivedName("my-build", "-manifest"), Namespace: "test-ns",
+			OwnerReferences: ownerRefs,
+		},
+	}
+
+	scheme := newTestSchemeWithTekton()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&ib, pipelineRun, pushTaskRun, pvc, manifestCM).
+		WithStatusSubresource(&ib).
+		Build()
+
+	r := &ImageBuildReconciler{
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Log:      logr.Discard(),
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	return r, &ib
+}
+
+func testOwnerRef(buildName string) []metav1.OwnerReference {
+	return []metav1.OwnerReference{{
+		APIVersion: "automotive.sdv.cloud.redhat.com/v1alpha1",
+		Kind:       "ImageBuild",
+		Name:       buildName,
+		Controller: ptr.To(true),
+	}}
+}
+
+func TestHandleExpiredState_DeletesPipelineRun(t *testing.T) {
+	r, ib := newExpiredBuildWithResources(t)
+	ctx := context.Background()
+
+	result := r.handleExpiredState(ctx, ib)
+	if result.RequeueAfter != 0 {
+		t.Errorf("expected no requeue, got %v", result.RequeueAfter)
+	}
+
+	pr := &tektonv1.PipelineRun{}
+	err := r.Get(ctx, types.NamespacedName{Name: "my-build-build-abc", Namespace: "test-ns"}, pr)
+	if !errors.IsNotFound(err) {
+		t.Errorf("expected PipelineRun to be deleted, got err=%v", err)
+	}
+}
+
+func TestHandleExpiredState_DeletesPushTaskRun(t *testing.T) {
+	r, ib := newExpiredBuildWithResources(t)
+	ctx := context.Background()
+
+	r.handleExpiredState(ctx, ib) //nolint:errcheck
+
+	tr := &tektonv1.TaskRun{}
+	err := r.Get(ctx, types.NamespacedName{Name: "my-build-push-def", Namespace: "test-ns"}, tr)
+	if !errors.IsNotFound(err) {
+		t.Errorf("expected push TaskRun to be deleted, got err=%v", err)
+	}
+}
+
+func TestHandleExpiredState_DeletesPVC(t *testing.T) {
+	r, ib := newExpiredBuildWithResources(t)
+	ctx := context.Background()
+
+	r.handleExpiredState(ctx, ib) //nolint:errcheck
+
+	pvc := &corev1.PersistentVolumeClaim{}
+	err := r.Get(ctx, types.NamespacedName{Name: "my-build-pvc", Namespace: "test-ns"}, pvc)
+	if !errors.IsNotFound(err) {
+		t.Errorf("expected PVC to be deleted, got err=%v", err)
+	}
+}
+
+func TestHandleExpiredState_DeletesManifestConfigMap(t *testing.T) {
+	r, ib := newExpiredBuildWithResources(t)
+	ctx := context.Background()
+
+	r.handleExpiredState(ctx, ib) //nolint:errcheck
+
+	cm := &corev1.ConfigMap{}
+	cmName := safeDerivedName("my-build", "-manifest")
+	err := r.Get(ctx, types.NamespacedName{Name: cmName, Namespace: "test-ns"}, cm)
+	if !errors.IsNotFound(err) {
+		t.Errorf("expected manifest ConfigMap to be deleted, got err=%v", err)
+	}
+}
+
+func TestHandleExpiredState_DeletesImageStream(t *testing.T) {
+	r, ib := newExpiredBuildWithResources(t)
+	ctx := context.Background()
+
+	is := &unstructured.Unstructured{}
+	is.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: "image.openshift.io", Version: "v1", Kind: "ImageStream",
+	})
+	is.SetName("my-image")
+	is.SetNamespace("test-ns")
+	if err := r.Create(ctx, is); err != nil {
+		t.Fatalf("failed to create ImageStream: %v", err)
+	}
+
+	r.handleExpiredState(ctx, ib) //nolint:errcheck
+
+	got := &unstructured.Unstructured{}
+	got.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: "image.openshift.io", Version: "v1", Kind: "ImageStream",
+	})
+	err := r.Get(ctx, types.NamespacedName{Name: "my-image", Namespace: "test-ns"}, got)
+	if !errors.IsNotFound(err) {
+		t.Errorf("expected ImageStream to be deleted, got err=%v", err)
+	}
+}
+
+func TestHandleExpiredState_IdempotentWhenResourcesAlreadyGone(t *testing.T) {
+	// Build with status refs to resources that don't exist
+	ib := newTestImageBuild("clean-build", automotivev1alpha1.ImageBuildPhaseExpired, "1h", 2*time.Hour)
+	ib.Status.PipelineRunName = "gone-pipeline"
+	ib.Status.PushTaskRunName = "gone-push"
+	ib.Status.PVCName = "gone-pvc"
+
+	r := newExpiryReconciler(ib)
+	ctx := context.Background()
+
+	result := r.handleExpiredState(ctx, &ib)
+	if result.RequeueAfter != 0 {
+		t.Errorf("expected no requeue when resources already gone, got %v", result.RequeueAfter)
+	}
+}
+
+func TestHandleExpiredState_PreservesImageBuildCR(t *testing.T) {
+	r, ib := newExpiredBuildWithResources(t)
+	ctx := context.Background()
+
+	r.handleExpiredState(ctx, ib) //nolint:errcheck
+
+	got := &automotivev1alpha1.ImageBuild{}
+	if err := r.Get(ctx, types.NamespacedName{Name: "my-build", Namespace: "test-ns"}, got); err != nil {
+		t.Fatalf("ImageBuild CR should still exist after cleanup: %v", err)
+	}
+	if got.Status.Phase != automotivev1alpha1.ImageBuildPhaseExpired {
+		t.Errorf("phase should remain %q, got %q", automotivev1alpha1.ImageBuildPhaseExpired, got.Status.Phase)
+	}
+}
+
+func TestHandleExpiredState_DeletesFlashTaskRun(t *testing.T) {
+	r, ib := newExpiredBuildWithResources(t)
+	ctx := context.Background()
+
+	// Add a flash TaskRun
+	ib.Status.FlashTaskRunName = "my-build-flash-ghi"
+	flashTR := &tektonv1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-build-flash-ghi",
+			Namespace: "test-ns",
+		},
+	}
+	if err := r.Create(ctx, flashTR); err != nil {
+		t.Fatalf("failed to create flash TaskRun: %v", err)
+	}
+
+	r.handleExpiredState(ctx, ib) //nolint:errcheck
+
+	tr := &tektonv1.TaskRun{}
+	err := r.Get(ctx, types.NamespacedName{Name: "my-build-flash-ghi", Namespace: "test-ns"}, tr)
+	if !errors.IsNotFound(err) {
+		t.Errorf("expected flash TaskRun to be deleted, got err=%v", err)
+	}
+}
+
+func TestCheckExpiry_AlreadyExpiredSkipsCheck(t *testing.T) {
+	ib := newTestImageBuild("already-expired", automotivev1alpha1.ImageBuildPhaseExpired, "1h", 2*time.Hour)
+	r := newExpiryReconciler(ib)
+
+	result, expired, err := r.checkExpiry(context.Background(), &ib)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if expired {
+		t.Fatal("already-expired build should not re-trigger expiry")
+	}
+	if result.RequeueAfter != 0 {
+		t.Errorf("expected no requeue for already-expired build, got %v", result.RequeueAfter)
+	}
+}
+
+func TestReconcile_ExpiredPhaseCallsCleanup(t *testing.T) {
+	ib := newTestImageBuild("reconcile-expired", automotivev1alpha1.ImageBuildPhaseExpired, "1h", 2*time.Hour)
+	ib.Status.PipelineRunName = "reconcile-expired-build-abc"
+	ib.Status.PVCName = "reconcile-expired-pvc"
+
+	pipelineRun := &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "reconcile-expired-build-abc",
+			Namespace: "test-ns",
+		},
+	}
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "reconcile-expired-pvc",
+			Namespace: "test-ns",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+
+	scheme := newTestSchemeWithTekton()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&ib, pipelineRun, pvc).
+		WithStatusSubresource(&ib).
+		Build()
+
+	r := &ImageBuildReconciler{
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Log:      logr.Discard(),
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "reconcile-expired", Namespace: "test-ns"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_ = result
+
+	// PipelineRun should be cleaned up
+	pr := &tektonv1.PipelineRun{}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "reconcile-expired-build-abc", Namespace: "test-ns"}, pr); !errors.IsNotFound(err) {
+		t.Errorf("expected PipelineRun to be cleaned up via Reconcile, got err=%v", err)
+	}
+
+	// ImageBuild should still exist
+	got := &automotivev1alpha1.ImageBuild{}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "reconcile-expired", Namespace: "test-ns"}, got); err != nil {
+		t.Fatalf("ImageBuild should still exist: %v", err)
 	}
 }
 
@@ -221,5 +566,94 @@ func TestResolveEffectiveTTL(t *testing.T) {
 				t.Errorf("expected %v, got %v", tc.expectedTTL, ttl)
 			}
 		})
+	}
+}
+
+func TestHandleExpiredState_SkipsSharedBuildCachePVC(t *testing.T) {
+	ib := newTestImageBuild("cache-build", automotivev1alpha1.ImageBuildPhaseExpired, "1h", 2*time.Hour)
+	ib.Spec.BuildCachePVC = "shared-cache"
+	ib.Status.PVCName = "shared-cache"
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared-cache", Namespace: "test-ns"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("10Gi"),
+				},
+			},
+		},
+	}
+
+	scheme := newTestSchemeWithTekton()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&ib, pvc).
+		WithStatusSubresource(&ib).
+		Build()
+
+	r := &ImageBuildReconciler{
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Log:      logr.Discard(),
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	r.handleExpiredState(context.Background(), &ib) //nolint:errcheck
+
+	got := &corev1.PersistentVolumeClaim{}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "shared-cache", Namespace: "test-ns"}, got); err != nil {
+		t.Fatalf("shared build-cache PVC should NOT be deleted: %v", err)
+	}
+}
+
+func TestHandleExpiredState_DeletesMultipleImageStreams(t *testing.T) {
+	ib := newTestImageBuild("multi-is-build", automotivev1alpha1.ImageBuildPhaseExpired, "1h", 2*time.Hour)
+	ib.Spec.Export = &automotivev1alpha1.ExportSpec{
+		Container:             tasks.DefaultInternalRegistryURL + "/test-ns/app-bootc:latest",
+		Disk:                  &automotivev1alpha1.DiskExport{OCI: tasks.DefaultInternalRegistryURL + "/test-ns/app-disk:latest"},
+		UseServiceAccountAuth: true,
+	}
+
+	scheme := newTestSchemeWithTekton()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&ib).
+		WithStatusSubresource(&ib).
+		Build()
+
+	r := &ImageBuildReconciler{
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Log:      logr.Discard(),
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	ctx := context.Background()
+
+	for _, name := range []string{"app-bootc", "app-disk"} {
+		is := &unstructured.Unstructured{}
+		is.SetGroupVersionKind(schema.GroupVersionKind{
+			Group: "image.openshift.io", Version: "v1", Kind: "ImageStream",
+		})
+		is.SetName(name)
+		is.SetNamespace("test-ns")
+		if err := r.Create(ctx, is); err != nil {
+			t.Fatalf("failed to create ImageStream %s: %v", name, err)
+		}
+	}
+
+	r.handleExpiredState(ctx, &ib) //nolint:errcheck
+
+	for _, name := range []string{"app-bootc", "app-disk"} {
+		got := &unstructured.Unstructured{}
+		got.SetGroupVersionKind(schema.GroupVersionKind{
+			Group: "image.openshift.io", Version: "v1", Kind: "ImageStream",
+		})
+		err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: "test-ns"}, got)
+		if !errors.IsNotFound(err) {
+			t.Errorf("expected ImageStream %s to be deleted, got err=%v", name, err)
+		}
 	}
 }


### PR DESCRIPTION
This would help observability

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [X] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [X] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Expired" terminal build phase for image builds.

* **Bug Fixes / Behavior Changes**
  * TTL now transitions completed builds to "Expired" and triggers cleanup of associated resources while preserving the ImageBuild resource; in-progress builds never expire.
  * Cleanup scope expanded (pipeline/task runs, PVCs excluding shared cache, manifests, image streams, transient secrets).

* **CLI**
  * Build logs now indicate expired builds and exit early when detected.

* **Tests**
  * Expanded tests for expiry, cleanup, non-expiring in-progress/workspace builds and idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->