### PR TITLE
feat: Add validation for provided URL when running caib login

### DIFF
--- a/cmd/caib/login.go
+++ b/cmd/caib/login.go
@@ -2,14 +2,72 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/auth"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/config"
 	"github.com/spf13/cobra"
 )
+
+// normalizeServerURL parses and normalizes a raw server URL argument.
+// It prepends "https://" if no scheme is present, and rejects URLs with
+// invalid schemes, credentials, query parameters, fragments, or non-root paths.
+func normalizeServerURL(raw string) (string, error) {
+	server := strings.TrimSpace(raw)
+	if server == "" {
+		return "", fmt.Errorf("server URL is required")
+	}
+	if strings.Contains(server, "://") {
+		if !strings.HasPrefix(server, "http://") && !strings.HasPrefix(server, "https://") {
+			return "", fmt.Errorf("invalid server URL %q: scheme must be http or https", raw)
+		}
+	} else {
+		server = "https://" + server
+	}
+	parsedURL, err := url.Parse(server)
+	if err != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
+		return "", fmt.Errorf("invalid server URL %q", raw)
+	}
+	if parsedURL.User != nil {
+		return "", fmt.Errorf("server URL must not include credentials")
+	}
+	if parsedURL.RawQuery != "" {
+		return "", fmt.Errorf("server URL must not include query parameters")
+	}
+	if parsedURL.Fragment != "" {
+		return "", fmt.Errorf("server URL must not include fragments")
+	}
+	if parsedURL.Path != "" && parsedURL.Path != "/" {
+		return "", fmt.Errorf("server URL must not include a non-root path")
+	}
+	return parsedURL.Scheme + "://" + parsedURL.Host, nil
+}
+
+// checkServerReachable performs a lightweight GET against /v1/healthz to confirm
+// the server exists and is reachable before the URL is persisted to config.
+// Any HTTP response (even an error status) is accepted — only a connection
+// failure causes an error.
+func checkServerReachable(serverURL string, insecureSkipTLS bool) error {
+	transport := &http.Transport{}
+	if insecureSkipTLS {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec
+	}
+	client := &http.Client{
+		Timeout:   10 * time.Second,
+		Transport: transport,
+	}
+	resp, err := client.Get(strings.TrimSuffix(serverURL, "/") + "/v1/healthz")
+	if err != nil {
+		return err
+	}
+	_ = resp.Body.Close()
+	return nil
+}
 
 // runLogin saves the server URL and optionally performs OIDC authentication.
 func runLogin(_ *cobra.Command, args []string) {
@@ -21,34 +79,15 @@ func runLogin(_ *cobra.Command, args []string) {
 			handleError(fmt.Errorf("no Jumpstarter config found or derived endpoint unreachable; provide a server URL explicitly"))
 		}
 	} else {
-		server = strings.TrimSpace(args[0])
-		if server == "" {
-			handleError(fmt.Errorf("server URL is required"))
+		var err error
+		server, err = normalizeServerURL(args[0])
+		if err != nil {
+			handleError(err)
 		}
-		if !strings.HasPrefix(server, "http://") && !strings.HasPrefix(server, "https://") {
-			server = "https://" + server
-		}
+	}
 
-		parsedURL, err := url.Parse(server)
-		if err != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
-			handleError(fmt.Errorf("invalid server URL %q", server))
-		}
-		if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
-			handleError(fmt.Errorf("invalid server URL %q: scheme must be http or https", server))
-		}
-		if parsedURL.User != nil {
-			handleError(fmt.Errorf("server URL must not include credentials"))
-		}
-		if parsedURL.RawQuery != "" {
-			handleError(fmt.Errorf("server URL must not include query parameters"))
-		}
-		if parsedURL.Fragment != "" {
-			handleError(fmt.Errorf("server URL must not include fragments"))
-		}
-		if parsedURL.Path != "" && parsedURL.Path != "/" {
-			handleError(fmt.Errorf("server URL must not include a non-root path"))
-		}
-		server = parsedURL.Scheme + "://" + parsedURL.Host
+	if err := checkServerReachable(server, insecureSkipTLS); err != nil {
+		handleError(fmt.Errorf("cannot connect to server %q: %w", server, err))
 	}
 
 	if err := config.SaveServerURL(server); err != nil {

--- a/cmd/caib/login_test.go
+++ b/cmd/caib/login_test.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/config"
+)
+
+func TestNormalizeServerURL(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    string
+		wantErr bool
+	}{
+		// valid inputs
+		{input: "https://example.com", want: "https://example.com"},
+		{input: "http://example.com", want: "http://example.com"},
+		{input: "example.com", want: "https://example.com"},
+		{input: "example.com/", want: "https://example.com"},
+		{input: "  example.com  ", want: "https://example.com"},
+		{input: "https://example.com/", want: "https://example.com"},
+		{input: "https://example.com:8443", want: "https://example.com:8443"},
+		{input: "http://192.168.1.1:9090", want: "http://192.168.1.1:9090"},
+
+		// empty / whitespace
+		{input: "", wantErr: true},
+		{input: "   ", wantErr: true},
+
+		// missing host (e.g. bare "https://")
+		{input: "https://", wantErr: true},
+		{input: "http://", wantErr: true},
+
+		// disallowed components
+		{input: "https://user:pass@example.com", wantErr: true},
+		{input: "https://example.com?foo=bar", wantErr: true},
+		{input: "https://example.com#anchor", wantErr: true},
+		{input: "https://example.com/some/path", wantErr: true},
+
+		// invalid schemes — must be caught before https:// prepend
+		{input: "ftp://example.com", wantErr: true},
+		{input: "grpc://example.com", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := normalizeServerURL(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("normalizeServerURL(%q) = %q, want error", tt.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("normalizeServerURL(%q) unexpected error: %v", tt.input, err)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("normalizeServerURL(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCheckServerReachable_Unreachable verifies that an unreachable address
+// returns an error, which prevents the URL from being saved to config.
+func TestCheckServerReachable_Unreachable(t *testing.T) {
+	// Port 1 is never open; any HTTP dial will fail immediately.
+	err := checkServerReachable("http://127.0.0.1:1", false)
+	if err == nil {
+		t.Fatal("expected error for unreachable server, got nil")
+	}
+}
+
+// TestCheckServerReachable_Reachable verifies that a server responding on
+// /v1/healthz (any status code) is considered reachable.
+func TestCheckServerReachable_Reachable(t *testing.T) {
+	// Return 200 OK — healthy server.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	if err := checkServerReachable(srv.URL, false); err != nil {
+		t.Errorf("unexpected error for reachable server: %v", err)
+	}
+}
+
+// TestCheckServerReachable_NonOKStatusStillReachable verifies that a non-200
+// response (e.g. 404 when the server has no healthz endpoint) is still treated
+// as reachable — only connection failures are fatal.
+func TestCheckServerReachable_NonOKStatusStillReachable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	if err := checkServerReachable(srv.URL, false); err != nil {
+		t.Errorf("unexpected error for server returning 404: %v", err)
+	}
+}
+
+// TestLoginDoesNotSaveConfigWhenServerUnreachable verifies that an unreachable
+// server URL is never written to the config file. This mirrors the runLogin
+// guard: checkServerReachable must succeed before SaveServerURL is called.
+func TestLoginDoesNotSaveConfigWhenServerUnreachable(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	cfgPath := filepath.Join(tmpDir, "caib", "cli.json")
+	if _, err := os.Stat(cfgPath); !os.IsNotExist(err) {
+		t.Fatal("config file should not exist before test")
+	}
+
+	// checkServerReachable fails → SaveServerURL must not be called.
+	if err := checkServerReachable("http://127.0.0.1:1", false); err == nil {
+		t.Fatal("expected reachability error, got nil")
+	}
+
+	if _, err := os.Stat(cfgPath); !os.IsNotExist(err) {
+		t.Error("config file must not be written when the server is unreachable")
+	}
+}
+
+// TestLoginSavesConfigWhenServerReachable verifies that a reachable server
+// results in the URL being saved to config.
+func TestLoginSavesConfigWhenServerReachable(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	if err := checkServerReachable(srv.URL, false); err != nil {
+		t.Fatalf("unexpected reachability error: %v", err)
+	}
+
+	if err := config.SaveServerURL(srv.URL); err != nil {
+		t.Fatalf("SaveServerURL: %v", err)
+	}
+
+	cfgPath := filepath.Join(tmpDir, "caib", "cli.json")
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("config file not found after save: %v", err)
+	}
+
+	var cfg config.CLIConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("failed to parse config: %v", err)
+	}
+	if cfg.ServerURL != srv.URL {
+		t.Errorf("config server_url = %q, want %q", cfg.ServerURL, srv.URL)
+	}
+}


### PR DESCRIPTION

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [X] Tested on OpenShift cluster (if applicable) + locally with caib

releted to: https://github.com/centos-automotive-suite/automotive-dev-operator/issues/138


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Login now validates and normalizes server URLs (trims input, auto-adds https when needed, rejects invalid formats) and verifies server connectivity before saving configuration.

* **Tests**
  * Added tests covering URL normalization, server reachability behavior, and config persistence to ensure correct save/no-save behavior based on connectivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->