### PR TITLE
refactor: extract helpers and auth from server.go

### DIFF
--- a/internal/buildapi/auth.go
+++ b/internal/buildapi/auth.go
@@ -1,0 +1,370 @@
+package buildapi
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"k8s.io/apimachinery/pkg/types"
+	apiserverv1beta1 "k8s.io/apiserver/pkg/apis/apiserver/v1beta1"
+	"k8s.io/client-go/kubernetes"
+
+	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
+	authnv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (a *APIServer) authMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		username, authType, authErr := a.authenticateRequest(c)
+		if authErr != nil {
+			c.JSON(http.StatusUnauthorized, gin.H{
+				"error":   "unauthorized",
+				"reason":  authErr.Reason,
+				"details": authErr.Details,
+			})
+			c.Abort()
+			return
+		}
+		if username != "" {
+			c.Set("requester", username)
+			c.Set("authType", authType)
+		}
+		c.Next()
+	}
+}
+
+func (a *APIServer) refreshAuthConfigIfNeeded() {
+	a.authConfigMu.Lock()
+	defer a.authConfigMu.Unlock()
+
+	// Check if it's time to refresh (every 60 seconds)
+	if time.Since(a.lastAuthConfigCheck) < 60*time.Second {
+		return
+	}
+	a.lastAuthConfigCheck = time.Now()
+
+	namespace := resolveNamespace()
+	k8sClient, err := getKubernetesClient()
+	if err != nil {
+		a.log.Error(err, "failed to get k8s client for auth config refresh", "namespace", namespace)
+		return
+	}
+
+	// Get the OperatorConfig to check if it changed
+	operatorConfig := &automotivev1alpha1.OperatorConfig{}
+	key := types.NamespacedName{Name: "config", Namespace: namespace}
+	fetchCtx, fetchCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer fetchCancel()
+	if err := k8sClient.Get(fetchCtx, key, operatorConfig); err != nil {
+		a.log.Error(err, "failed to get OperatorConfig during refresh", "namespace", namespace)
+		return
+	}
+
+	// Build new config from OperatorConfig (without creating authenticator yet)
+	var newConfig *AuthenticationConfiguration
+	if operatorConfig.Spec.BuildAPI != nil && operatorConfig.Spec.BuildAPI.Authentication != nil {
+		auth := operatorConfig.Spec.BuildAPI.Authentication
+		// Deep copy JWT config with Prefix handling
+		jwtCopy := make([]apiserverv1beta1.JWTAuthenticator, len(auth.JWT))
+		for i, jwt := range auth.JWT {
+			jwtCopy[i] = jwt
+			if jwt.ClaimMappings.Username.Claim != "" && jwt.ClaimMappings.Username.Prefix == nil {
+				emptyPrefix := ""
+				jwtCopy[i].ClaimMappings.Username.Prefix = &emptyPrefix
+			}
+			if jwt.ClaimMappings.Groups.Claim != "" && jwt.ClaimMappings.Groups.Prefix == nil {
+				emptyPrefix := ""
+				jwtCopy[i].ClaimMappings.Groups.Prefix = &emptyPrefix
+			}
+		}
+		newConfig = &AuthenticationConfiguration{
+			ClientID: auth.ClientID,
+			Internal: InternalAuthConfig{Prefix: "internal:"},
+			JWT:      jwtCopy,
+		}
+		if auth.Internal != nil && auth.Internal.Prefix != "" {
+			newConfig.Internal.Prefix = auth.Internal.Prefix
+		}
+	}
+
+	// Compare with existing config, only recreate authenticator if config changed
+	if authConfigsEqual(a.authConfig, newConfig) {
+		return
+	}
+
+	// Config changed - need to recreate authenticator
+	a.log.Info("auth config changed, recreating OIDC authenticator")
+
+	if newConfig == nil {
+		a.authConfig = nil
+		a.externalJWT = nil
+		a.internalPrefix = ""
+		return
+	}
+
+	// Create new authenticator
+	authn, err := newJWTAuthenticator(context.Background(), *newConfig)
+	if err != nil {
+		a.log.Error(err, "failed to create JWT authenticator during refresh, keeping existing config")
+		return
+	}
+
+	// Update config fields
+	a.authConfig = newConfig
+	a.internalPrefix = newConfig.Internal.Prefix
+	if newConfig.ClientID != "" {
+		a.oidcClientID = newConfig.ClientID
+	}
+
+	a.externalJWT = authn
+}
+
+func (a *APIServer) authenticateRequest(c *gin.Context) (string, string, *authError) {
+	a.refreshAuthConfigIfNeeded()
+
+	token := extractBearerToken(c)
+	if token == "" {
+		return "", "", &authError{
+			Reason:  "missing_token",
+			Details: "No bearer token provided. Set Authorization header with 'Bearer <token>' or use CAIB_TOKEN environment variable.",
+		}
+	}
+
+	// Track which auth methods were tried for error reporting
+	var authAttempts []string
+	var oidcError error
+
+	a.authConfigMu.RLock()
+	internalJWT := a.internalJWT
+	internalPrefix := a.internalPrefix
+	externalJWT := a.externalJWT
+	a.authConfigMu.RUnlock()
+
+	if internalJWT != nil {
+		authAttempts = append(authAttempts, "internal_jwt")
+		if subject, ok := validateInternalJWT(token, internalJWT); ok {
+			username := subject
+			if internalPrefix != "" {
+				username = internalPrefix + username
+			}
+			return username, "internal", nil
+		}
+	}
+
+	if externalJWT != nil {
+		authAttempts = append(authAttempts, "oidc")
+		result := a.authenticateExternalJWT(c, token, externalJWT)
+		if result.ok {
+			if internalJWT != nil {
+				if err := a.ensureClientTokenSecret(c, result.username, token); err != nil {
+					a.log.Error(err, "failed to ensure client token secret", "username", result.username)
+				}
+			}
+			return result.username, "external", nil
+		}
+		oidcError = result.err
+	}
+
+	// Fallback to kubeconfig TokenReview authentication
+	authAttempts = append(authAttempts, "k8s_token_review")
+
+	cfg, err := getRESTConfigFromRequest(c)
+	if err != nil {
+		a.log.Error(err, "Failed to get REST config for TokenReview fallback")
+		return "", "", &authError{
+			Reason:  "server_error",
+			Details: "Failed to initialize Kubernetes client for token validation. Check build-api logs.",
+		}
+	}
+
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		a.log.Error(err, "Failed to create Kubernetes client for TokenReview")
+		return "", "", &authError{
+			Reason:  "server_error",
+			Details: "Failed to create Kubernetes client for token validation. Check build-api logs.",
+		}
+	}
+
+	tr := &authnv1.TokenReview{Spec: authnv1.TokenReviewSpec{Token: token}}
+	res, err := clientset.AuthenticationV1().TokenReviews().Create(c.Request.Context(), tr, metav1.CreateOptions{})
+	if err != nil {
+		a.log.Error(err, "TokenReview API call failed")
+		return "", "", &authError{
+			Reason:  "token_review_failed",
+			Details: "Failed to validate token with Kubernetes API. The token may be malformed or the server may have connectivity issues.",
+		}
+	}
+	if res.Status.Authenticated {
+		username := res.Status.User.Username
+		if username == "" {
+			return "", "", &authError{
+				Reason:  "invalid_token",
+				Details: "Token was authenticated but no username was returned.",
+			}
+		}
+		return username, "k8s", nil
+	}
+
+	return "", "", a.buildAuthFailureError(authAttempts, oidcError, res.Status.Error)
+}
+
+func (a *APIServer) buildAuthFailureError(authAttempts []string, oidcError error, tokenReviewError string) *authError {
+	oidcAttempted := false
+	for _, method := range authAttempts {
+		if method == "oidc" {
+			oidcAttempted = true
+			break
+		}
+	}
+
+	// Log full error details server-side for debugging
+	if tokenReviewError != "" {
+		a.log.Info("TokenReview authentication failed", "error", tokenReviewError)
+	}
+	if oidcError != nil {
+		a.log.Info("OIDC authentication failed", "error", oidcError.Error())
+	}
+
+	if !oidcAttempted {
+		return &authError{
+			Reason:  "invalid_token",
+			Details: "Token validation failed. The token may be expired or invalid. Try 'oc login' to refresh your session, then use 'oc whoami -t' for a fresh token.",
+		}
+	}
+
+	var details strings.Builder
+	details.WriteString("Authentication failed. OIDC is configured on this cluster. ")
+
+	if oidcError != nil {
+		details.WriteString("OIDC: token validation failed. ")
+	} else {
+		details.WriteString("OIDC: token not valid for configured issuer. ")
+	}
+
+	if tokenReviewError != "" {
+		details.WriteString("Kubernetes fallback: token rejected. ")
+	} else {
+		details.WriteString("Kubernetes fallback: token rejected (may be expired or invalid). ")
+	}
+
+	details.WriteString("If using OIDC, ensure you have a valid OIDC token. Otherwise, try 'oc login' to refresh your session.")
+
+	return &authError{
+		Reason:  "invalid_token",
+		Details: details.String(),
+	}
+}
+
+func extractBearerToken(c *gin.Context) string {
+	authHeader := c.Request.Header.Get("Authorization")
+	token, _ := strings.CutPrefix(authHeader, "Bearer ")
+	if token != "" {
+		return strings.TrimSpace(token)
+	}
+	token = c.Request.Header.Get("X-Forwarded-Access-Token")
+	if token != "" {
+		return strings.TrimSpace(token)
+	}
+	return ""
+}
+
+func (a *APIServer) handleGetAuthConfig(c *gin.Context) {
+	a.refreshAuthConfigIfNeeded()
+
+	type OIDCConfigResponse struct {
+		ClientID string `json:"clientId,omitempty"`
+		JWT      []struct {
+			Issuer struct {
+				URL       string   `json:"url"`
+				Audiences []string `json:"audiences,omitempty"`
+			} `json:"issuer"`
+			ClaimMappings struct {
+				Username struct {
+					Claim  string `json:"claim"`
+					Prefix string `json:"prefix,omitempty"`
+				} `json:"username"`
+			} `json:"claimMappings"`
+		} `json:"jwt"`
+	}
+
+	a.authConfigMu.RLock()
+	clientID := a.oidcClientID
+	authConfig := a.authConfig
+	a.authConfigMu.RUnlock()
+
+	response := OIDCConfigResponse{
+		ClientID: clientID,
+	}
+
+	if clientID != "" && authConfig != nil {
+		clientIDInAudience := false
+		for _, jwtConfig := range authConfig.JWT {
+			for _, audience := range jwtConfig.Issuer.Audiences {
+				if audience == clientID {
+					clientIDInAudience = true
+					break
+				}
+			}
+		}
+		if !clientIDInAudience && len(authConfig.JWT) > 0 {
+			a.log.Info("OIDC clientId does not match any JWT audience", "clientId", clientID)
+		}
+	}
+
+	a.authConfigMu.RLock()
+	externalJWTWorking := a.externalJWT != nil
+	a.authConfigMu.RUnlock()
+
+	if authConfig != nil && len(authConfig.JWT) > 0 && externalJWTWorking {
+		for _, jwtConfig := range authConfig.JWT {
+			prefix := ""
+			if jwtConfig.ClaimMappings.Username.Prefix != nil {
+				prefix = *jwtConfig.ClaimMappings.Username.Prefix
+			}
+			response.JWT = append(response.JWT, struct {
+				Issuer struct {
+					URL       string   `json:"url"`
+					Audiences []string `json:"audiences,omitempty"`
+				} `json:"issuer"`
+				ClaimMappings struct {
+					Username struct {
+						Claim  string `json:"claim"`
+						Prefix string `json:"prefix,omitempty"`
+					} `json:"username"`
+				} `json:"claimMappings"`
+			}{
+				Issuer: struct {
+					URL       string   `json:"url"`
+					Audiences []string `json:"audiences,omitempty"`
+				}{
+					URL:       jwtConfig.Issuer.URL,
+					Audiences: jwtConfig.Issuer.Audiences,
+				},
+				ClaimMappings: struct {
+					Username struct {
+						Claim  string `json:"claim"`
+						Prefix string `json:"prefix,omitempty"`
+					} `json:"username"`
+				}{
+					Username: struct {
+						Claim  string `json:"claim"`
+						Prefix string `json:"prefix,omitempty"`
+					}{
+						Claim:  jwtConfig.ClaimMappings.Username.Claim,
+						Prefix: prefix,
+					},
+				},
+			})
+		}
+	}
+
+	if len(response.JWT) == 0 {
+		c.AbortWithStatus(http.StatusNotFound)
+		return
+	}
+	c.JSON(http.StatusOK, response)
+}

--- a/internal/buildapi/container_builds.go
+++ b/internal/buildapi/container_builds.go
@@ -26,44 +26,11 @@ import (
 	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/labels"
 )
 
-// --- Container Build Handlers ---
-
-func (a *APIServer) handleStreamContainerBuildLogs(c *gin.Context) {
-	name := c.Param("name")
-	a.log.Info("container build logs requested", "build", name, "reqID", c.GetString("reqID"))
-	a.streamContainerBuildLogs(c, name)
-}
-
-func (a *APIServer) handleCreateContainerBuild(c *gin.Context) {
-	a.log.Info("create container build", "reqID", c.GetString("reqID"))
-	a.createContainerBuild(c)
-}
-
-func (a *APIServer) handleListContainerBuilds(c *gin.Context) {
-	a.log.Info("list container builds", "reqID", c.GetString("reqID"))
-	listContainerBuilds(c)
-}
-
-func (a *APIServer) handleGetContainerBuild(c *gin.Context) {
-	name := c.Param("name")
-	a.log.Info("get container build", "build", name, "reqID", c.GetString("reqID"))
-	a.getContainerBuild(c, name)
-}
-
-func (a *APIServer) handleContainerBuildUpload(c *gin.Context) {
-	name := c.Param("name")
-	a.log.Info("container build upload", "build", name, "reqID", c.GetString("reqID"))
-	a.uploadContainerBuildContext(c, name)
-}
-
-// --- Container Build Implementation ---
-
 func (a *APIServer) streamContainerBuildLogs(c *gin.Context, name string) {
 	namespace := resolveNamespace()
 
-	k8sClient, err := getClientFromRequest(c)
+	k8sClient, err := getK8sClientOrFail(c)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
@@ -73,12 +40,7 @@ func (a *APIServer) streamContainerBuildLogs(c *gin.Context, name string) {
 	defer cancel()
 
 	cb := &automotivev1alpha1.ContainerBuild{}
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, cb); err != nil {
-		if k8serrors.IsNotFound(err) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	if err := getResourceOrFail(ctx, c, k8sClient, name, namespace, cb, "container build"); err != nil {
 		return
 	}
 
@@ -88,14 +50,8 @@ func (a *APIServer) streamContainerBuildLogs(c *gin.Context, name string) {
 		return
 	}
 
-	restCfg, err := getRESTConfigFromRequest(c)
+	cs, err := getClientsetOrFail(c)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	cs, err := kubernetes.NewForConfig(restCfg)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
@@ -222,9 +178,8 @@ func (a *APIServer) createContainerBuild(c *gin.Context) {
 		req.Name = fmt.Sprintf("cb-%s", uuid.New().String()[:8])
 	}
 
-	k8sClient, err := getClientFromRequestFn(c)
+	k8sClient, err := getK8sClientOrFail(c)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("k8s client error: %v", err)})
 		return
 	}
 
@@ -369,9 +324,8 @@ func listContainerBuilds(c *gin.Context) {
 	namespace := resolveNamespace()
 	limit, offset := parsePagination(c)
 
-	k8sClient, err := getClientFromRequest(c)
+	k8sClient, err := getK8sClientOrFail(c)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("k8s client error: %v", err)})
 		return
 	}
 
@@ -413,20 +367,14 @@ func listContainerBuilds(c *gin.Context) {
 func (a *APIServer) getContainerBuild(c *gin.Context, name string) {
 	namespace := resolveNamespace()
 
-	k8sClient, err := getClientFromRequest(c)
+	k8sClient, err := getK8sClientOrFail(c)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("k8s client error: %v", err)})
 		return
 	}
 
 	ctx := c.Request.Context()
 	cb := &automotivev1alpha1.ContainerBuild{}
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, cb); err != nil {
-		if k8serrors.IsNotFound(err) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("error fetching container build: %v", err)})
+	if err := getResourceOrFail(ctx, c, k8sClient, name, namespace, cb, "container build"); err != nil {
 		return
 	}
 
@@ -540,20 +488,14 @@ func findWaiterContainer(pod *corev1.Pod) string {
 func (a *APIServer) uploadContainerBuildContext(c *gin.Context, name string) {
 	namespace := resolveNamespace()
 
-	k8sClient, err := getClientFromRequestFn(c)
+	k8sClient, err := getK8sClientOrFail(c)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("k8s client error: %v", err)})
 		return
 	}
 
 	ctx := c.Request.Context()
 	cb := &automotivev1alpha1.ContainerBuild{}
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, cb); err != nil {
-		if k8serrors.IsNotFound(err) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("error fetching container build: %v", err)})
+	if err := getResourceOrFail(ctx, c, k8sClient, name, namespace, cb, "container build"); err != nil {
 		return
 	}
 

--- a/internal/buildapi/flash.go
+++ b/internal/buildapi/flash.go
@@ -17,7 +17,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
@@ -25,28 +24,6 @@ import (
 	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/tasks"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 )
-
-func (a *APIServer) handleCreateFlash(c *gin.Context) {
-	a.log.Info("create flash", "reqID", c.GetString("reqID"))
-	a.createFlash(c)
-}
-
-func (a *APIServer) handleListFlash(c *gin.Context) {
-	a.log.Info("list flash jobs", "reqID", c.GetString("reqID"))
-	a.listFlash(c)
-}
-
-func (a *APIServer) handleGetFlash(c *gin.Context) {
-	name := c.Param("name")
-	a.log.Info("get flash", "flash", name, "reqID", c.GetString("reqID"))
-	a.getFlash(c, name)
-}
-
-func (a *APIServer) handleFlashLogs(c *gin.Context) {
-	name := c.Param("name")
-	a.log.Info("flash logs requested", "flash", name, "reqID", c.GetString("reqID"))
-	a.streamFlashLogs(c, name)
-}
 
 func (a *APIServer) createFlash(c *gin.Context) {
 	var req FlashRequest
@@ -83,20 +60,12 @@ func (a *APIServer) createFlash(c *gin.Context) {
 		return
 	}
 
-	k8sClient, err := getClientFromRequestFn(c)
+	k8sClient, err := getK8sClientOrFail(c)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("k8s client error: %v", err)})
 		return
 	}
-
-	restCfg, err := getRESTConfigFromRequestFn(c)
+	clientset, err := getClientsetOrFail(c)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	clientset, err := kubernetes.NewForConfig(restCfg)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
@@ -258,9 +227,8 @@ func (a *APIServer) listFlash(c *gin.Context) {
 	namespace := resolveNamespace()
 	limit, offset := parsePagination(c)
 
-	k8sClient, err := getClientFromRequestFn(c)
+	k8sClient, err := getK8sClientOrFail(c)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("k8s client error: %v", err)})
 		return
 	}
 
@@ -302,20 +270,14 @@ func (a *APIServer) listFlash(c *gin.Context) {
 func (a *APIServer) getFlash(c *gin.Context, name string) {
 	namespace := resolveNamespace()
 
-	k8sClient, err := getClientFromRequestFn(c)
+	k8sClient, err := getK8sClientOrFail(c)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("k8s client error: %v", err)})
 		return
 	}
 
 	ctx := c.Request.Context()
 	taskRun := &tektonv1.TaskRun{}
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, taskRun); err != nil {
-		if k8serrors.IsNotFound(err) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "flash TaskRun not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to get flash TaskRun: %v", err)})
+	if err := getResourceOrFail(ctx, c, k8sClient, name, namespace, taskRun, "flash TaskRun"); err != nil {
 		return
 	}
 
@@ -371,20 +333,12 @@ func getTaskRunStatus(tr *tektonv1.TaskRun) (phase, message string) {
 func (a *APIServer) streamFlashLogs(c *gin.Context, name string) {
 	namespace := resolveNamespace()
 
-	k8sClient, err := getClientFromRequestFn(c)
+	k8sClient, err := getK8sClientOrFail(c)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("k8s client error: %v", err)})
 		return
 	}
-
-	restCfg, err := getRESTConfigFromRequestFn(c)
+	clientset, err := getClientsetOrFail(c)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	clientset, err := kubernetes.NewForConfig(restCfg)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
@@ -392,12 +346,7 @@ func (a *APIServer) streamFlashLogs(c *gin.Context, name string) {
 
 	// Verify the TaskRun exists and is a flash TaskRun
 	taskRun := &tektonv1.TaskRun{}
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, taskRun); err != nil {
-		if k8serrors.IsNotFound(err) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "flash TaskRun not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to get flash TaskRun: %v", err)})
+	if err := getResourceOrFail(ctx, c, k8sClient, name, namespace, taskRun, "flash TaskRun"); err != nil {
 		return
 	}
 	if taskRun.Labels[labels.FlashTaskRun] == "" {

--- a/internal/buildapi/helpers.go
+++ b/internal/buildapi/helpers.go
@@ -1,6 +1,7 @@
 package buildapi
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -10,8 +11,11 @@ import (
 
 	"github.com/gin-gonic/gin"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -19,6 +23,56 @@ import (
 	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 )
+
+func (a *APIServer) wrapHandler(op string, fn gin.HandlerFunc) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		a.log.Info(op, "reqID", c.GetString("reqID"))
+		fn(c)
+	}
+}
+
+func (a *APIServer) wrapNamedHandler(op string, fn func(*gin.Context, string)) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		name := c.Param("name")
+		a.log.Info(op, "name", name, "reqID", c.GetString("reqID"))
+		fn(c, name)
+	}
+}
+
+func getK8sClientOrFail(c *gin.Context) (client.Client, error) {
+	k8sClient, err := getClientFromRequestFn(c)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("k8s client error: %v", err)})
+		return nil, err
+	}
+	return k8sClient, nil
+}
+
+func getClientsetOrFail(c *gin.Context) (*kubernetes.Clientset, error) {
+	restCfg, err := getRESTConfigFromRequestFn(c)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("REST config error: %v", err)})
+		return nil, err
+	}
+	clientset, err := kubernetes.NewForConfig(restCfg)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("clientset error: %v", err)})
+		return nil, err
+	}
+	return clientset, nil
+}
+
+func getResourceOrFail(ctx context.Context, c *gin.Context, k8sClient client.Client, name, namespace string, obj client.Object, kind string) error {
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, obj); err != nil {
+		if k8serrors.IsNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("%s not found", kind)})
+			return err
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("error fetching %s: %v", kind, err)})
+		return err
+	}
+	return nil
+}
 
 func writeJSON(c *gin.Context, status int, v any) {
 	c.Header("Cache-Control", "no-store")

--- a/internal/buildapi/log_streaming.go
+++ b/internal/buildapi/log_streaming.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -221,9 +220,8 @@ func processPodLogs(
 func (a *APIServer) streamLogs(c *gin.Context, name string) {
 	namespace := resolveNamespace()
 
-	k8sClient, err := getClientFromRequest(c)
+	k8sClient, err := getK8sClientOrFail(c)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
@@ -233,12 +231,7 @@ func (a *APIServer) streamLogs(c *gin.Context, name string) {
 	defer cancel()
 
 	ib := &automotivev1alpha1.ImageBuild{}
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, ib); err != nil {
-		if k8serrors.IsNotFound(err) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	if err := getResourceOrFail(ctx, c, k8sClient, name, namespace, ib, "build"); err != nil {
 		return
 	}
 
@@ -248,14 +241,8 @@ func (a *APIServer) streamLogs(c *gin.Context, name string) {
 		return
 	}
 
-	restCfg, err := getRESTConfigFromRequest(c)
+	cs, err := getClientsetOrFail(c)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	cs, err := kubernetes.NewForConfig(restCfg)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/buildapi/sealed.go
+++ b/internal/buildapi/sealed.go
@@ -18,7 +18,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
@@ -103,9 +102,9 @@ func (a *APIServer) registerSealedRoutes(v1 *gin.RouterGroup) {
 		grp.Use(sealedMetricsMiddleware(), a.authMiddleware())
 		{
 			grp.POST("", a.handleCreateSealed)
-			grp.GET("", a.handleListSealed)
-			grp.GET("/:name", a.handleGetSealed)
-			grp.GET("/:name/logs", a.handleSealedLogs)
+			grp.GET("", a.wrapHandler("list reseal jobs", a.listSealed))
+			grp.GET("/:name", a.wrapNamedHandler("get reseal", a.getSealed))
+			grp.GET("/:name/logs", a.wrapNamedHandler("reseal logs requested", a.streamSealedLogs))
 		}
 	}
 }
@@ -114,23 +113,6 @@ func (a *APIServer) handleCreateSealed(c *gin.Context) {
 	op := resolveSealedOperation(c)
 	a.log.Info("create reseal", "operation", op, "reqID", c.GetString("reqID"))
 	a.createSealed(c, op)
-}
-
-func (a *APIServer) handleListSealed(c *gin.Context) {
-	a.log.Info("list reseal jobs", "reqID", c.GetString("reqID"))
-	a.listSealed(c)
-}
-
-func (a *APIServer) handleGetSealed(c *gin.Context) {
-	name := c.Param("name")
-	a.log.Info("get reseal", "name", name, "reqID", c.GetString("reqID"))
-	a.getSealed(c, name)
-}
-
-func (a *APIServer) handleSealedLogs(c *gin.Context) {
-	name := c.Param("name")
-	a.log.Info("reseal logs requested", "name", name, "reqID", c.GetString("reqID"))
-	a.streamSealedLogs(c, name)
 }
 
 func (a *APIServer) createSealed(c *gin.Context, pathOp SealedOperation) {
@@ -164,25 +146,16 @@ func (a *APIServer) createSealed(c *gin.Context, pathOp SealedOperation) {
 		attribute.String("sealed.operation", opLabel),
 	)
 
-	k8sClient, err := getClientFromRequestFn(c)
+	k8sClient, err := getK8sClientOrFail(c)
 	if err != nil {
 		spanError(span, err)
 		SealedCreateRequestsTotal.WithLabelValues(opLabel, "error").Inc()
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	restCfg, err := getRESTConfigFromRequestFn(c)
+	clientset, err := getClientsetOrFail(c)
 	if err != nil {
 		spanError(span, err)
 		SealedCreateRequestsTotal.WithLabelValues(opLabel, "error").Inc()
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	clientset, err := kubernetes.NewForConfig(restCfg)
-	if err != nil {
-		spanError(span, err)
-		SealedCreateRequestsTotal.WithLabelValues(opLabel, "error").Inc()
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 	namespace := resolveNamespace()
@@ -273,10 +246,9 @@ func (a *APIServer) listSealed(c *gin.Context) {
 	namespace := resolveNamespace()
 	limit, offset := parsePagination(c)
 
-	k8sClient, err := getClientFromRequestFn(c)
+	k8sClient, err := getK8sClientOrFail(c)
 	if err != nil {
 		spanError(span, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 	list := &automotivev1alpha1.ImageResealList{}
@@ -316,20 +288,14 @@ func (a *APIServer) getSealed(c *gin.Context, name string) {
 	span.SetAttributes(attribute.String("sealed.name", name))
 
 	namespace := resolveNamespace()
-	k8sClient, err := getClientFromRequestFn(c)
+	k8sClient, err := getK8sClientOrFail(c)
 	if err != nil {
 		spanError(span, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 	sealed := &automotivev1alpha1.ImageReseal{}
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, sealed); err != nil {
-		if k8serrors.IsNotFound(err) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "job not found"})
-			return
-		}
+	if err := getResourceOrFail(ctx, c, k8sClient, name, namespace, sealed, "job"); err != nil {
 		spanError(span, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 	var startStr, compStr string
@@ -358,32 +324,19 @@ func (a *APIServer) streamSealedLogs(c *gin.Context, name string) {
 	span.SetAttributes(attribute.String("sealed.name", name))
 
 	namespace := resolveNamespace()
-	k8sClient, err := getClientFromRequestFn(c)
+	k8sClient, err := getK8sClientOrFail(c)
 	if err != nil {
 		spanError(span, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	restCfg, err := getRESTConfigFromRequestFn(c)
+	clientset, err := getClientsetOrFail(c)
 	if err != nil {
 		spanError(span, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	clientset, err := kubernetes.NewForConfig(restCfg)
-	if err != nil {
-		spanError(span, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 	sealed := &automotivev1alpha1.ImageReseal{}
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, sealed); err != nil {
-		if k8serrors.IsNotFound(err) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "job not found"})
-			return
-		}
+	if err := getResourceOrFail(ctx, c, k8sClient, name, namespace, sealed, "job"); err != nil {
 		spanError(span, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 	var taskRun *tektonv1.TaskRun

--- a/internal/buildapi/server.go
+++ b/internal/buildapi/server.go
@@ -30,7 +30,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	apiserverv1beta1 "k8s.io/apiserver/pkg/apis/apiserver/v1beta1"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/client-go/kubernetes"
 	kscheme "k8s.io/client-go/kubernetes/scheme"
@@ -48,7 +47,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
-	authnv1 "k8s.io/api/authentication/v1"
 )
 
 var apiTracer = otel.Tracer("build-api")
@@ -389,25 +387,25 @@ func (a *APIServer) createRouter() *gin.Engine {
 		buildsGroup := v1.Group("/builds")
 		buildsGroup.Use(a.authMiddleware())
 		{
-			buildsGroup.POST("", a.handleCreateBuild)
-			buildsGroup.GET("", a.handleListBuilds)
-			buildsGroup.GET("/:name", a.handleGetBuild)
-			buildsGroup.GET("/:name/logs", a.handleStreamLogs)
+			buildsGroup.POST("", a.wrapHandler("create build", a.createBuild))
+			buildsGroup.GET("", a.wrapHandler("list builds", listBuilds))
+			buildsGroup.GET("/:name", a.wrapNamedHandler("get build", a.getBuild))
+			buildsGroup.GET("/:name/logs", a.wrapNamedHandler("logs requested", a.streamLogs))
 			buildsGroup.GET("/:name/progress", a.handleGetProgress)
-			buildsGroup.GET("/:name/template", a.handleGetBuildTemplate)
-			buildsGroup.POST("/:name/uploads", a.handleUploadFiles)
+			buildsGroup.GET("/:name/template", a.wrapNamedHandler("template requested", getBuildTemplate))
+			buildsGroup.POST("/:name/uploads", a.wrapNamedHandler("uploads", a.uploadFiles))
 			buildsGroup.POST("/:name/token", a.handleCreateBuildToken)
-			buildsGroup.POST("/:name/cancel", a.handleCancelBuild)
-			buildsGroup.DELETE("/:name", a.handleDeleteBuild)
+			buildsGroup.POST("/:name/cancel", a.wrapNamedHandler("cancel build", a.cancelBuild))
+			buildsGroup.DELETE("/:name", a.wrapNamedHandler("delete build", a.deleteBuild))
 		}
 
 		flashGroup := v1.Group("/flash")
 		flashGroup.Use(flashMetricsMiddleware(), a.authMiddleware())
 		{
-			flashGroup.POST("", a.handleCreateFlash)
-			flashGroup.GET("", a.handleListFlash)
-			flashGroup.GET("/:name", a.handleGetFlash)
-			flashGroup.GET("/:name/logs", a.handleFlashLogs)
+			flashGroup.POST("", a.wrapHandler("create flash", a.createFlash))
+			flashGroup.GET("", a.wrapHandler("list flash jobs", a.listFlash))
+			flashGroup.GET("/:name", a.wrapNamedHandler("get flash", a.getFlash))
+			flashGroup.GET("/:name/logs", a.wrapNamedHandler("flash logs requested", a.streamFlashLogs))
 		}
 
 		configGroup := v1.Group("/config")
@@ -419,11 +417,11 @@ func (a *APIServer) createRouter() *gin.Engine {
 		containerBuildsGroup := v1.Group("/container-builds")
 		containerBuildsGroup.Use(a.authMiddleware())
 		{
-			containerBuildsGroup.POST("", a.handleCreateContainerBuild)
-			containerBuildsGroup.GET("", a.handleListContainerBuilds)
-			containerBuildsGroup.GET("/:name", a.handleGetContainerBuild)
-			containerBuildsGroup.POST("/:name/upload", a.handleContainerBuildUpload)
-			containerBuildsGroup.GET("/:name/logs", a.handleStreamContainerBuildLogs)
+			containerBuildsGroup.POST("", a.wrapHandler("create container build", a.createContainerBuild))
+			containerBuildsGroup.GET("", a.wrapHandler("list container builds", listContainerBuilds))
+			containerBuildsGroup.GET("/:name", a.wrapNamedHandler("get container build", a.getContainerBuild))
+			containerBuildsGroup.POST("/:name/upload", a.wrapNamedHandler("container build upload", a.uploadContainerBuildContext))
+			containerBuildsGroup.GET("/:name/logs", a.wrapNamedHandler("container build logs", a.streamContainerBuildLogs))
 		}
 
 		a.registerSealedRoutes(v1)
@@ -489,62 +487,19 @@ type authError struct {
 	Details string `json:"details,omitempty"`
 }
 
-// authMiddleware provides authentication middleware for Gin
-func (a *APIServer) authMiddleware() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		username, authType, authErr := a.authenticateRequest(c)
-		if authErr != nil {
-			c.JSON(http.StatusUnauthorized, gin.H{
-				"error":   "unauthorized",
-				"reason":  authErr.Reason,
-				"details": authErr.Details,
-			})
-			c.Abort()
-			return
-		}
-		if username != "" {
-			c.Set("requester", username)
-			c.Set("authType", authType)
-		}
-		c.Next()
-	}
-}
-
-func (a *APIServer) handleCreateBuild(c *gin.Context) {
-	a.log.Info("create build", "reqID", c.GetString("reqID"))
-	a.createBuild(c)
-}
-
-func (a *APIServer) handleListBuilds(c *gin.Context) {
-	a.log.Info("list builds", "reqID", c.GetString("reqID"))
-	listBuilds(c)
-}
-
-func (a *APIServer) handleGetBuild(c *gin.Context) {
-	name := c.Param("name")
-	a.log.Info("get build", "build", name, "reqID", c.GetString("reqID"))
-	a.getBuild(c, name)
-}
-
 func (a *APIServer) handleCreateBuildToken(c *gin.Context) {
 	name := c.Param("name")
 	a.log.Info("token requested", "build", name, "reqID", c.GetString("reqID"))
 
 	namespace := resolveNamespace()
-	k8sClient, err := getClientFromRequest(c)
+	k8sClient, err := getK8sClientOrFail(c)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("k8s client error: %v", err)})
 		return
 	}
 
 	ctx := c.Request.Context()
 	build := &automotivev1alpha1.ImageBuild{}
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, build); err != nil {
-		if k8serrors.IsNotFound(err) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "build not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("error fetching build: %v", err)})
+	if err := getResourceOrFail(ctx, c, k8sClient, name, namespace, build, "build"); err != nil {
 		return
 	}
 
@@ -602,16 +557,9 @@ func (a *APIServer) handleCreateBuildToken(c *gin.Context) {
 	})
 }
 
-func (a *APIServer) handleDeleteBuild(c *gin.Context) {
-	name := c.Param("name")
-	a.log.Info("delete build", "name", name, "reqID", c.GetString("reqID"))
-	a.deleteBuild(c, name)
-}
-
 func (a *APIServer) deleteBuild(c *gin.Context, name string) {
-	k8sClient, err := getClientFromRequestFn(c)
+	k8sClient, err := getK8sClientOrFail(c)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create kubernetes client"})
 		return
 	}
 
@@ -619,12 +567,7 @@ func (a *APIServer) deleteBuild(c *gin.Context, name string) {
 	ctx := c.Request.Context()
 
 	build := &automotivev1alpha1.ImageBuild{}
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, build); err != nil {
-		if k8serrors.IsNotFound(err) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "build not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("error fetching build: %v", err)})
+	if err := getResourceOrFail(ctx, c, k8sClient, name, namespace, build, "build"); err != nil {
 		return
 	}
 
@@ -674,16 +617,9 @@ func (a *APIServer) deleteBuild(c *gin.Context, name string) {
 	c.JSON(http.StatusOK, gin.H{"message": fmt.Sprintf("build %q deleted", name)})
 }
 
-func (a *APIServer) handleCancelBuild(c *gin.Context) {
-	name := c.Param("name")
-	a.log.Info("cancel build", "name", name, "reqID", c.GetString("reqID"))
-	a.cancelBuild(c, name)
-}
-
 func (a *APIServer) cancelBuild(c *gin.Context, name string) {
-	k8sClient, err := getClientFromRequestFn(c)
+	k8sClient, err := getK8sClientOrFail(c)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create kubernetes client"})
 		return
 	}
 
@@ -691,12 +627,7 @@ func (a *APIServer) cancelBuild(c *gin.Context, name string) {
 	ctx := c.Request.Context()
 
 	build := &automotivev1alpha1.ImageBuild{}
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, build); err != nil {
-		if k8serrors.IsNotFound(err) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "build not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("error fetching build: %v", err)})
+	if err := getResourceOrFail(ctx, c, k8sClient, name, namespace, build, "build"); err != nil {
 		return
 	}
 
@@ -756,24 +687,6 @@ func (a *APIServer) cancelBuild(c *gin.Context, name string) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"message": fmt.Sprintf("build %q cancelled", name)})
-}
-
-func (a *APIServer) handleStreamLogs(c *gin.Context) {
-	name := c.Param("name")
-	a.log.Info("logs requested", "build", name, "reqID", c.GetString("reqID"))
-	a.streamLogs(c, name)
-}
-
-func (a *APIServer) handleGetBuildTemplate(c *gin.Context) {
-	name := c.Param("name")
-	a.log.Info("template requested", "build", name, "reqID", c.GetString("reqID"))
-	getBuildTemplate(c, name)
-}
-
-func (a *APIServer) handleUploadFiles(c *gin.Context) {
-	name := c.Param("name")
-	a.log.Info("uploads", "build", name, "reqID", c.GetString("reqID"))
-	a.uploadFiles(c, name)
 }
 
 // validateBuildRequest validates the build request, sanitizes the name, and applies defaults
@@ -1300,10 +1213,9 @@ func (a *APIServer) createBuild(c *gin.Context) {
 		return
 	}
 
-	k8sClient, err := getClientFromRequest(c)
+	k8sClient, err := getK8sClientOrFail(c)
 	if err != nil {
 		spanError(span, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("k8s client error: %v", err)})
 		return
 	}
 
@@ -1498,9 +1410,8 @@ func listBuilds(c *gin.Context) {
 	namespace := resolveNamespace()
 	limit, offset := parsePagination(c)
 
-	k8sClient, err := getClientFromRequest(c)
+	k8sClient, err := getK8sClientOrFail(c)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("k8s client error: %v", err)})
 		return
 	}
 
@@ -1560,20 +1471,14 @@ func listBuilds(c *gin.Context) {
 
 func (a *APIServer) getBuild(c *gin.Context, name string) {
 	namespace := resolveNamespace()
-	k8sClient, err := getClientFromRequest(c)
+	k8sClient, err := getK8sClientOrFail(c)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("k8s client error: %v", err)})
 		return
 	}
 
 	ctx := c.Request.Context()
 	build := &automotivev1alpha1.ImageBuild{}
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, build); err != nil {
-		if k8serrors.IsNotFound(err) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("error fetching build: %v", err)})
+	if err := getResourceOrFail(ctx, c, k8sClient, name, namespace, build, "build"); err != nil {
 		return
 	}
 
@@ -1707,20 +1612,14 @@ func (a *APIServer) getBuild(c *gin.Context, name string) {
 // getBuildTemplate returns a BuildRequest-like struct representing the inputs that produced a given build
 func getBuildTemplate(c *gin.Context, name string) {
 	namespace := resolveNamespace()
-	k8sClient, err := getClientFromRequest(c)
+	k8sClient, err := getK8sClientOrFail(c)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("k8s client error: %v", err)})
 		return
 	}
 
 	ctx := c.Request.Context()
 	build := &automotivev1alpha1.ImageBuild{}
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, build); err != nil {
-		if k8serrors.IsNotFound(err) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("error fetching build: %v", err)})
+	if err := getResourceOrFail(ctx, c, k8sClient, name, namespace, build, "build"); err != nil {
 		return
 	}
 
@@ -1915,22 +1814,14 @@ func findRunningUploadPod(ctx context.Context, k8sClient client.Client, namespac
 func (a *APIServer) uploadFiles(c *gin.Context, name string) {
 	namespace := resolveNamespace()
 
-	k8sClient, err := getClientFromRequest(c)
+	k8sClient, err := getK8sClientOrFail(c)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("k8s client error: %v", err)})
 		return
 	}
 	build := &automotivev1alpha1.ImageBuild{}
-	buildKey := types.NamespacedName{Name: name, Namespace: namespace}
-	if err := k8sClient.Get(c.Request.Context(), buildKey, build); err != nil {
-		if k8serrors.IsNotFound(err) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("error fetching build: %v", err)})
+	if err := getResourceOrFail(c.Request.Context(), c, k8sClient, name, namespace, build, "build"); err != nil {
 		return
 	}
-
 	uploadPod, err := findRunningUploadPod(c.Request.Context(), k8sClient, namespace, name)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -2052,373 +1943,6 @@ func copyFileToPod(ctx context.Context, config *rest.Config, namespace, podName,
 	}
 	return nil
 }
-
-// refreshAuthConfigIfNeeded periodically checks and refreshes authentication configuration from OperatorConfig
-// IMPORTANT: This function only recreates the OIDC authenticator if the config actually changed.
-func (a *APIServer) refreshAuthConfigIfNeeded() {
-	a.authConfigMu.Lock()
-	defer a.authConfigMu.Unlock()
-
-	// Check if it's time to refresh (every 60 seconds)
-	if time.Since(a.lastAuthConfigCheck) < 60*time.Second {
-		return
-	}
-	a.lastAuthConfigCheck = time.Now()
-
-	namespace := resolveNamespace()
-	k8sClient, err := getKubernetesClient()
-	if err != nil {
-		a.log.Error(err, "failed to get k8s client for auth config refresh", "namespace", namespace)
-		return
-	}
-
-	// Get the OperatorConfig to check if it changed
-	operatorConfig := &automotivev1alpha1.OperatorConfig{}
-	key := types.NamespacedName{Name: "config", Namespace: namespace}
-	if err := k8sClient.Get(context.Background(), key, operatorConfig); err != nil {
-		a.log.Error(err, "failed to get OperatorConfig during refresh", "namespace", namespace)
-		return
-	}
-
-	// Build new config from OperatorConfig (without creating authenticator yet)
-	var newConfig *AuthenticationConfiguration
-	if operatorConfig.Spec.BuildAPI != nil && operatorConfig.Spec.BuildAPI.Authentication != nil {
-		auth := operatorConfig.Spec.BuildAPI.Authentication
-		// Deep copy JWT config with Prefix handling
-		jwtCopy := make([]apiserverv1beta1.JWTAuthenticator, len(auth.JWT))
-		for i, jwt := range auth.JWT {
-			jwtCopy[i] = jwt
-			if jwt.ClaimMappings.Username.Claim != "" && jwt.ClaimMappings.Username.Prefix == nil {
-				emptyPrefix := ""
-				jwtCopy[i].ClaimMappings.Username.Prefix = &emptyPrefix
-			}
-			if jwt.ClaimMappings.Groups.Claim != "" && jwt.ClaimMappings.Groups.Prefix == nil {
-				emptyPrefix := ""
-				jwtCopy[i].ClaimMappings.Groups.Prefix = &emptyPrefix
-			}
-		}
-		newConfig = &AuthenticationConfiguration{
-			ClientID: auth.ClientID,
-			Internal: InternalAuthConfig{Prefix: "internal:"},
-			JWT:      jwtCopy,
-		}
-		if auth.Internal != nil && auth.Internal.Prefix != "" {
-			newConfig.Internal.Prefix = auth.Internal.Prefix
-		}
-	}
-
-	// Compare with existing config, only recreate authenticator if config changed
-	if authConfigsEqual(a.authConfig, newConfig) {
-		// Config unchanged, keep existing authenticator (which is already initialized)
-		return
-	}
-
-	// Config changed - need to recreate authenticator
-	a.log.Info("auth config changed, recreating OIDC authenticator")
-
-	if newConfig == nil {
-		// No auth config, clear everything
-		a.authConfig = nil
-		a.externalJWT = nil
-		a.internalPrefix = ""
-		return
-	}
-
-	// Create new authenticator
-	authn, err := newJWTAuthenticator(context.Background(), *newConfig)
-	if err != nil {
-		a.log.Error(err, "failed to create JWT authenticator during refresh, keeping existing config")
-		return
-	}
-
-	// Update config fields
-	a.authConfig = newConfig
-	a.internalPrefix = newConfig.Internal.Prefix
-	if newConfig.ClientID != "" {
-		a.oidcClientID = newConfig.ClientID
-	}
-
-	// Update authenticator
-	if authn != nil {
-		a.externalJWT = authn
-	} else {
-		if len(newConfig.JWT) == 0 {
-			a.externalJWT = nil
-		} else {
-			a.externalJWT = nil
-		}
-	}
-}
-
-func (a *APIServer) authenticateRequest(c *gin.Context) (string, string, *authError) {
-	// Refresh auth config if needed (checks OperatorConfig periodically)
-	a.refreshAuthConfigIfNeeded()
-
-	token := extractBearerToken(c)
-	if token == "" {
-		return "", "", &authError{
-			Reason:  "missing_token",
-			Details: "No bearer token provided. Set Authorization header with 'Bearer <token>' or use CAIB_TOKEN environment variable.",
-		}
-	}
-
-	// Track which auth methods were tried for error reporting
-	var authAttempts []string
-	var oidcError error
-
-	// Try internal JWT first
-	a.authConfigMu.RLock()
-	internalJWT := a.internalJWT
-	internalPrefix := a.internalPrefix
-	a.authConfigMu.RUnlock()
-
-	if internalJWT != nil {
-		authAttempts = append(authAttempts, "internal_jwt")
-		if subject, ok := validateInternalJWT(token, internalJWT); ok {
-			username := subject
-			if internalPrefix != "" {
-				username = internalPrefix + username
-			}
-			return username, "internal", nil
-		}
-	}
-
-	// Try external JWT (OIDC)
-	a.authConfigMu.RLock()
-	externalJWT := a.externalJWT
-	a.authConfigMu.RUnlock()
-
-	if externalJWT != nil {
-		authAttempts = append(authAttempts, "oidc")
-		result := a.authenticateExternalJWT(c, token, externalJWT)
-		if result.ok {
-			// Store OIDC token in secret after successful authentication
-			if a.internalJWT != nil {
-				if err := a.ensureClientTokenSecret(c, result.username, token); err != nil {
-					a.log.Error(err, "failed to ensure client token secret", "username", result.username)
-				}
-			}
-			return result.username, "external", nil
-		}
-		oidcError = result.err
-	}
-
-	// Fallback to kubeconfig TokenReview authentication
-	authAttempts = append(authAttempts, "k8s_token_review")
-
-	cfg, err := getRESTConfigFromRequest(c)
-	if err != nil {
-		a.log.Error(err, "Failed to get REST config for TokenReview fallback")
-		return "", "", &authError{
-			Reason:  "server_error",
-			Details: "Failed to initialize Kubernetes client for token validation. Check build-api logs.",
-		}
-	}
-
-	clientset, err := kubernetes.NewForConfig(cfg)
-	if err != nil {
-		a.log.Error(err, "Failed to create Kubernetes client for TokenReview")
-		return "", "", &authError{
-			Reason:  "server_error",
-			Details: "Failed to create Kubernetes client for token validation. Check build-api logs.",
-		}
-	}
-
-	tr := &authnv1.TokenReview{Spec: authnv1.TokenReviewSpec{Token: token}}
-	res, err := clientset.AuthenticationV1().TokenReviews().Create(c.Request.Context(), tr, metav1.CreateOptions{})
-	if err != nil {
-		a.log.Error(err, "TokenReview API call failed")
-		return "", "", &authError{
-			Reason:  "token_review_failed",
-			Details: "Failed to validate token with Kubernetes API. The token may be malformed or the server may have connectivity issues.",
-		}
-	}
-	if res.Status.Authenticated {
-		username := res.Status.User.Username
-		if username == "" {
-			return "", "", &authError{
-				Reason:  "invalid_token",
-				Details: "Token was authenticated but no username was returned.",
-			}
-		}
-		return username, "k8s", nil
-	}
-
-	// Build detailed error message for token validation failure
-	return "", "", a.buildAuthFailureError(authAttempts, oidcError, res.Status.Error)
-}
-
-// buildAuthFailureError constructs a sanitized error message explaining authentication failure.
-// Raw error details are logged server-side and not exposed to the client.
-func (a *APIServer) buildAuthFailureError(authAttempts []string, oidcError error, tokenReviewError string) *authError {
-	// Check if OIDC was attempted
-	oidcAttempted := false
-	for _, method := range authAttempts {
-		if method == "oidc" {
-			oidcAttempted = true
-			break
-		}
-	}
-
-	// Log full error details server-side for debugging
-	if tokenReviewError != "" {
-		a.log.Info("TokenReview authentication failed", "error", tokenReviewError)
-	}
-	if oidcError != nil {
-		a.log.Info("OIDC authentication failed", "error", oidcError.Error())
-	}
-
-	// only TokenReview was tried (no OIDC configured)
-	if !oidcAttempted {
-		return &authError{
-			Reason:  "invalid_token",
-			Details: "Token validation failed. The token may be expired or invalid. Try 'oc login' to refresh your session, then use 'oc whoami -t' for a fresh token.",
-		}
-	}
-
-	// OIDC was configured and attempted
-	var details strings.Builder
-	details.WriteString("Authentication failed. OIDC is configured on this cluster. ")
-
-	if oidcError != nil {
-		details.WriteString("OIDC: token validation failed. ")
-	} else {
-		details.WriteString("OIDC: token not valid for configured issuer. ")
-	}
-
-	if tokenReviewError != "" {
-		details.WriteString("Kubernetes fallback: token rejected. ")
-	} else {
-		details.WriteString("Kubernetes fallback: token rejected (may be expired or invalid). ")
-	}
-
-	details.WriteString("If using OIDC, ensure you have a valid OIDC token. Otherwise, try 'oc login' to refresh your session.")
-
-	return &authError{
-		Reason:  "invalid_token",
-		Details: details.String(),
-	}
-}
-
-// extractBearerToken extracts the bearer token from the request.
-func extractBearerToken(c *gin.Context) string {
-	authHeader := c.Request.Header.Get("Authorization")
-	token, _ := strings.CutPrefix(authHeader, "Bearer ")
-	if token != "" {
-		return strings.TrimSpace(token)
-	}
-	token = c.Request.Header.Get("X-Forwarded-Access-Token")
-	if token != "" {
-		return strings.TrimSpace(token)
-	}
-	return ""
-}
-
-// handleGetAuthConfig returns OIDC configuration for clients (no auth required)
-func (a *APIServer) handleGetAuthConfig(c *gin.Context) {
-	// Refresh auth config if needed
-	a.refreshAuthConfigIfNeeded()
-
-	type OIDCConfigResponse struct {
-		ClientID string `json:"clientId,omitempty"`
-		JWT      []struct {
-			Issuer struct {
-				URL       string   `json:"url"`
-				Audiences []string `json:"audiences,omitempty"`
-			} `json:"issuer"`
-			ClaimMappings struct {
-				Username struct {
-					Claim  string `json:"claim"`
-					Prefix string `json:"prefix,omitempty"`
-				} `json:"username"`
-			} `json:"claimMappings"`
-		} `json:"jwt"`
-	}
-
-	// Read auth config with mutex
-	a.authConfigMu.RLock()
-	clientID := a.oidcClientID
-	authConfig := a.authConfig
-	a.authConfigMu.RUnlock()
-
-	response := OIDCConfigResponse{
-		ClientID: clientID,
-	}
-
-	// Validate clientId matches at least one audience if both are set
-	if clientID != "" && authConfig != nil {
-		clientIDInAudience := false
-		for _, jwtConfig := range authConfig.JWT {
-			for _, audience := range jwtConfig.Issuer.Audiences {
-				if audience == clientID {
-					clientIDInAudience = true
-					break
-				}
-			}
-		}
-		if !clientIDInAudience && len(authConfig.JWT) > 0 {
-			a.log.Info("OIDC clientId does not match any JWT audience", "clientId", clientID)
-		}
-	}
-
-	// Only return OIDC config if externalJWT is actually working (not nil)
-	// If externalJWT is nil, OIDC isn't working and clients should use kubeconfig
-	a.authConfigMu.RLock()
-	externalJWTWorking := a.externalJWT != nil
-	a.authConfigMu.RUnlock()
-
-	// Try to get from parsed config first, but only if OIDC is actually working
-	if authConfig != nil && len(authConfig.JWT) > 0 && externalJWTWorking {
-		for _, jwtConfig := range authConfig.JWT {
-			prefix := ""
-			if jwtConfig.ClaimMappings.Username.Prefix != nil {
-				prefix = *jwtConfig.ClaimMappings.Username.Prefix
-			}
-			response.JWT = append(response.JWT, struct {
-				Issuer struct {
-					URL       string   `json:"url"`
-					Audiences []string `json:"audiences,omitempty"`
-				} `json:"issuer"`
-				ClaimMappings struct {
-					Username struct {
-						Claim  string `json:"claim"`
-						Prefix string `json:"prefix,omitempty"`
-					} `json:"username"`
-				} `json:"claimMappings"`
-			}{
-				Issuer: struct {
-					URL       string   `json:"url"`
-					Audiences []string `json:"audiences,omitempty"`
-				}{
-					URL:       jwtConfig.Issuer.URL,
-					Audiences: jwtConfig.Issuer.Audiences,
-				},
-				ClaimMappings: struct {
-					Username struct {
-						Claim  string `json:"claim"`
-						Prefix string `json:"prefix,omitempty"`
-					} `json:"username"`
-				}{
-					Username: struct {
-						Claim  string `json:"claim"`
-						Prefix string `json:"prefix,omitempty"`
-					}{
-						Claim:  jwtConfig.ClaimMappings.Username.Claim,
-						Prefix: prefix,
-					},
-				},
-			})
-		}
-	}
-
-	// OIDC not configured or not working, return 404 so clients use kubeconfig without trying OIDC
-	if len(response.JWT) == 0 {
-		c.AbortWithStatus(http.StatusNotFound)
-		return
-	}
-	c.JSON(http.StatusOK, response)
-}
-
 func (a *APIServer) handleGetOperatorConfig(c *gin.Context) {
 	ctx := c.Request.Context()
 	reqID, _ := c.Get("reqID")

--- a/internal/buildapi/workspace.go
+++ b/internal/buildapi/workspace.go
@@ -97,83 +97,27 @@ func (a *APIServer) registerWorkspaceRoutes(v1 *gin.RouterGroup) {
 	workspaceGroup := v1.Group("/workspaces")
 	workspaceGroup.Use(a.authMiddleware())
 	{
-		workspaceGroup.POST("", a.handleCreateWorkspace)
-		workspaceGroup.GET("", a.handleListWorkspaces)
-		workspaceGroup.GET("/:name", a.handleGetWorkspace)
-		workspaceGroup.DELETE("/:name", a.handleDeleteWorkspace)
-		workspaceGroup.POST("/:name/start", a.handleStartWorkspace)
-		workspaceGroup.POST("/:name/stop", a.handleStopWorkspace)
-		workspaceGroup.POST("/:name/sync", a.handleSyncWorkspace)
-		workspaceGroup.POST("/:name/sync/plan", a.handleSyncPlanWorkspace)
-		workspaceGroup.POST("/:name/exec", a.handleExecWorkspace)
-		workspaceGroup.GET("/:name/shell", a.handleShellWorkspace)
-		workspaceGroup.POST("/:name/deploy", a.handleDeployWorkspace)
+		workspaceGroup.POST("", a.wrapHandler("create workspace", a.createWorkspace))
+		workspaceGroup.GET("", a.wrapHandler("list workspaces", a.listWorkspaces))
+		workspaceGroup.GET("/:name", a.wrapNamedHandler("get workspace", a.getWorkspace))
+		workspaceGroup.DELETE("/:name", a.wrapNamedHandler("delete workspace", a.deleteWorkspace))
+		workspaceGroup.POST("/:name/start", a.wrapNamedHandler("start workspace", a.startWorkspace))
+		workspaceGroup.POST("/:name/stop", a.wrapNamedHandler("stop workspace", a.stopWorkspace))
+		workspaceGroup.POST("/:name/sync", a.wrapNamedHandler("sync workspace", a.syncWorkspace))
+		workspaceGroup.POST("/:name/sync/plan", a.wrapNamedHandler("sync plan workspace", a.syncPlanWorkspace))
+		workspaceGroup.POST("/:name/exec", a.wrapNamedHandler("exec workspace", a.execWorkspace))
+		workspaceGroup.GET("/:name/shell", a.wrapNamedHandler("shell workspace", a.shellWorkspace))
+		workspaceGroup.POST("/:name/deploy", a.wrapNamedHandler("deploy workspace", a.deployWorkspace))
 		workspaceGroup.PUT("/:name/lease", a.handleSetWorkspaceLease)
 	}
 }
 
-func (a *APIServer) handleCreateWorkspace(c *gin.Context) {
-	a.log.Info("create workspace", "reqID", c.GetString("reqID"))
-	a.createWorkspace(c)
-}
-
-func (a *APIServer) handleListWorkspaces(c *gin.Context) {
-	a.log.Info("list workspaces", "reqID", c.GetString("reqID"))
-	a.listWorkspaces(c)
-}
-
-func (a *APIServer) handleGetWorkspace(c *gin.Context) {
-	name := c.Param("name")
-	a.log.Info("get workspace", "name", name, "reqID", c.GetString("reqID"))
-	a.getWorkspace(c, name)
-}
-
-func (a *APIServer) handleDeleteWorkspace(c *gin.Context) {
-	name := c.Param("name")
-	a.log.Info("delete workspace", "name", name, "reqID", c.GetString("reqID"))
-	a.deleteWorkspace(c, name)
-}
-
-func (a *APIServer) handleSyncWorkspace(c *gin.Context) {
-	name := c.Param("name")
-	a.log.Info("sync workspace", "name", name, "reqID", c.GetString("reqID"))
-	a.syncWorkspace(c, name)
-}
-
-func (a *APIServer) handleSyncPlanWorkspace(c *gin.Context) {
-	name := c.Param("name")
-	a.log.Info("sync plan workspace", "name", name, "reqID", c.GetString("reqID"))
-	a.syncPlanWorkspace(c, name)
-}
-
-func (a *APIServer) handleExecWorkspace(c *gin.Context) {
-	name := c.Param("name")
-	a.log.Info("exec workspace", "name", name, "reqID", c.GetString("reqID"))
-	a.execWorkspace(c, name)
-}
-
-func (a *APIServer) handleShellWorkspace(c *gin.Context) {
-	name := c.Param("name")
-	a.log.Info("shell workspace", "name", name, "reqID", c.GetString("reqID"))
-	a.shellWorkspace(c, name)
-}
-
-func (a *APIServer) handleStartWorkspace(c *gin.Context) {
-	name := c.Param("name")
-	a.log.Info("start workspace", "name", name, "reqID", c.GetString("reqID"))
+func (a *APIServer) startWorkspace(c *gin.Context, name string) {
 	a.setWorkspaceStopped(c, name, false)
 }
 
-func (a *APIServer) handleStopWorkspace(c *gin.Context) {
-	name := c.Param("name")
-	a.log.Info("stop workspace", "name", name, "reqID", c.GetString("reqID"))
+func (a *APIServer) stopWorkspace(c *gin.Context, name string) {
 	a.setWorkspaceStopped(c, name, true)
-}
-
-func (a *APIServer) handleDeployWorkspace(c *gin.Context) {
-	name := c.Param("name")
-	a.log.Info("deploy workspace", "name", name, "reqID", c.GetString("reqID"))
-	a.deployWorkspace(c, name)
 }
 
 func (a *APIServer) createWorkspace(c *gin.Context) {
@@ -188,9 +132,8 @@ func (a *APIServer) createWorkspace(c *gin.Context) {
 		return
 	}
 
-	k8sClient, err := getClientFromRequest(c)
+	k8sClient, err := getK8sClientOrFail(c)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create kubernetes client"})
 		return
 	}
 
@@ -311,9 +254,8 @@ func (a *APIServer) createWorkspace(c *gin.Context) {
 }
 
 func (a *APIServer) listWorkspaces(c *gin.Context) {
-	k8sClient, err := getClientFromRequest(c)
+	k8sClient, err := getK8sClientOrFail(c)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create kubernetes client"})
 		return
 	}
 
@@ -359,9 +301,8 @@ func (a *APIServer) deleteWorkspace(c *gin.Context, name string) {
 		return // response already sent
 	}
 
-	k8sClient, err := getClientFromRequest(c)
+	k8sClient, err := getK8sClientOrFail(c)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create kubernetes client"})
 		return
 	}
 
@@ -393,9 +334,8 @@ func (a *APIServer) setWorkspaceStopped(c *gin.Context, name string, stopped boo
 		return
 	}
 
-	k8sClient, err := getClientFromRequest(c)
+	k8sClient, err := getK8sClientOrFail(c)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create kubernetes client"})
 		return
 	}
 
@@ -429,9 +369,8 @@ func (a *APIServer) handleSetWorkspaceLease(c *gin.Context) {
 		return
 	}
 
-	k8sClient, err := getClientFromRequest(c)
+	k8sClient, err := getK8sClientOrFail(c)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create kubernetes client"})
 		return
 	}
 
@@ -446,10 +385,9 @@ func (a *APIServer) handleSetWorkspaceLease(c *gin.Context) {
 }
 
 func (a *APIServer) getOwnedWorkspace(c *gin.Context, name string) (*automotivev1alpha1.Workspace, error) {
-	k8sClient, err := getClientFromRequest(c)
+	k8sClient, err := getK8sClientOrFail(c)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create kubernetes client"})
-		return nil, err
+		return nil, fmt.Errorf("failed to create kubernetes client")
 	}
 
 	namespace := resolveNamespace()
@@ -480,9 +418,9 @@ func (a *APIServer) touchWorkspaceActivity(c *gin.Context, ws *automotivev1alpha
 	if ws.Spec.Stopped {
 		return
 	}
-	k8sClient, err := getClientFromRequest(c)
+	k8sClient, err := getClientFromRequestFn(c)
 	if err != nil {
-		return // best-effort, don't fail the operation
+		return
 	}
 
 	now := metav1.Now()


### PR DESCRIPTION
## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [X] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [X] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication now required for Build API endpoints, supporting JWT, OIDC, and Kubernetes TokenReview methods
  * New OIDC configuration endpoint available for retrieving current authentication settings

* **Improvements**
  * Standardized error handling and response messages across Build API endpoints for better consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->