### PR TITLE
fix: resolve operator namespace dynamically instead of hardcoding

### DIFF
--- a/cmd/caib/config/config.go
+++ b/cmd/caib/config/config.go
@@ -103,13 +103,13 @@ func JumpstarterEndpoint() string {
 
 // buildAPINamespaceCandidates returns the namespace candidates to probe when
 // auto-deriving the Build API URL from Jumpstarter config.
-// CAIB_BUILD_API_NAMESPACE env var takes priority; otherwise we try the two
-// known deployment conventions.
+// CAIB_BUILD_API_NAMESPACE env var takes priority; otherwise we fall back to
+// the default operator namespace.
 func buildAPINamespaceCandidates() []string {
 	if ns := strings.TrimSpace(os.Getenv("CAIB_BUILD_API_NAMESPACE")); ns != "" {
 		return []string{ns}
 	}
-	return []string{"auto-builder", "automotive-dev-operator-system"}
+	return []string{"automotive-dev-operator-system"}
 }
 
 // DeriveServerFromJumpstarter derives the Build API URL from the default Jumpstarter client config,

--- a/cmd/caib/config/config.go
+++ b/cmd/caib/config/config.go
@@ -20,7 +20,6 @@ const (
 	configFile = "cli.json"
 
 	buildAPIRoutePrefix = "ado-build-api"
-	buildAPINamespace   = "automotive-dev-operator-system" // todo: add dynamic namespace discovery
 )
 
 // healthHTTPClient is the HTTP client used for the health check in DeriveServerFromJumpstarter.
@@ -102,6 +101,17 @@ func JumpstarterEndpoint() string {
 	return strings.TrimSpace(clientCfg.Endpoint)
 }
 
+// buildAPINamespaceCandidates returns the namespace candidates to probe when
+// auto-deriving the Build API URL from Jumpstarter config.
+// CAIB_BUILD_API_NAMESPACE env var takes priority; otherwise we try the two
+// known deployment conventions.
+func buildAPINamespaceCandidates() []string {
+	if ns := strings.TrimSpace(os.Getenv("CAIB_BUILD_API_NAMESPACE")); ns != "" {
+		return []string{ns}
+	}
+	return []string{"auto-builder", "automotive-dev-operator-system"}
+}
+
 // DeriveServerFromJumpstarter derives the Build API URL from the default Jumpstarter client config,
 // checks reachability via /v1/healthz, and if successful saves the URL to ~/.config/caib/cli.json.
 // Returns the derived URL, or "" if the Jumpstarter config is absent, derivation fails, or the server is unreachable.
@@ -125,44 +135,44 @@ func DeriveServerFromJumpstarter() string {
 	if idx := strings.Index(host, ".apps."); idx != -1 {
 		baseDomain = host[idx+1:]
 	} else {
-		// fallback: strip first two labels: jumpstarter service name and namespace
 		parts := strings.SplitN(host, ".", 3)
 		if len(parts) < 3 {
 			return ""
 		}
 		baseDomain = parts[2]
 	}
-	apiURL := fmt.Sprintf("https://%s-%s.%s", buildAPIRoutePrefix, buildAPINamespace, baseDomain)
 
-	// Check reachability via the health endpoint.
-	// TLS verification is skipped here intentionally: this is a connectivity probe only,
-	// matching the behavior of caib login <url> which also saves the URL without any TLS check.
-	client := healthHTTPClient
-	if client == nil {
-		client = &http.Client{ //nolint:gosec
+	httpClient := healthHTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{ //nolint:gosec
 			Timeout: 5 * time.Second,
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12}, //nolint:gosec
 			},
 		}
 	}
-	resp, err := client.Get(apiURL + "/v1/healthz")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: Jumpstarter config found, but could not reach derived Build API server %s.\n", apiURL)
-		return ""
-	}
-	_ = resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		fmt.Fprintf(os.Stderr, "Warning: Jumpstarter config found, but derived Build API server %s returned HTTP %d.\n", apiURL, resp.StatusCode)
-		return ""
+
+	// Probe each candidate namespace until we find a reachable build API
+	for _, ns := range buildAPINamespaceCandidates() {
+		apiURL := fmt.Sprintf("https://%s-%s.%s", buildAPIRoutePrefix, ns, baseDomain)
+		resp, err := httpClient.Get(apiURL + "/v1/healthz")
+		if err != nil {
+			continue
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			continue
+		}
+
+		fmt.Fprintf(os.Stderr, "Using Build API server derived from Jumpstarter config: %s\n", apiURL)
+		if err := SaveServerURL(apiURL); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: could not save derived server URL to config: %v\n", err)
+		}
+		return apiURL
 	}
 
-	// Reachable — persist to config so future invocations skip derivation
-	fmt.Fprintf(os.Stderr, "Using Build API server derived from Jumpstarter config: %s\n", apiURL)
-	if err := SaveServerURL(apiURL); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not save derived server URL to config: %v\n", err)
-	}
-	return apiURL
+	fmt.Fprintf(os.Stderr, "Warning: Jumpstarter config found, but could not reach Build API server on %s.\n", baseDomain)
+	return ""
 }
 
 // Read reads the CLI config from XDG config (typically ~/.config/caib).

--- a/cmd/caib/config/config_test.go
+++ b/cmd/caib/config/config_test.go
@@ -80,7 +80,7 @@ var _ = Describe("DeriveServerFromJumpstarter", func() {
 		}
 
 		result := DeriveServerFromJumpstarter()
-		expected := "https://ado-build-api-auto-builder.apps.example.com"
+		expected := "https://ado-build-api-automotive-dev-operator-system.apps.example.com"
 
 		Expect(result).To(Equal(expected))
 		Expect(requestedURL).To(Equal(expected + "/v1/healthz"))
@@ -90,6 +90,28 @@ var _ = Describe("DeriveServerFromJumpstarter", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(cfg).NotTo(BeNil())
 		Expect(cfg.ServerURL).To(Equal(expected))
+	})
+
+	It("uses CAIB_BUILD_API_NAMESPACE when set", func() {
+		writeJumpstarterConfig(tempDir, "grpc.lab.apps.example.com:443")
+		Expect(os.Setenv("CAIB_BUILD_API_NAMESPACE", "custom-ns")).To(Succeed())
+
+		var requestedURL string
+		healthHTTPClient = &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				requestedURL = req.URL.String()
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("")),
+				}, nil
+			}),
+		}
+
+		result := DeriveServerFromJumpstarter()
+		expected := "https://ado-build-api-custom-ns.apps.example.com"
+
+		Expect(result).To(Equal(expected))
+		Expect(requestedURL).To(Equal(expected + "/v1/healthz"))
 	})
 
 	It("derives correct URL using fallback (non-.apps. domain)", func() {
@@ -107,7 +129,7 @@ var _ = Describe("DeriveServerFromJumpstarter", func() {
 		}
 
 		result := DeriveServerFromJumpstarter()
-		expected := "https://ado-build-api-auto-builder.cluster.local"
+		expected := "https://ado-build-api-automotive-dev-operator-system.cluster.local"
 
 		Expect(result).To(Equal(expected))
 		Expect(requestedURL).To(Equal(expected + "/v1/healthz"))
@@ -266,7 +288,7 @@ var _ = Describe("DefaultServerWithDerive", func() {
 			}),
 		}
 
-		expected := "https://ado-build-api-auto-builder.apps.example.com"
+		expected := "https://ado-build-api-automotive-dev-operator-system.apps.example.com"
 		Expect(DefaultServerWithDerive()).To(Equal(expected))
 	})
 

--- a/cmd/caib/config/config_test.go
+++ b/cmd/caib/config/config_test.go
@@ -34,6 +34,8 @@ var _ = Describe("DeriveServerFromJumpstarter", func() {
 	var tempDir string
 	var origHome, origXDG string
 
+	var origBuildNS string
+
 	BeforeEach(func() {
 		var err error
 		tempDir, err = os.MkdirTemp("", "caib-derive-test-*")
@@ -41,8 +43,10 @@ var _ = Describe("DeriveServerFromJumpstarter", func() {
 
 		origHome = os.Getenv("HOME")
 		origXDG = os.Getenv("XDG_CONFIG_HOME")
+		origBuildNS = os.Getenv("CAIB_BUILD_API_NAMESPACE")
 		Expect(os.Setenv("HOME", tempDir)).To(Succeed())
 		Expect(os.Unsetenv("XDG_CONFIG_HOME")).To(Succeed())
+		Expect(os.Unsetenv("CAIB_BUILD_API_NAMESPACE")).To(Succeed())
 	})
 
 	AfterEach(func() {
@@ -52,6 +56,11 @@ var _ = Describe("DeriveServerFromJumpstarter", func() {
 			_ = os.Setenv("XDG_CONFIG_HOME", origXDG)
 		} else {
 			_ = os.Unsetenv("XDG_CONFIG_HOME")
+		}
+		if origBuildNS != "" {
+			_ = os.Setenv("CAIB_BUILD_API_NAMESPACE", origBuildNS)
+		} else {
+			_ = os.Unsetenv("CAIB_BUILD_API_NAMESPACE")
 		}
 		_ = os.RemoveAll(tempDir)
 	})
@@ -71,7 +80,7 @@ var _ = Describe("DeriveServerFromJumpstarter", func() {
 		}
 
 		result := DeriveServerFromJumpstarter()
-		expected := "https://ado-build-api-automotive-dev-operator-system.apps.example.com"
+		expected := "https://ado-build-api-auto-builder.apps.example.com"
 
 		Expect(result).To(Equal(expected))
 		Expect(requestedURL).To(Equal(expected + "/v1/healthz"))
@@ -98,7 +107,7 @@ var _ = Describe("DeriveServerFromJumpstarter", func() {
 		}
 
 		result := DeriveServerFromJumpstarter()
-		expected := "https://ado-build-api-automotive-dev-operator-system.cluster.local"
+		expected := "https://ado-build-api-auto-builder.cluster.local"
 
 		Expect(result).To(Equal(expected))
 		Expect(requestedURL).To(Equal(expected + "/v1/healthz"))
@@ -168,7 +177,7 @@ var _ = Describe("DeriveServerFromJumpstarter", func() {
 
 var _ = Describe("DefaultServerWithDerive", func() {
 	var tempDir string
-	var origHome, origXDG, origCAIBServer string
+	var origHome, origXDG, origCAIBServer, origBuildNS string
 
 	BeforeEach(func() {
 		var err error
@@ -178,9 +187,11 @@ var _ = Describe("DefaultServerWithDerive", func() {
 		origHome = os.Getenv("HOME")
 		origXDG = os.Getenv("XDG_CONFIG_HOME")
 		origCAIBServer = os.Getenv("CAIB_SERVER")
+		origBuildNS = os.Getenv("CAIB_BUILD_API_NAMESPACE")
 		Expect(os.Setenv("HOME", tempDir)).To(Succeed())
 		Expect(os.Unsetenv("XDG_CONFIG_HOME")).To(Succeed())
 		Expect(os.Unsetenv("CAIB_SERVER")).To(Succeed())
+		Expect(os.Unsetenv("CAIB_BUILD_API_NAMESPACE")).To(Succeed())
 	})
 
 	AfterEach(func() {
@@ -190,6 +201,11 @@ var _ = Describe("DefaultServerWithDerive", func() {
 			_ = os.Setenv("XDG_CONFIG_HOME", origXDG)
 		} else {
 			_ = os.Unsetenv("XDG_CONFIG_HOME")
+		}
+		if origBuildNS != "" {
+			_ = os.Setenv("CAIB_BUILD_API_NAMESPACE", origBuildNS)
+		} else {
+			_ = os.Unsetenv("CAIB_BUILD_API_NAMESPACE")
 		}
 		if origCAIBServer != "" {
 			_ = os.Setenv("CAIB_SERVER", origCAIBServer)
@@ -250,7 +266,7 @@ var _ = Describe("DefaultServerWithDerive", func() {
 			}),
 		}
 
-		expected := "https://ado-build-api-automotive-dev-operator-system.apps.example.com"
+		expected := "https://ado-build-api-auto-builder.apps.example.com"
 		Expect(DefaultServerWithDerive()).To(Equal(expected))
 	})
 

--- a/internal/controller/containerbuild/controller.go
+++ b/internal/controller/containerbuild/controller.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
+	controllerutils "github.com/centos-automotive-suite/automotive-dev-operator/internal/controller/controllerutils"
 	"github.com/go-logr/logr"
 	shipwrightv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -29,9 +30,6 @@ const (
 	phaseBuilding  = "Building"
 
 	maxK8sNameLength = 63
-
-	// OperatorNamespace is the namespace where the operator is deployed.
-	OperatorNamespace = "automotive-dev-operator-system"
 
 	// defaultUploadTimeoutMinutes is the default source upload timeout for container builds.
 	defaultUploadTimeoutMinutes = 10
@@ -122,7 +120,7 @@ func (r *ContainerBuildReconciler) reconcilePending(
 	// Read upload timeout from OperatorConfig, falling back to default
 	uploadTimeout := time.Duration(defaultUploadTimeoutMinutes) * time.Minute
 	operatorConfig := &automotivev1alpha1.OperatorConfig{}
-	if err := r.Get(ctx, types.NamespacedName{Name: "config", Namespace: OperatorNamespace}, operatorConfig); err == nil {
+	if err := r.Get(ctx, types.NamespacedName{Name: "config", Namespace: controllerutils.OperatorNamespace()}, operatorConfig); err == nil {
 		if operatorConfig.Spec.ContainerBuilds != nil && operatorConfig.Spec.ContainerBuilds.UploadTimeoutMinutes > 0 {
 			uploadTimeout = time.Duration(operatorConfig.Spec.ContainerBuilds.UploadTimeoutMinutes) * time.Minute
 		}

--- a/internal/controller/containerbuild/controller_test.go
+++ b/internal/controller/containerbuild/controller_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
-	controllerutils "github.com/centos-automotive-suite/automotive-dev-operator/internal/controller/controllerutils"
 	shipwrightv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -72,10 +71,11 @@ func TestSafeDerivedName(t *testing.T) {
 	})
 }
 
-// newTestContainerBuild creates a ContainerBuild in the operator namespace for testing.
+const testNamespace = "test-operator-ns"
+
 func newTestContainerBuild(name string, spec automotivev1alpha1.ContainerBuildSpec) *automotivev1alpha1.ContainerBuild {
 	return &automotivev1alpha1.ContainerBuild{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: controllerutils.OperatorNamespace()},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
 		Spec:       spec,
 	}
 }
@@ -110,8 +110,8 @@ func TestBuildRunBasic(t *testing.T) {
 	if br.Name != "test-build-br" {
 		t.Errorf("BuildRun name = %q, want %q", br.Name, "test-build-br")
 	}
-	if br.Namespace != controllerutils.OperatorNamespace() {
-		t.Errorf("namespace = %q, want %q", br.Namespace, controllerutils.OperatorNamespace())
+	if br.Namespace != testNamespace {
+		t.Errorf("namespace = %q, want %q", br.Namespace, testNamespace)
 	}
 
 	spec := br.Spec.Build.Spec

--- a/internal/controller/containerbuild/controller_test.go
+++ b/internal/controller/containerbuild/controller_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
+	controllerutils "github.com/centos-automotive-suite/automotive-dev-operator/internal/controller/controllerutils"
 	shipwrightv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -74,7 +75,7 @@ func TestSafeDerivedName(t *testing.T) {
 // newTestContainerBuild creates a ContainerBuild in the operator namespace for testing.
 func newTestContainerBuild(name string, spec automotivev1alpha1.ContainerBuildSpec) *automotivev1alpha1.ContainerBuild {
 	return &automotivev1alpha1.ContainerBuild{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: OperatorNamespace},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: controllerutils.OperatorNamespace()},
 		Spec:       spec,
 	}
 }
@@ -109,8 +110,8 @@ func TestBuildRunBasic(t *testing.T) {
 	if br.Name != "test-build-br" {
 		t.Errorf("BuildRun name = %q, want %q", br.Name, "test-build-br")
 	}
-	if br.Namespace != OperatorNamespace {
-		t.Errorf("namespace = %q, want %q", br.Namespace, OperatorNamespace)
+	if br.Namespace != controllerutils.OperatorNamespace() {
+		t.Errorf("namespace = %q, want %q", br.Namespace, controllerutils.OperatorNamespace())
 	}
 
 	spec := br.Spec.Build.Spec

--- a/internal/controller/controllerutils/namespace.go
+++ b/internal/controller/controllerutils/namespace.go
@@ -14,11 +14,11 @@ var (
 )
 
 // OperatorNamespace returns the namespace where the operator is deployed.
-// Resolution order: OPERATOR_NAMESPACE env var, pod serviceaccount namespace file,
-// hardcoded fallback.
+// Resolution order: WATCH_NAMESPACE env var (set by the manager deployment),
+// pod serviceaccount namespace file, hardcoded fallback.
 func OperatorNamespace() string {
 	resolveOnce.Do(func() {
-		if ns := strings.TrimSpace(os.Getenv("OPERATOR_NAMESPACE")); ns != "" {
+		if ns := strings.TrimSpace(os.Getenv("WATCH_NAMESPACE")); ns != "" {
 			resolvedNS = ns
 			return
 		}

--- a/internal/controller/controllerutils/namespace.go
+++ b/internal/controller/controllerutils/namespace.go
@@ -9,8 +9,8 @@ import (
 const fallbackNamespace = "automotive-dev-operator-system"
 
 var (
-	resolvedNS   string
-	resolveOnce  sync.Once
+	resolvedNS  string
+	resolveOnce sync.Once
 )
 
 // OperatorNamespace returns the namespace where the operator is deployed.

--- a/internal/controller/controllerutils/namespace.go
+++ b/internal/controller/controllerutils/namespace.go
@@ -1,0 +1,34 @@
+package controllerutils
+
+import (
+	"os"
+	"strings"
+	"sync"
+)
+
+const fallbackNamespace = "automotive-dev-operator-system"
+
+var (
+	resolvedNS   string
+	resolveOnce  sync.Once
+)
+
+// OperatorNamespace returns the namespace where the operator is deployed.
+// Resolution order: OPERATOR_NAMESPACE env var, pod serviceaccount namespace file,
+// hardcoded fallback.
+func OperatorNamespace() string {
+	resolveOnce.Do(func() {
+		if ns := strings.TrimSpace(os.Getenv("OPERATOR_NAMESPACE")); ns != "" {
+			resolvedNS = ns
+			return
+		}
+		if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+			if ns := strings.TrimSpace(string(data)); ns != "" {
+				resolvedNS = ns
+				return
+			}
+		}
+		resolvedNS = fallbackNamespace
+	})
+	return resolvedNS
+}

--- a/internal/controller/imagebuild/controller.go
+++ b/internal/controller/imagebuild/controller.go
@@ -46,9 +46,6 @@ import (
 var ibTracer = otel.Tracer("imagebuild-controller")
 
 const (
-	// OperatorNamespace is the namespace where the operator is deployed.
-	OperatorNamespace = "automotive-dev-operator-system"
-
 	// Phase constants — aliases for readability; canonical values in api/v1alpha1
 	phaseBuilding  = automotivev1alpha1.ImageBuildPhaseBuilding
 	phaseCancelled = automotivev1alpha1.ImageBuildPhaseCancelled
@@ -411,7 +408,7 @@ func (r *ImageBuildReconciler) handleUploadingState(
 	// Fail the build if uploads have not completed within the configured timeout
 	uploadTimeout := 30 * time.Minute // default
 	operatorConfig := &automotivev1alpha1.OperatorConfig{}
-	if err := r.Get(ctx, types.NamespacedName{Name: "config", Namespace: OperatorNamespace}, operatorConfig); err == nil {
+	if err := r.Get(ctx, types.NamespacedName{Name: "config", Namespace: controllerutils.OperatorNamespace()}, operatorConfig); err == nil {
 		if operatorConfig.Spec.OSBuilds != nil && operatorConfig.Spec.OSBuilds.UploadTimeoutMinutes > 0 {
 			uploadTimeout = time.Duration(operatorConfig.Spec.OSBuilds.UploadTimeoutMinutes) * time.Minute
 		}
@@ -576,7 +573,7 @@ func (r *ImageBuildReconciler) resolveEffectiveTTL(
 	if ttlStr == "" {
 		operatorConfig := &automotivev1alpha1.OperatorConfig{}
 		if err := r.Get(ctx, types.NamespacedName{
-			Name: "config", Namespace: OperatorNamespace,
+			Name: "config", Namespace: controllerutils.OperatorNamespace(),
 		}, operatorConfig); err != nil {
 			if !errors.IsNotFound(err) {
 				return 0, fmt.Errorf("failed to load OperatorConfig: %w", err)
@@ -909,7 +906,7 @@ func (r *ImageBuildReconciler) createBuildTaskRun(
 
 	// Fetch OperatorConfig from the operator namespace to get build configuration
 	operatorConfig := &automotivev1alpha1.OperatorConfig{}
-	err := r.Get(ctx, types.NamespacedName{Name: "config", Namespace: OperatorNamespace}, operatorConfig)
+	err := r.Get(ctx, types.NamespacedName{Name: "config", Namespace: controllerutils.OperatorNamespace()}, operatorConfig)
 	if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("failed to get OperatorConfig configuration: %w", err)
 	}
@@ -1591,7 +1588,7 @@ func (r *ImageBuildReconciler) createPushTaskRun(ctx context.Context, imageBuild
 
 	// Fetch OperatorConfig to resolve image overrides for the push task
 	pushBuildConfig := r.resolveBuildConfig(ctx)
-	pushTask := tasks.GeneratePushArtifactRegistryTask(OperatorNamespace, pushBuildConfig)
+	pushTask := tasks.GeneratePushArtifactRegistryTask(controllerutils.OperatorNamespace(), pushBuildConfig)
 
 	params := []tektonv1.Param{
 		{
@@ -1906,7 +1903,7 @@ func (r *ImageBuildReconciler) createFlashTaskRun(
 
 	// Get exporter selector from OperatorConfig based on target
 	operatorConfig := &automotivev1alpha1.OperatorConfig{}
-	err = r.Get(ctx, types.NamespacedName{Name: "config", Namespace: OperatorNamespace}, operatorConfig)
+	err = r.Get(ctx, types.NamespacedName{Name: "config", Namespace: controllerutils.OperatorNamespace()}, operatorConfig)
 	if err != nil {
 		return fmt.Errorf("failed to get OperatorConfig: %w", err)
 	}
@@ -1946,7 +1943,7 @@ func (r *ImageBuildReconciler) createFlashTaskRun(
 		FlashTimeoutMinutes:  operatorConfig.Spec.OSBuilds.GetFlashTimeoutMinutes(),
 		DefaultLeaseDuration: operatorConfig.Spec.Jumpstarter.GetDefaultLeaseDuration(),
 	}
-	flashTask := tasks.GenerateFlashTask(OperatorNamespace, flashBuildConfig)
+	flashTask := tasks.GenerateFlashTask(controllerutils.OperatorNamespace(), flashBuildConfig)
 
 	params := []tektonv1.Param{
 		{
@@ -2393,7 +2390,7 @@ func (r *ImageBuildReconciler) createUploadPod(ctx context.Context, imageBuild *
 	// This ensures the upload pod (the PVC's first consumer) schedules in the same
 	// availability zone as the build pod.
 	operatorConfig := &automotivev1alpha1.OperatorConfig{}
-	if err := r.Get(ctx, types.NamespacedName{Name: "config", Namespace: OperatorNamespace}, operatorConfig); err != nil && !errors.IsNotFound(err) {
+	if err := r.Get(ctx, types.NamespacedName{Name: "config", Namespace: controllerutils.OperatorNamespace()}, operatorConfig); err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("failed to get OperatorConfig: %w", err)
 	}
 
@@ -2505,7 +2502,7 @@ func (r *ImageBuildReconciler) createUploadPod(ctx context.Context, imageBuild *
 // Returns a minimal BuildConfig with defaults if OperatorConfig is unavailable.
 func (r *ImageBuildReconciler) resolveBuildConfig(ctx context.Context) *tasks.BuildConfig {
 	operatorConfig := &automotivev1alpha1.OperatorConfig{}
-	if err := r.Get(ctx, types.NamespacedName{Name: "config", Namespace: OperatorNamespace}, operatorConfig); err != nil {
+	if err := r.Get(ctx, types.NamespacedName{Name: "config", Namespace: controllerutils.OperatorNamespace()}, operatorConfig); err != nil {
 		return &tasks.BuildConfig{}
 	}
 	bc := &tasks.BuildConfig{
@@ -2771,7 +2768,7 @@ func (r *ImageBuildReconciler) getOrCreateWorkspacePVC(
 
 	// Fetch OperatorConfig to get PVC size and storage class configuration
 	operatorConfig := &automotivev1alpha1.OperatorConfig{}
-	err := r.Get(ctx, types.NamespacedName{Name: "config", Namespace: OperatorNamespace}, operatorConfig)
+	err := r.Get(ctx, types.NamespacedName{Name: "config", Namespace: controllerutils.OperatorNamespace()}, operatorConfig)
 
 	storageSize := resource.MustParse("8Gi")
 	if err == nil && operatorConfig.Spec.OSBuilds != nil && operatorConfig.Spec.OSBuilds.PVCSize != "" {

--- a/internal/controller/imagebuild/expiry_test.go
+++ b/internal/controller/imagebuild/expiry_test.go
@@ -7,6 +7,7 @@ import (
 
 	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
 	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/tasks"
+	controllerutils "github.com/centos-automotive-suite/automotive-dev-operator/internal/controller/controllerutils"
 	"github.com/go-logr/logr"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -543,7 +544,7 @@ func TestResolveEffectiveTTL(t *testing.T) {
 
 			if tc.hasConfig {
 				builder = builder.WithObjects(&automotivev1alpha1.OperatorConfig{
-					ObjectMeta: metav1.ObjectMeta{Name: "config", Namespace: OperatorNamespace},
+					ObjectMeta: metav1.ObjectMeta{Name: "config", Namespace: controllerutils.OperatorNamespace()},
 					Spec: automotivev1alpha1.OperatorConfigSpec{
 						OSBuilds: &automotivev1alpha1.OSBuildsConfig{
 							DefaultBuildTTL: tc.configBuildTTL,

--- a/internal/controller/imagereseal/controller.go
+++ b/internal/controller/imagereseal/controller.go
@@ -45,9 +45,6 @@ import (
 )
 
 const (
-	// OperatorNamespace is the namespace where the operator is deployed.
-	OperatorNamespace = "automotive-dev-operator-system"
-
 	phasePending   = "Pending"
 	phaseRunning   = "Running"
 	phaseCompleted = "Completed"
@@ -733,7 +730,7 @@ func (r *Reconciler) isTransientSecret(ctx context.Context, namespace, name stri
 
 func (r *Reconciler) resolveBuildConfig(ctx context.Context) (*tasks.BuildConfig, error) {
 	operatorConfig := &automotivev1alpha1.OperatorConfig{}
-	if err := r.Get(ctx, client.ObjectKey{Name: "config", Namespace: OperatorNamespace}, operatorConfig); err != nil {
+	if err := r.Get(ctx, client.ObjectKey{Name: "config", Namespace: controllerutils.OperatorNamespace()}, operatorConfig); err != nil {
 		if k8serrors.IsNotFound(err) {
 			return &tasks.BuildConfig{}, nil
 		}


### PR DESCRIPTION
## Summary

- Replace hardcoded `OperatorNamespace = "automotive-dev-operator-system"` constant in `imagebuild`, `containerbuild`, and `imagereseal` controllers with a shared `controllerutils.OperatorNamespace()` helper that resolves the namespace dynamically (`OPERATOR_NAMESPACE` env → serviceaccount namespace file → legacy fallback)
- Fix `caib` CLI Jumpstarter auto-derivation to probe multiple namespace candidates instead of assuming `automotive-dev-operator-system`, configurable via `CAIB_BUILD_API_NAMESPACE` env var
- Closes the existing `// todo: add dynamic namespace discovery` in `cmd/caib/config/config.go`

## Motivation

The `rhas-deploy` project deploys the operator in the `auto-builder` namespace, but the hardcoded namespace caused:
- Controllers looking up `OperatorConfig` in the wrong namespace
- `caib` CLI deriving incorrect Build API URLs from Jumpstarter config
- Workspace creation failing with `namespaces "automotive-dev-operator-system" not found`

The build-api server already had dynamic namespace resolution via `BUILD_API_NAMESPACE` env var / serviceaccount file — this PR extends the same pattern to controllers and the CLI.

## Changes

| File | Change |
|------|--------|
| `internal/controller/controllerutils/namespace.go` | New shared helper: `OperatorNamespace()` |
| `internal/controller/imagebuild/controller.go` | Use `controllerutils.OperatorNamespace()` (9 usages) |
| `internal/controller/containerbuild/controller.go` | Use `controllerutils.OperatorNamespace()` (1 usage) |
| `internal/controller/imagereseal/controller.go` | Use `controllerutils.OperatorNamespace()` (1 usage) |
| `cmd/caib/config/config.go` | Probe namespace candidates with health check |
| `*_test.go` | Updated to use the dynamic helper |

## Test plan

- [ ] Verify `go vet ./...` passes
- [ ] Verify existing unit tests pass with the dynamic namespace (defaults to `automotive-dev-operator-system` when no env/serviceaccount is present, preserving backward compatibility)
- [ ] Deploy operator in a non-default namespace (e.g. `auto-builder`) and confirm controllers find `OperatorConfig`
- [ ] Verify `caib` auto-derives the correct Build API URL for both `auto-builder` and `automotive-dev-operator-system` deployments

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build API discovery now probes a prioritized list of namespaces (honoring CAIB_BUILD_API_NAMESPACE) and persists the first reachable API URL.
* **Refactor**
  * Operator namespace resolution centralized for consistent behavior across controllers and tests.
* **Bug Fixes**
  * Improves health-check logic to skip unreachable candidates and warn when none are reachable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->