### PR TITLE
warn for jmp login instead of failing

### DIFF
--- a/internal/common/tasks/scripts/flash_image.sh
+++ b/internal/common/tasks/scripts/flash_image.sh
@@ -17,7 +17,9 @@ fi
 echo "Using client config: ${JMP_CLIENT_CONFIG}"
 
 echo "refreshing jumpstarter token"
-jmp login --client-config "${JMP_CLIENT_CONFIG}"
+if ! jmp login --client-config "${JMP_CLIENT_CONFIG}" 2>&1; then
+    echo "WARNING: jmp login failed, continuing with existing credentials"
+fi
 
 FLASH_CMD="${FLASH_CMD:-j storage flash oci://{image_uri}}"
 FLASH_CMD=$(echo "${FLASH_CMD}" | sed "s|{image_uri}|${IMAGE_REF}|g")


### PR DESCRIPTION
jmp login for refreshing may fail, if the user is a machine user and does not log in using OIDC integration

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [X] Tested on OpenShift cluster (if applicable)
