### PR TITLE
bug: fix sealed task scc and SA

### DIFF
--- a/internal/controller/imagereseal/controller.go
+++ b/internal/controller/imagereseal/controller.go
@@ -360,9 +360,10 @@ func (r *Reconciler) createSealedTaskRun(ctx context.Context, sealed *automotive
 	}
 
 	trSpec := tektonv1.TaskRunSpec{
-		TaskRef:    &tektonv1.TaskRef{Name: tasks.SealedTaskName(operation)},
-		Params:     params,
-		Workspaces: workspaces,
+		TaskRef:            &tektonv1.TaskRef{Name: tasks.SealedTaskName(operation)},
+		Params:             params,
+		Workspaces:         workspaces,
+		ServiceAccountName: automotivev1alpha1.BuildServiceAccountName,
 	}
 	if nodeArch := archToNodeArch(sealed.Spec.Architecture); nodeArch != "" {
 		trSpec.PodTemplate = &pod.Template{

--- a/internal/controller/imagereseal/trusted_ca_test.go
+++ b/internal/controller/imagereseal/trusted_ca_test.go
@@ -1,12 +1,64 @@
 package imagereseal
 
 import (
+	"context"
 	"testing"
 
 	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
 	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/tasks"
 	controllerutils "github.com/centos-automotive-suite/automotive-dev-operator/internal/controller/controllerutils"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func newTestScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(automotivev1alpha1.AddToScheme(s))
+	utilruntime.Must(tektonv1.AddToScheme(s))
+	return s
+}
+
+func TestCreateSealedTaskRun_ServiceAccount(t *testing.T) {
+	scheme := newTestScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &Reconciler{Client: fakeClient, Scheme: scheme}
+
+	sealed := &automotivev1alpha1.ImageReseal{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-reseal",
+			Namespace: "default",
+			UID:       "test-uid",
+		},
+		Spec: automotivev1alpha1.ImageResealSpec{
+			Operation: "reseal",
+			InputRef:  "quay.io/test/bootc:seal",
+			OutputRef: "quay.io/test/bootc:resealed",
+		},
+	}
+
+	tr, err := r.createSealedTaskRun(context.Background(), sealed, "reseal")
+	if err != nil {
+		t.Fatalf("createSealedTaskRun returned error: %v", err)
+	}
+	if tr.Spec.ServiceAccountName != automotivev1alpha1.BuildServiceAccountName {
+		t.Errorf("TaskRun ServiceAccountName = %q, want %q", tr.Spec.ServiceAccountName, automotivev1alpha1.BuildServiceAccountName)
+	}
+
+	// Verify the TaskRun was actually created in the cluster with the right SA
+	created := &tektonv1.TaskRun{}
+	if err := fakeClient.Get(context.Background(), client.ObjectKey{Name: "test-reseal", Namespace: "default"}, created); err != nil {
+		t.Fatalf("TaskRun not found after creation: %v", err)
+	}
+	if created.Spec.ServiceAccountName != automotivev1alpha1.BuildServiceAccountName {
+		t.Errorf("persisted TaskRun ServiceAccountName = %q, want %q", created.Spec.ServiceAccountName, automotivev1alpha1.BuildServiceAccountName)
+	}
+}
 
 func TestApplyTrustedCABundleFromOSBuilds_ImageReseal(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [X] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Explicitly set the service account for reseal operations to ensure consistent permissions across all run types.
* **Tests**
  * Added a unit test to verify the service account is correctly applied for reseal runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->