### PR TITLE
add ocp-4.21 compat

### DIFF
--- a/config/manifests/bases/automotive-dev-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/automotive-dev-operator.clusterserviceversion.yaml
@@ -93,7 +93,7 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Developer Tools
-    com.redhat.openshift.versions: v4.18-v4.20
+    com.redhat.openshift.versions: v4.18-v4.21
     containerImage: quay.io/rh-sdv-cloud/automotive-dev-operator:VERSION
     description: The CentOS Automotive Suite Operator enables building automotive
       OS images on OpenShift clusters.


### PR DESCRIPTION
## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended supported OpenShift capability range to version 4.21, enabling compatibility with the latest OpenShift releases.
  * Updated manifest configuration formatting for improved readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->