### PR TITLE
caib: add --define-file

### DIFF
--- a/cmd/caib/buildcmd/build.go
+++ b/cmd/caib/buildcmd/build.go
@@ -49,6 +49,7 @@ type Options struct {
 	Timeout                *int
 	WaitForBuild           *bool
 	CustomDefs             *[]string
+	DefineFiles            *[]string
 	AIBExtraArgs           *[]string
 	ExtraRepos             *[]string
 	Workspace              *string
@@ -383,6 +384,21 @@ func (h *Handler) displayBuildLogsCommand(buildName string) {
 	fmt.Printf("\n%s\n  %s\n\n", labelColor("View build logs:"), commandColor("caib image logs "+buildName))
 }
 
+func (h *Handler) resolveCustomDefs() ([]string, error) {
+	var defs []string
+	if len(*h.opts.DefineFiles) > 0 {
+		fileDefs, err := common.LoadDefineFiles(*h.opts.DefineFiles)
+		if err != nil {
+			return nil, err
+		}
+		defs = append(defs, fileDefs...)
+	}
+	if h.opts.CustomDefs != nil {
+		defs = append(defs, *h.opts.CustomDefs...)
+	}
+	return defs, nil
+}
+
 // RunBuild handles the main `caib image build` command.
 func (h *Handler) RunBuild(cmd *cobra.Command, args []string) {
 	h.applyWaitFollowDefaults(cmd, true, false)
@@ -430,6 +446,12 @@ func (h *Handler) RunBuild(cmd *cobra.Command, args []string) {
 
 	h.resolveTarget(cmd, common.ManifestTarget(manifestBytes))
 
+	customDefs, err := h.resolveCustomDefs()
+	if err != nil {
+		h.handleError(err)
+		return
+	}
+
 	req := buildapitypes.BuildRequest{
 		Name:                   *h.opts.BuildName,
 		Manifest:               string(manifestBytes),
@@ -441,7 +463,7 @@ func (h *Handler) RunBuild(cmd *cobra.Command, args []string) {
 		Mode:                   buildapitypes.ModeBootc,
 		AutomotiveImageBuilder: *h.opts.AutomotiveImageBuilder,
 		StorageClass:           *h.opts.StorageClass,
-		CustomDefs:             *h.opts.CustomDefs,
+		CustomDefs:             customDefs,
 		AIBExtraArgs:           *h.opts.AIBExtraArgs,
 		ExtraRepos:             *h.opts.ExtraRepos,
 		Workspace:              *h.opts.Workspace,
@@ -661,6 +683,12 @@ func (h *Handler) RunBuildDev(cmd *cobra.Command, args []string) {
 
 	h.resolveTarget(cmd, common.ManifestTarget(manifestBytes))
 
+	customDefs, err := h.resolveCustomDefs()
+	if err != nil {
+		h.handleError(err)
+		return
+	}
+
 	var parsedMode buildapitypes.Mode
 	switch *h.opts.Mode {
 	case "image":
@@ -688,7 +716,7 @@ func (h *Handler) RunBuildDev(cmd *cobra.Command, args []string) {
 		Mode:                   parsedMode,
 		AutomotiveImageBuilder: *h.opts.AutomotiveImageBuilder,
 		StorageClass:           *h.opts.StorageClass,
-		CustomDefs:             *h.opts.CustomDefs,
+		CustomDefs:             customDefs,
 		AIBExtraArgs:           *h.opts.AIBExtraArgs,
 		ExtraRepos:             *h.opts.ExtraRepos,
 		Workspace:              *h.opts.Workspace,

--- a/cmd/caib/buildcmd/build_define_test.go
+++ b/cmd/caib/buildcmd/build_define_test.go
@@ -1,0 +1,36 @@
+package buildcmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveCustomDefs_FileThenInline(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "vars.yaml")
+	if err := os.WriteFile(path, []byte("routing: Proxy\nverbose: true\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := newTestDiskOpts()
+	*opts.DefineFiles = []string{path}
+	*opts.CustomDefs = []string{"routing=Engine"}
+
+	h := NewHandler(opts)
+	got, err := h.resolveCustomDefs()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// File defines first, inline after — inline "routing=Engine" comes last
+	want := []string{`routing="Proxy"`, `verbose=true`, `routing=Engine`}
+	if len(got) != len(want) {
+		t.Fatalf("got %d items, want %d: %v", len(got), len(want), got)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/cmd/caib/buildcmd/build_disk_test.go
+++ b/cmd/caib/buildcmd/build_disk_test.go
@@ -49,6 +49,7 @@ func newTestDiskOpts() Options {
 		buildTTL             string
 		insecureSkipTLS      bool
 	)
+	var defineFiles []string
 	return Options{
 		ServerURL:                 &serverURL,
 		Manifest:                  &manifest,
@@ -64,6 +65,7 @@ func newTestDiskOpts() Options {
 		Timeout:                   &timeout,
 		WaitForBuild:              &waitForBuild,
 		CustomDefs:                &customDefs,
+		DefineFiles:               &defineFiles,
 		AIBExtraArgs:              &aibExtraArgs,
 		FollowLogs:                &followLogs,
 		CompressionAlgo:           &compressionAlgo,

--- a/cmd/caib/common/define_file.go
+++ b/cmd/caib/common/define_file.go
@@ -1,0 +1,53 @@
+package caibcommon
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+
+	"gopkg.in/yaml.v3"
+)
+
+// LoadDefineFiles reads one or more YAML dictionary files and returns
+// KEY=VALUE strings with JSON-encoded values, matching AIB's --define-file
+// behavior. Later files override earlier ones for the same key.
+func LoadDefineFiles(paths []string) ([]string, error) {
+	merged := make(map[string]any)
+
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("reading define file %q: %w", path, err)
+		}
+
+		var fileDefines map[string]any
+		if err := yaml.Unmarshal(data, &fileDefines); err != nil {
+			return nil, fmt.Errorf("parsing define file %q: %w", path, err)
+		}
+		if fileDefines == nil {
+			continue
+		}
+
+		for k, v := range fileDefines {
+			merged[k] = v
+		}
+	}
+
+	keys := make([]string, 0, len(merged))
+	for k := range merged {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	result := make([]string, 0, len(keys))
+	for _, k := range keys {
+		encoded, err := json.Marshal(merged[k])
+		if err != nil {
+			return nil, fmt.Errorf("encoding value for key %q: %w", k, err)
+		}
+		result = append(result, fmt.Sprintf("%s=%s", k, string(encoded)))
+	}
+
+	return result, nil
+}

--- a/cmd/caib/common/define_file_test.go
+++ b/cmd/caib/common/define_file_test.go
@@ -1,0 +1,112 @@
+package caibcommon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadDefineFiles(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    []string
+	}{
+		{
+			name:    "string values",
+			content: "routing: Engine\nmode: debug\n",
+			want:    []string{`mode="debug"`, `routing="Engine"`},
+		},
+		{
+			name:    "numeric values",
+			content: "count: 42\nratio: 1.5\n",
+			want:    []string{`count=42`, `ratio=1.5`},
+		},
+		{
+			name:    "boolean values",
+			content: "enabled: true\nverbose: false\n",
+			want:    []string{`enabled=true`, `verbose=false`},
+		},
+		{
+			name:    "list values",
+			content: "extra_rpms:\n  - vim\n  - curl\n",
+			want:    []string{`extra_rpms=["vim","curl"]`},
+		},
+		{
+			name:    "quoted string preserves type",
+			content: "version: \"1.0\"\n",
+			want:    []string{`version="1.0"`},
+		},
+		{
+			name:    "map values",
+			content: "config:\n  key: val\n",
+			want:    []string{`config={"key":"val"}`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "vars.yaml")
+			if err := os.WriteFile(path, []byte(tt.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := LoadDefineFiles([]string{path})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d defines, want %d: %v", len(got), len(tt.want), got)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("define[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestLoadDefineFiles_MultipleFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	file1 := filepath.Join(dir, "base.yaml")
+	if err := os.WriteFile(file1, []byte("key1: val1\nshared: from_base\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	file2 := filepath.Join(dir, "override.yaml")
+	if err := os.WriteFile(file2, []byte("key2: val2\nshared: from_override\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := LoadDefineFiles([]string{file1, file2})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []string{`key1="val1"`, `key2="val2"`, `shared="from_override"`}
+	if len(got) != len(want) {
+		t.Fatalf("got %d defines, want %d: %v", len(got), len(want), got)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("define[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestLoadDefineFiles_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.yaml")
+	if err := os.WriteFile(path, []byte(":\n  - :\n  [invalid"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadDefineFiles([]string{path})
+	if err == nil {
+		t.Fatal("expected error for invalid YAML")
+	}
+}

--- a/cmd/caib/image/image.go
+++ b/cmd/caib/image/image.go
@@ -44,6 +44,7 @@ type Options struct {
 	Timeout                *int
 	WaitForBuild           *bool
 	CustomDefs             *[]string
+	DefineFiles            *[]string
 	AIBExtraArgs           *[]string
 	ExtraRepos             *[]string
 	Workspace              *string
@@ -145,6 +146,7 @@ func NewImageCmd(opts Options) *cobra.Command {
 	buildCmd.Flags().BoolVar(opts.RebuildBuilder, "rebuild-builder", false, "force rebuild of the bootc builder image")
 	buildCmd.Flags().StringVar(opts.StorageClass, "storage-class", "", "Kubernetes storage class for build workspace")
 	buildCmd.Flags().StringArrayVarP(opts.CustomDefs, "define", "D", []string{}, "custom definition KEY=VALUE")
+	buildCmd.Flags().StringArrayVar(opts.DefineFiles, "define-file", []string{}, "load defines from YAML dictionary file (can be repeated)")
 	buildCmd.Flags().StringArrayVar(opts.AIBExtraArgs, "extra-args", []string{}, "extra arguments to pass to AIB (can be repeated)")
 	buildCmd.Flags().StringArrayVar(opts.ExtraRepos, "extra-repo", []string{}, "serve RPMs from workspace as extra repo (workspace:path, can be repeated)")
 	buildCmd.Flags().StringVar(opts.Workspace, "workspace", "", "workspace name for build caching and lease forwarding")
@@ -249,6 +251,7 @@ func NewImageCmd(opts Options) *cobra.Command {
 	)
 	buildDevCmd.Flags().StringVar(opts.StorageClass, "storage-class", "", "Kubernetes storage class")
 	buildDevCmd.Flags().StringArrayVarP(opts.CustomDefs, "define", "D", []string{}, "custom definition KEY=VALUE")
+	buildDevCmd.Flags().StringArrayVar(opts.DefineFiles, "define-file", []string{}, "load defines from YAML dictionary file (can be repeated)")
 	buildDevCmd.Flags().StringArrayVar(opts.AIBExtraArgs, "extra-args", []string{}, "extra arguments to pass to AIB (can be repeated)")
 	buildDevCmd.Flags().StringArrayVar(opts.ExtraRepos, "extra-repo", []string{}, "serve RPMs from workspace as extra repo (workspace:path, can be repeated)")
 	buildDevCmd.Flags().StringVar(opts.Workspace, "workspace", "", "workspace name for build caching and lease forwarding")

--- a/cmd/caib/main.go
+++ b/cmd/caib/main.go
@@ -27,6 +27,7 @@ var (
 	timeout                int
 	waitForBuild           bool
 	customDefs             []string
+	defineFiles            []string
 	aibExtraArgs           []string
 	extraRepos             []string
 	workspaceName          string

--- a/cmd/caib/runtime_wiring.go
+++ b/cmd/caib/runtime_wiring.go
@@ -26,6 +26,7 @@ type runtimeState struct {
 	Timeout                *int
 	WaitForBuild           *bool
 	CustomDefs             *[]string
+	DefineFiles            *[]string
 	AIBExtraArgs           *[]string
 	ExtraRepos             *[]string
 	Workspace              *string
@@ -87,6 +88,7 @@ func newRuntimeState() runtimeState {
 		Timeout:                &timeout,
 		WaitForBuild:           &waitForBuild,
 		CustomDefs:             &customDefs,
+		DefineFiles:            &defineFiles,
 		AIBExtraArgs:           &aibExtraArgs,
 		ExtraRepos:             &extraRepos,
 		Workspace:              &workspaceName,
@@ -158,6 +160,7 @@ func (s runtimeState) newHandlers() handlerSet {
 			Timeout:                   s.Timeout,
 			WaitForBuild:              s.WaitForBuild,
 			CustomDefs:                s.CustomDefs,
+			DefineFiles:               s.DefineFiles,
 			AIBExtraArgs:              s.AIBExtraArgs,
 			ExtraRepos:                s.ExtraRepos,
 			Workspace:                 s.Workspace,
@@ -279,6 +282,7 @@ func (s runtimeState) imageOptions(h handlerSet) image.Options {
 		Timeout:                s.Timeout,
 		WaitForBuild:           s.WaitForBuild,
 		CustomDefs:             s.CustomDefs,
+		DefineFiles:            s.DefineFiles,
 		AIBExtraArgs:           s.AIBExtraArgs,
 		ExtraRepos:             s.ExtraRepos,
 		Workspace:              s.Workspace,


### PR DESCRIPTION

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [x] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for supplying custom build definitions via YAML files with the new `--define-file` CLI flag. Define files can be repeated and are processed in order, with inline definitions appended after file-based definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->