### PR TITLE
fix flash cmd rendering

### DIFF
--- a/internal/common/tasks/scripts/flash_image.sh
+++ b/internal/common/tasks/scripts/flash_image.sh
@@ -21,7 +21,10 @@ if ! jmp login --client-config "${JMP_CLIENT_CONFIG}" 2>&1; then
     echo "WARNING: jmp login failed, continuing with existing credentials"
 fi
 
-FLASH_CMD="${FLASH_CMD:-j storage flash oci://{image_uri}}"
+FLASH_CMD="${FLASH_CMD:-}"
+if [[ -z "${FLASH_CMD}" ]]; then
+    FLASH_CMD='j storage flash oci://{image_uri}'
+fi
 FLASH_CMD=$(echo "${FLASH_CMD}" | sed "s|{image_uri}|${IMAGE_REF}|g")
 
 


### PR DESCRIPTION
the closing } was treated as a literal from the flash cmd string

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [X] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced image flashing process to properly handle custom configurations when explicitly specified versus using default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->