### PR TITLE
fix: fix incorrect progressing state on expired builds

### DIFF
--- a/internal/controller/imagebuild/controller.go
+++ b/internal/controller/imagebuild/controller.go
@@ -2704,7 +2704,7 @@ func setImageBuildConditions(imageBuild *automotivev1alpha1.ImageBuild, phase, m
 			Reason:  "BuildSucceeded",
 			Message: message,
 		})
-	case phaseFailed, phaseCancelled:
+	case phaseFailed, phaseCancelled, automotivev1alpha1.ImageBuildPhaseExpired:
 		meta.SetStatusCondition(&imageBuild.Status.Conditions, metav1.Condition{
 			Type:    automotivev1alpha1.ImageBuildConditionProgressing,
 			Status:  metav1.ConditionFalse,

--- a/internal/controller/imagebuild/expiry_test.go
+++ b/internal/controller/imagebuild/expiry_test.go
@@ -79,6 +79,29 @@ func TestCheckExpiry_ExpiredBuild_TransitionsToExpiredPhase(t *testing.T) {
 	if got.Status.Phase != automotivev1alpha1.ImageBuildPhaseExpired {
 		t.Errorf("expected phase %q, got %q", automotivev1alpha1.ImageBuildPhaseExpired, got.Status.Phase)
 	}
+
+	foundProgressing := false
+	foundReady := false
+	for _, c := range got.Status.Conditions {
+		switch c.Type {
+		case automotivev1alpha1.ImageBuildConditionProgressing:
+			foundProgressing = true
+			if c.Status != metav1.ConditionFalse {
+				t.Errorf("Progressing condition should be False for expired build, got %s", c.Status)
+			}
+		case automotivev1alpha1.ImageBuildConditionReady:
+			foundReady = true
+			if c.Status != metav1.ConditionFalse {
+				t.Errorf("Ready condition should be False for expired build, got %s", c.Status)
+			}
+		}
+	}
+	if !foundProgressing {
+		t.Error("expected Progressing condition to be present")
+	}
+	if !foundReady {
+		t.Error("expected Ready condition to be present")
+	}
 }
 
 func TestCheckExpiry_NotYetExpired(t *testing.T) {


### PR DESCRIPTION

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [X] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed image build status conditions to properly reflect expired state, ensuring Progressing and Ready conditions are correctly set to false for expired builds.

* **Tests**
  * Enhanced test coverage to verify status condition reporting for expired builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->