### PR TITLE
fix: fix creds passing when using internal-registry

### DIFF
--- a/cmd/caib/buildcmd/build.go
+++ b/cmd/caib/buildcmd/build.go
@@ -173,16 +173,17 @@ func (h *Handler) validateReproducibleFlags() error {
 // applyRegistryCredentialsToRequest sets registry credentials on the build request.
 // When --internal-registry is combined with --push, both are configured so the
 // container is pushed externally while the disk image uses the internal registry.
+// Credentials are also resolved for --internal-registry without --push when the
+// user provides them (env vars or --registry-auth-file), enabling authenticated
+// pulls of private source images during the build.
 func (h *Handler) applyRegistryCredentialsToRequest(req *buildapitypes.BuildRequest) error {
 	if *h.opts.UseInternalRegistry {
 		req.UseInternalRegistry = true
 		req.InternalRegistryImageName = *h.opts.InternalRegistryImageName
 		req.InternalRegistryTag = *h.opts.InternalRegistryTag
-		if *h.opts.ContainerPush == "" {
+		if *h.opts.ContainerPush == "" && !h.hasRegistryCredentials() {
 			return nil
 		}
-		// Hybrid: fall through to also set external registry credentials
-		// for the container push.
 	}
 
 	effectiveRegistryURL, registryUsername, registryPassword := registryauth.ExtractRegistryCredentials(*h.opts.ContainerPush, *h.opts.ExportOCI)
@@ -197,6 +198,18 @@ func (h *Handler) applyRegistryCredentialsToRequest(req *buildapitypes.BuildRequ
 	}
 	req.RegistryCredentials = registryCreds
 	return nil
+}
+
+// hasRegistryCredentials returns true if the user has provided registry credentials
+// via environment variables or --registry-auth-file.
+func (h *Handler) hasRegistryCredentials() bool {
+	if h.opts.RegistryAuthFile != nil && strings.TrimSpace(*h.opts.RegistryAuthFile) != "" {
+		return true
+	}
+	if os.Getenv("REGISTRY_USERNAME") != "" || os.Getenv("REGISTRY_URL") != "" {
+		return true
+	}
+	return false
 }
 
 // resolveTarget determines the build target: --target flag > manifest value > "qemu".

--- a/cmd/caib/buildcmd/build_creds_test.go
+++ b/cmd/caib/buildcmd/build_creds_test.go
@@ -1,0 +1,103 @@
+package buildcmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	buildapitypes "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi"
+)
+
+func TestApplyRegistryCredentials_InternalRegistryWithEnvCreds(t *testing.T) {
+	t.Setenv("REGISTRY_URL", "quay.io")
+	t.Setenv("REGISTRY_USERNAME", "myuser")
+	t.Setenv("REGISTRY_PASSWORD", "mypass")
+
+	opts := newTestDiskOpts()
+	*opts.UseInternalRegistry = true
+	h := NewHandler(opts)
+
+	req := &buildapitypes.BuildRequest{}
+	if err := h.applyRegistryCredentialsToRequest(req); err != nil {
+		t.Fatalf("applyRegistryCredentialsToRequest() error = %v", err)
+	}
+
+	if !req.UseInternalRegistry {
+		t.Fatal("expected UseInternalRegistry = true")
+	}
+	if req.RegistryCredentials == nil {
+		t.Fatal("expected RegistryCredentials to be set when env vars are provided")
+	}
+	if req.RegistryCredentials.AuthType != "username-password" {
+		t.Fatalf("authType = %q, want username-password", req.RegistryCredentials.AuthType)
+	}
+	if req.RegistryCredentials.RegistryURL != "quay.io" {
+		t.Fatalf("registryURL = %q, want quay.io", req.RegistryCredentials.RegistryURL)
+	}
+}
+
+func TestApplyRegistryCredentials_InternalRegistryWithAuthFile(t *testing.T) {
+	t.Setenv("REGISTRY_URL", "")
+	t.Setenv("REGISTRY_USERNAME", "")
+	t.Setenv("REGISTRY_PASSWORD", "")
+	t.Setenv("REGISTRY_AUTH_FILE", "")
+	t.Setenv("XDG_RUNTIME_DIR", "")
+	t.Setenv("HOME", t.TempDir())
+
+	tmpDir := t.TempDir()
+	authFile := filepath.Join(tmpDir, "auth.json")
+	writeTestAuthFile(t, authFile)
+
+	opts := newTestDiskOpts()
+	*opts.UseInternalRegistry = true
+	*opts.RegistryAuthFile = authFile
+	h := NewHandler(opts)
+
+	req := &buildapitypes.BuildRequest{}
+	if err := h.applyRegistryCredentialsToRequest(req); err != nil {
+		t.Fatalf("applyRegistryCredentialsToRequest() error = %v", err)
+	}
+
+	if !req.UseInternalRegistry {
+		t.Fatal("expected UseInternalRegistry = true")
+	}
+	if req.RegistryCredentials == nil {
+		t.Fatal("expected RegistryCredentials to be set when --registry-auth-file is provided")
+	}
+	if req.RegistryCredentials.AuthType != "docker-config" {
+		t.Fatalf("authType = %q, want docker-config", req.RegistryCredentials.AuthType)
+	}
+}
+
+func TestApplyRegistryCredentials_InternalRegistryNoCredsReturnsNil(t *testing.T) {
+	t.Setenv("REGISTRY_URL", "")
+	t.Setenv("REGISTRY_USERNAME", "")
+	t.Setenv("REGISTRY_PASSWORD", "")
+
+	opts := newTestDiskOpts()
+	*opts.UseInternalRegistry = true
+	h := NewHandler(opts)
+
+	req := &buildapitypes.BuildRequest{}
+	if err := h.applyRegistryCredentialsToRequest(req); err != nil {
+		t.Fatalf("applyRegistryCredentialsToRequest() error = %v", err)
+	}
+
+	if !req.UseInternalRegistry {
+		t.Fatal("expected UseInternalRegistry = true")
+	}
+	if req.RegistryCredentials != nil {
+		t.Fatalf("expected nil RegistryCredentials when no creds provided, got %+v", req.RegistryCredentials)
+	}
+}
+
+func writeTestAuthFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("failed to create directory: %v", err)
+	}
+	content := []byte(`{"auths":{"quay.io":{"auth":"dGVzdDp0ZXN0"}}}`)
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatalf("failed to write auth file: %v", err)
+	}
+}

--- a/cmd/caib/registryauth/credentials.go
+++ b/cmd/caib/registryauth/credentials.go
@@ -18,7 +18,7 @@ func ExtractRegistryCredentials(primaryRef, secondaryRef string) (string, string
 		ref = secondaryRef
 	}
 	if ref == "" {
-		return "", username, password
+		return os.Getenv("REGISTRY_URL"), username, password
 	}
 
 	if username == "" || password == "" {
@@ -66,6 +66,10 @@ func ResolveRegistryCredentials(
 		}, nil
 	}
 	if registryURL == "" {
+		if username != "" || password != "" {
+			fmt.Fprintln(os.Stderr, "Warning: REGISTRY_USERNAME/REGISTRY_PASSWORD set but no registry URL could be determined.")
+			fmt.Fprintln(os.Stderr, "Use --registry-auth-file for authenticated pulls, or set REGISTRY_URL for a single registry.")
+		}
 		return nil, nil
 	}
 

--- a/cmd/caib/registryauth/credentials_test.go
+++ b/cmd/caib/registryauth/credentials_test.go
@@ -6,15 +6,18 @@ import (
 	"testing"
 )
 
-const authTypeDockerConfig = "docker-config"
+const (
+	authTypeDockerConfig = "docker-config"
+	testRegistryQuayIO   = "quay.io"
+)
 
 func TestExtractRegistryCredentials_FromPrimaryRefAndEnv(t *testing.T) {
 	t.Setenv("REGISTRY_USERNAME", "user1")
 	t.Setenv("REGISTRY_PASSWORD", "pass1")
 
-	gotURL, gotUser, gotPass := ExtractRegistryCredentials("quay.io/org/image:latest", "")
-	if gotURL != "quay.io" {
-		t.Fatalf("registry URL = %q, want %q", gotURL, "quay.io")
+	gotURL, gotUser, gotPass := ExtractRegistryCredentials(testRegistryQuayIO+"/org/image:latest", "")
+	if gotURL != testRegistryQuayIO {
+		t.Fatalf("registry URL = %q, want %q", gotURL, testRegistryQuayIO)
 	}
 	if gotUser != "user1" || gotPass != "pass1" {
 		t.Fatalf("unexpected credentials: user=%q pass=%q", gotUser, gotPass)
@@ -49,11 +52,11 @@ func TestValidateRegistryCredentials_PartialCredentialsError(t *testing.T) {
 		pass    string
 		wantErr bool
 	}{
-		{name: "both set", url: "quay.io", user: "u", pass: "p", wantErr: false},
-		{name: "neither set", url: "quay.io", user: "", pass: "", wantErr: false},
+		{name: "both set", url: testRegistryQuayIO, user: "u", pass: "p", wantErr: false},
+		{name: "neither set", url: testRegistryQuayIO, user: "", pass: "", wantErr: false},
 		{name: "no registry URL", url: "", user: "u", pass: "", wantErr: false},
-		{name: "username only", url: "quay.io", user: "u", pass: "", wantErr: true},
-		{name: "password only", url: "quay.io", user: "", pass: "p", wantErr: true},
+		{name: "username only", url: testRegistryQuayIO, user: "u", pass: "", wantErr: true},
+		{name: "password only", url: testRegistryQuayIO, user: "", pass: "p", wantErr: true},
 	}
 
 	for _, tt := range tests {
@@ -74,10 +77,10 @@ func TestResolveRegistryCredentials_ExplicitAuthFileOverridesEnv(t *testing.T) {
 	tmpDir := t.TempDir()
 	authFile := filepath.Join(tmpDir, "auth.json")
 	writeAuthFile(t, authFile, map[string]map[string]string{
-		"quay.io": {"auth": "from-file-token"},
+		testRegistryQuayIO: {"auth": "from-file-token"},
 	})
 
-	creds, err := ResolveRegistryCredentials("quay.io", "env-user", "env-pass", authFile)
+	creds, err := ResolveRegistryCredentials(testRegistryQuayIO, "env-user", "env-pass", authFile)
 	if err != nil {
 		t.Fatalf("ResolveRegistryCredentials() error = %v", err)
 	}
@@ -100,7 +103,7 @@ func TestResolveRegistryCredentials_ExplicitAuthFileWithEmptyRegistryURL(t *test
 	tmpDir := t.TempDir()
 	authFile := filepath.Join(tmpDir, "auth.json")
 	writeAuthFile(t, authFile, map[string]map[string]string{
-		"quay.io": {"auth": "from-file-token"},
+		testRegistryQuayIO: {"auth": "from-file-token"},
 	})
 
 	creds, err := ResolveRegistryCredentials("", "", "", authFile)
@@ -122,7 +125,7 @@ func TestResolveRegistryCredentials_ExplicitAuthFileWithEmptyRegistryURL(t *test
 }
 
 func TestResolveRegistryCredentials_UsesEnvCredentialsWhenNoAuthFile(t *testing.T) {
-	creds, err := ResolveRegistryCredentials("quay.io", "env-user", "env-pass", "")
+	creds, err := ResolveRegistryCredentials(testRegistryQuayIO, "env-user", "env-pass", "")
 	if err != nil {
 		t.Fatalf("ResolveRegistryCredentials() error = %v", err)
 	}
@@ -164,8 +167,84 @@ func TestResolveRegistryCredentials_AutoDiscoversAuthJSONFallback(t *testing.T) 
 	}
 }
 
+func TestExtractRegistryCredentials_FallsBackToRegistryURLEnv(t *testing.T) {
+	t.Setenv("REGISTRY_URL", testRegistryQuayIO)
+	t.Setenv("REGISTRY_USERNAME", "user1")
+	t.Setenv("REGISTRY_PASSWORD", "pass1")
+
+	gotURL, gotUser, gotPass := ExtractRegistryCredentials("", "")
+	if gotURL != testRegistryQuayIO {
+		t.Fatalf("registry URL = %q, want %q", gotURL, testRegistryQuayIO)
+	}
+	if gotUser != "user1" || gotPass != "pass1" {
+		t.Fatalf("unexpected credentials: user=%q pass=%q", gotUser, gotPass)
+	}
+}
+
+func TestExtractRegistryCredentials_RefTakesPrecedenceOverRegistryURLEnv(t *testing.T) {
+	t.Setenv("REGISTRY_URL", "should-not-use.io")
+	t.Setenv("REGISTRY_USERNAME", "user1")
+	t.Setenv("REGISTRY_PASSWORD", "pass1")
+
+	gotURL, _, _ := ExtractRegistryCredentials(testRegistryQuayIO+"/org/image:latest", "")
+	if gotURL != testRegistryQuayIO {
+		t.Fatalf("registry URL = %q, want %q (ref should take precedence)", gotURL, testRegistryQuayIO)
+	}
+}
+
+func TestExtractRegistryCredentials_EmptyRefsAndNoEnvReturnsEmpty(t *testing.T) {
+	t.Setenv("REGISTRY_URL", "")
+	t.Setenv("REGISTRY_USERNAME", "")
+	t.Setenv("REGISTRY_PASSWORD", "")
+
+	gotURL, gotUser, gotPass := ExtractRegistryCredentials("", "")
+	if gotURL != "" {
+		t.Fatalf("registry URL = %q, want empty", gotURL)
+	}
+	if gotUser != "" || gotPass != "" {
+		t.Fatalf("expected empty credentials, got user=%q pass=%q", gotUser, gotPass)
+	}
+}
+
+func TestResolveRegistryCredentials_RegistryURLEnvWithUsernamePassword(t *testing.T) {
+	t.Setenv("REGISTRY_AUTH_FILE", "")
+	t.Setenv("XDG_RUNTIME_DIR", "")
+	t.Setenv("HOME", t.TempDir())
+
+	creds, err := ResolveRegistryCredentials(testRegistryQuayIO, "myuser", "mypass", "")
+	if err != nil {
+		t.Fatalf("ResolveRegistryCredentials() error = %v", err)
+	}
+	if creds == nil {
+		t.Fatal("expected non-nil credentials")
+	}
+	if creds.AuthType != "username-password" {
+		t.Fatalf("authType = %q, want username-password", creds.AuthType)
+	}
+	if creds.RegistryURL != testRegistryQuayIO {
+		t.Fatalf("registryURL = %q, want %s", creds.RegistryURL, testRegistryQuayIO)
+	}
+	if creds.Username != "myuser" || creds.Password != "mypass" {
+		t.Fatalf("unexpected creds: user=%q pass=%q", creds.Username, creds.Password)
+	}
+}
+
+func TestResolveRegistryCredentials_WarnsWhenCredsSetButNoURL(t *testing.T) {
+	t.Setenv("REGISTRY_AUTH_FILE", "")
+	t.Setenv("XDG_RUNTIME_DIR", "")
+	t.Setenv("HOME", t.TempDir())
+
+	creds, err := ResolveRegistryCredentials("", "myuser", "mypass", "")
+	if err != nil {
+		t.Fatalf("ResolveRegistryCredentials() error = %v", err)
+	}
+	if creds != nil {
+		t.Fatalf("expected nil credentials when no registry URL, got %+v", creds)
+	}
+}
+
 func TestResolveRegistryCredentials_PartialCredentialsValidation(t *testing.T) {
-	_, err := ResolveRegistryCredentials("quay.io", "user-only", "", "")
+	_, err := ResolveRegistryCredentials(testRegistryQuayIO, "user-only", "", "")
 	if err == nil {
 		t.Fatal("expected validation error for partial credentials")
 	}


### PR DESCRIPTION
When using --internal-registry while having external private registry references in the aib manifest, the passed credentials were skipped.

This patch allows the user to set the registry which the credentials are meant for: 
REGISTRY_URL=quay.io REGISTRY_USERNAME=foo REGISTRY_PASSWORD=bar \
    caib image build-dev ffi.aib.yml --internal-registry ...


## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)
