### PR TITLE
feat: add initial metrics and observability for sealed operations

### DIFF
--- a/internal/buildapi/sealed.go
+++ b/internal/buildapi/sealed.go
@@ -3,6 +3,7 @@ package buildapi
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -23,6 +24,7 @@ import (
 	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
 	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/labels"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // sealedPathToOperation maps the API path prefix to the AIB sealed operation.
@@ -98,7 +100,7 @@ func validateSealedRequest(req *SealedRequest) ([]string, string) {
 func (a *APIServer) registerSealedRoutes(v1 *gin.RouterGroup) {
 	for _, opPath := range []string{"/prepare-reseals", "/reseals", "/extract-for-signings", "/inject-signeds"} {
 		grp := v1.Group(opPath)
-		grp.Use(a.authMiddleware())
+		grp.Use(sealedMetricsMiddleware(), a.authMiddleware())
 		{
 			grp.POST("", a.handleCreateSealed)
 			grp.GET("", a.handleListSealed)
@@ -132,8 +134,14 @@ func (a *APIServer) handleSealedLogs(c *gin.Context) {
 }
 
 func (a *APIServer) createSealed(c *gin.Context, pathOp SealedOperation) {
+	ctx, span := apiTracer.Start(c.Request.Context(), "createSealed")
+	defer span.End()
+	opLabel := sealedOperationLabel(pathOp, nil)
+
 	var req SealedRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
+		spanError(span, err)
+		SealedCreateRequestsTotal.WithLabelValues(opLabel, "bad_request").Inc()
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid JSON request"})
 		return
 	}
@@ -145,36 +153,51 @@ func (a *APIServer) createSealed(c *gin.Context, pathOp SealedOperation) {
 
 	stages, errMsg := validateSealedRequest(&req)
 	if errMsg != "" {
+		spanError(span, errors.New(errMsg))
+		SealedCreateRequestsTotal.WithLabelValues(opLabel, "bad_request").Inc()
 		c.JSON(http.StatusBadRequest, gin.H{"error": errMsg})
 		return
 	}
+	opLabel = sealedOperationLabel(req.Operation, stages)
+	span.SetAttributes(
+		attribute.String("sealed.name", req.Name),
+		attribute.String("sealed.operation", opLabel),
+	)
 
 	k8sClient, err := getClientFromRequestFn(c)
 	if err != nil {
+		spanError(span, err)
+		SealedCreateRequestsTotal.WithLabelValues(opLabel, "error").Inc()
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 	restCfg, err := getRESTConfigFromRequestFn(c)
 	if err != nil {
+		spanError(span, err)
+		SealedCreateRequestsTotal.WithLabelValues(opLabel, "error").Inc()
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 	clientset, err := kubernetes.NewForConfig(restCfg)
 	if err != nil {
+		spanError(span, err)
+		SealedCreateRequestsTotal.WithLabelValues(opLabel, "error").Inc()
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-
-	ctx := c.Request.Context()
 	namespace := resolveNamespace()
 	requestedBy := a.resolveRequester(c)
 
 	refs, err := createSealedSecrets(ctx, clientset, namespace, &req)
 	if err != nil {
 		if k8serrors.IsAlreadyExists(err) {
+			spanError(span, err)
+			SealedCreateRequestsTotal.WithLabelValues(opLabel, "conflict").Inc()
 			c.JSON(http.StatusConflict, gin.H{"error": fmt.Sprintf("job %s already exists", req.Name)})
 			return
 		}
+		spanError(span, err)
+		SealedCreateRequestsTotal.WithLabelValues(opLabel, "error").Inc()
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -216,9 +239,13 @@ func (a *APIServer) createSealed(c *gin.Context, pathOp SealedOperation) {
 	if err := k8sClient.Create(ctx, imageSealed); err != nil {
 		cleanupSealedSecrets(ctx, clientset, namespace, &req, refs)
 		if k8serrors.IsAlreadyExists(err) {
+			spanError(span, err)
+			SealedCreateRequestsTotal.WithLabelValues(opLabel, "conflict").Inc()
 			c.JSON(http.StatusConflict, gin.H{"error": fmt.Sprintf("job %s already exists", req.Name)})
 			return
 		}
+		spanError(span, err)
+		SealedCreateRequestsTotal.WithLabelValues(opLabel, "error").Inc()
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to create ImageReseal: %v", err)})
 		return
 	}
@@ -228,6 +255,7 @@ func (a *APIServer) createSealed(c *gin.Context, pathOp SealedOperation) {
 			a.log.Error(err, "failed to set owner reference on sealed secret", "secret", secretName, "job", imageSealed.Name)
 		}
 	}
+	SealedCreateRequestsTotal.WithLabelValues(opLabel, "accepted").Inc()
 
 	writeJSON(c, http.StatusAccepted, SealedResponse{
 		Name:        req.Name,
@@ -239,17 +267,21 @@ func (a *APIServer) createSealed(c *gin.Context, pathOp SealedOperation) {
 }
 
 func (a *APIServer) listSealed(c *gin.Context) {
+	ctx, span := apiTracer.Start(c.Request.Context(), "listSealed")
+	defer span.End()
+
 	namespace := resolveNamespace()
 	limit, offset := parsePagination(c)
 
 	k8sClient, err := getClientFromRequestFn(c)
 	if err != nil {
+		spanError(span, err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	ctx := c.Request.Context()
 	list := &automotivev1alpha1.ImageResealList{}
 	if err := k8sClient.List(ctx, list, client.InNamespace(namespace)); err != nil {
+		spanError(span, err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to list ImageReseal: %v", err)})
 		return
 	}
@@ -279,19 +311,24 @@ func (a *APIServer) listSealed(c *gin.Context) {
 }
 
 func (a *APIServer) getSealed(c *gin.Context, name string) {
+	ctx, span := apiTracer.Start(c.Request.Context(), "getSealed")
+	defer span.End()
+	span.SetAttributes(attribute.String("sealed.name", name))
+
 	namespace := resolveNamespace()
 	k8sClient, err := getClientFromRequestFn(c)
 	if err != nil {
+		spanError(span, err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	ctx := c.Request.Context()
 	sealed := &automotivev1alpha1.ImageReseal{}
 	if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, sealed); err != nil {
 		if k8serrors.IsNotFound(err) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "job not found"})
 			return
 		}
+		spanError(span, err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -316,29 +353,36 @@ func (a *APIServer) getSealed(c *gin.Context, name string) {
 }
 
 func (a *APIServer) streamSealedLogs(c *gin.Context, name string) {
+	ctx, span := apiTracer.Start(c.Request.Context(), "streamSealedLogs")
+	defer span.End()
+	span.SetAttributes(attribute.String("sealed.name", name))
+
 	namespace := resolveNamespace()
 	k8sClient, err := getClientFromRequestFn(c)
 	if err != nil {
+		spanError(span, err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 	restCfg, err := getRESTConfigFromRequestFn(c)
 	if err != nil {
+		spanError(span, err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 	clientset, err := kubernetes.NewForConfig(restCfg)
 	if err != nil {
+		spanError(span, err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	ctx := c.Request.Context()
 	sealed := &automotivev1alpha1.ImageReseal{}
 	if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, sealed); err != nil {
 		if k8serrors.IsNotFound(err) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "job not found"})
 			return
 		}
+		spanError(span, err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -350,6 +394,7 @@ func (a *APIServer) streamSealedLogs(c *gin.Context, name string) {
 				c.JSON(http.StatusServiceUnavailable, gin.H{"error": "TaskRun not found yet"})
 				return
 			}
+			spanError(span, err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
@@ -357,6 +402,7 @@ func (a *APIServer) streamSealedLogs(c *gin.Context, name string) {
 	} else if sealed.Status.PipelineRunName != "" {
 		trList := &tektonv1.TaskRunList{}
 		if err := k8sClient.List(ctx, trList, client.InNamespace(namespace), client.MatchingLabels{"tekton.dev/pipelineRun": sealed.Status.PipelineRunName}); err != nil {
+			spanError(span, err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}

--- a/internal/buildapi/sealed_metrics.go
+++ b/internal/buildapi/sealed_metrics.go
@@ -1,0 +1,69 @@
+package buildapi
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	sealedMetricsNamespace = "ado"
+	sealedMetricsSubsystem = "sealed"
+)
+
+var (
+	// SealedCreateRequestsTotal counts sealed create requests by operation and result.
+	SealedCreateRequestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: sealedMetricsNamespace,
+			Subsystem: sealedMetricsSubsystem,
+			Name:      "create_requests_total",
+			Help:      "Total number of sealed create requests by operation and result",
+		},
+		[]string{"operation", "result"},
+	)
+
+	// SealedRequestDuration tracks sealed API request duration by endpoint and status code.
+	SealedRequestDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: sealedMetricsNamespace,
+			Subsystem: sealedMetricsSubsystem,
+			Name:      "request_duration_seconds",
+			Help:      "Sealed API request duration in seconds",
+			Buckets:   prometheus.DefBuckets,
+		},
+		[]string{"endpoint", "status_code"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(
+		SealedCreateRequestsTotal,
+		SealedRequestDuration,
+	)
+}
+
+func sealedMetricsMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		start := time.Now()
+		c.Next()
+		duration := time.Since(start).Seconds()
+		endpoint := c.FullPath()
+		statusCode := fmt.Sprintf("%d", c.Writer.Status())
+		SealedRequestDuration.WithLabelValues(endpoint, statusCode).Observe(duration)
+	}
+}
+
+func sealedOperationLabel(op SealedOperation, stages []string) string {
+	if op != "" {
+		return string(op)
+	}
+	// For multi-stage flows, use only the first stage to keep label
+	// cardinality bounded and comparable across requests.
+	if len(stages) > 0 {
+		return stages[0]
+	}
+	return "unknown"
+}

--- a/internal/buildapi/sealed_metrics_test.go
+++ b/internal/buildapi/sealed_metrics_test.go
@@ -1,0 +1,78 @@
+package buildapi
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // Dot import is standard for Ginkgo
+	. "github.com/onsi/gomega"    //nolint:revive // Dot import is standard for Gomega
+)
+
+var _ = Describe("Sealed Metrics", func() {
+	var server *APIServer
+
+	BeforeEach(func() {
+		gin.SetMode(gin.TestMode)
+		server = NewAPIServer(":0", logr.Discard())
+	})
+
+	Context("metrics endpoint", func() {
+		It("should expose prometheus metrics at /metrics", func() {
+			// Ensure counter and histogram are present in exposition.
+			SealedCreateRequestsTotal.WithLabelValues("reseal", "accepted").Inc()
+			// Ensure at least one observation so the histogram appears
+			SealedRequestDuration.WithLabelValues("/v1/reseals", "200").Observe(0.001)
+
+			req, err := http.NewRequest("GET", "/metrics", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			w := httptest.NewRecorder()
+			server.router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			body := w.Body.String()
+			Expect(body).To(ContainSubstring("ado_sealed_create_requests_total"))
+			Expect(body).To(ContainSubstring("ado_sealed_request_duration_seconds"))
+		})
+
+		It("records bad request metric for sealed route through router", func() {
+			metricsTestRouter := gin.New()
+			metricsTestRouter.POST("/v1/reseals", sealedMetricsMiddleware(), func(c *gin.Context) {
+				server.createSealed(c, SealedReseal)
+			})
+			metricsTestRouter.GET("/metrics", metricsHandler())
+
+			reqBody := []byte(`{"name":"metrics-test","operation":"bad-op","inputRef":"quay.io/example/input:latest"}`)
+			req := httptest.NewRequest(http.MethodPost, "/v1/reseals", bytes.NewReader(reqBody))
+			req.Header.Set("Content-Type", "application/json")
+
+			w := httptest.NewRecorder()
+			metricsTestRouter.ServeHTTP(w, req)
+			Expect(w.Code).To(Equal(http.StatusBadRequest))
+
+			metricsReq, err := http.NewRequest(http.MethodGet, "/metrics", nil)
+			Expect(err).NotTo(HaveOccurred())
+			metricsResp := httptest.NewRecorder()
+			metricsTestRouter.ServeHTTP(metricsResp, metricsReq)
+
+			Expect(metricsResp.Code).To(Equal(http.StatusOK))
+			metricsBody := metricsResp.Body.String()
+			Expect(metricsBody).To(ContainSubstring(`ado_sealed_create_requests_total{operation="reseal",result="bad_request"}`))
+		})
+	})
+
+	Context("sealedOperationLabel", func() {
+		It("prefers explicit operation", func() {
+			label := sealedOperationLabel(SealedReseal, []string{"prepare-reseal"})
+			Expect(label).To(Equal("reseal"))
+		})
+
+		It("falls back to first stage", func() {
+			label := sealedOperationLabel("", []string{"extract-for-signing", "inject-signed"})
+			Expect(label).To(Equal("extract-for-signing"))
+		})
+	})
+})


### PR DESCRIPTION
Assisted-by: gpt-5.3-codex

## Summary
Add initial Prometheus metrics and OTel tracing for sealed operations, with tests for metrics exposure and behavior.

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [X] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive metrics for sealed operations: request outcome counters and request-duration histograms.
  * Instrumented sealed endpoints with distributed tracing spans and operation labels to capture operation names and outcomes.

* **Bug Fixes**
  * Ensured handlers consistently use the span-derived request context for tracing and metrics.

* **Tests**
  * Added tests validating metrics exposure and operation-label behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->