### PR TITLE
fix: validate arch for builds

### DIFF
--- a/internal/buildapi/internal_registry_test.go
+++ b/internal/buildapi/internal_registry_test.go
@@ -213,6 +213,50 @@ var _ = Describe("Internal Registry", func() {
 			})
 		})
 
+		Context("architecture validation", func() {
+			It("should accept amd64", func() {
+				req := &BuildRequest{Architecture: "amd64"}
+				err := applyBuildDefaults(req)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(req.Architecture).To(Equal(Architecture("amd64")))
+			})
+
+			It("should accept arm64", func() {
+				req := &BuildRequest{Architecture: "arm64"}
+				err := applyBuildDefaults(req)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(req.Architecture).To(Equal(Architecture("arm64")))
+			})
+
+			It("should normalize x86_64 to amd64", func() {
+				req := &BuildRequest{Architecture: "x86_64"}
+				err := applyBuildDefaults(req)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(req.Architecture).To(Equal(Architecture("amd64")))
+			})
+
+			It("should normalize aarch64 to arm64", func() {
+				req := &BuildRequest{Architecture: "aarch64"}
+				err := applyBuildDefaults(req)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(req.Architecture).To(Equal(Architecture("arm64")))
+			})
+
+			It("should default to arm64 when empty", func() {
+				req := &BuildRequest{}
+				err := applyBuildDefaults(req)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(req.Architecture).To(Equal(Architecture("arm64")))
+			})
+
+			It("should reject invalid architecture", func() {
+				req := &BuildRequest{Architecture: "mips64"}
+				err := applyBuildDefaults(req)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid architecture"))
+			})
+		})
+
 		Context("applyBuildDefaults with internal registry", func() {
 			It("should apply defaults without overwriting internal registry fields", func() {
 				req := &BuildRequest{

--- a/internal/buildapi/server.go
+++ b/internal/buildapi/server.go
@@ -780,6 +780,7 @@ func applyBuildDefaults(req *BuildRequest) error {
 	if req.Architecture == "" {
 		req.Architecture = "arm64"
 	}
+	req.Architecture = req.Architecture.Normalize()
 	if req.ExportFormat == "" {
 		req.ExportFormat = formatImage
 	}
@@ -799,7 +800,7 @@ func applyBuildDefaults(req *BuildRequest) error {
 		return fmt.Errorf("target cannot be empty")
 	}
 	if !req.Architecture.IsValid() {
-		return fmt.Errorf("architecture cannot be empty")
+		return fmt.Errorf("invalid architecture %q: must be amd64, arm64, x86_64, or aarch64", req.Architecture)
 	}
 	// ExportFormat validation removed - allow AIB to handle format validation
 	if !req.Mode.IsValid() {

--- a/internal/buildapi/types.go
+++ b/internal/buildapi/types.go
@@ -23,6 +23,12 @@ type Compression string
 // Mode represents the build mode (bootc, image, package, or disk).
 type Mode string
 
+// Supported CPU architectures.
+const (
+	ArchAMD64 Architecture = "amd64"
+	ArchARM64 Architecture = "arm64"
+)
+
 // Supported compression algorithms for build artifacts.
 const (
 	CompressionGzip Compression = "gzip"
@@ -52,8 +58,26 @@ func (d Distro) IsValid() bool { return IsValid(string(d)) }
 // IsValid returns true if the target value is non-empty.
 func (t Target) IsValid() bool { return IsValid(string(t)) }
 
-// IsValid returns true if the architecture value is non-empty.
-func (a Architecture) IsValid() bool { return IsValid(string(a)) }
+// Normalize maps Linux-convention architecture names to Kubernetes/OCI names.
+func (a Architecture) Normalize() Architecture {
+	switch strings.ToLower(strings.TrimSpace(string(a))) {
+	case "x86_64", "amd64":
+		return ArchAMD64
+	case "aarch64", "arm64":
+		return ArchARM64
+	default:
+		return a
+	}
+}
+
+// IsValid returns true if the architecture is a supported value.
+func (a Architecture) IsValid() bool {
+	switch a {
+	case ArchAMD64, ArchARM64:
+		return true
+	}
+	return false
+}
 
 // IsValid returns true if the export format value is non-empty.
 func (e ExportFormat) IsValid() bool { return IsValid(string(e)) }

--- a/internal/controller/catalogimage/registry.go
+++ b/internal/controller/catalogimage/registry.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
+	controllerutils "github.com/centos-automotive-suite/automotive-dev-operator/internal/controller/controllerutils"
 )
 
 // RegistryClient provides methods to interact with container registries
@@ -363,14 +364,7 @@ func (c *DefaultRegistryClient) VerifyDigest(
 
 // NormalizeArchitecture normalizes architecture names to OCI standard
 func NormalizeArchitecture(arch string) string {
-	switch strings.ToLower(arch) {
-	case "x86_64", "amd64":
-		return "amd64"
-	case "aarch64", "arm64":
-		return "arm64"
-	default:
-		return arch
-	}
+	return controllerutils.NormalizeArchToK8s(arch)
 }
 
 // GetCurrentTime returns the current time as a metav1.Time

--- a/internal/controller/controllerutils/arch.go
+++ b/internal/controller/controllerutils/arch.go
@@ -1,0 +1,16 @@
+package controllerutils
+
+import "strings"
+
+// NormalizeArchToK8s maps architecture names to Kubernetes kubernetes.io/arch values.
+// Handles both Linux (x86_64, aarch64) and OCI/Go (amd64, arm64) conventions.
+func NormalizeArchToK8s(arch string) string {
+	switch strings.ToLower(strings.TrimSpace(arch)) {
+	case "x86_64", "amd64":
+		return "amd64"
+	case "aarch64", "arm64":
+		return "arm64"
+	default:
+		return arch
+	}
+}

--- a/internal/controller/controllerutils/arch_test.go
+++ b/internal/controller/controllerutils/arch_test.go
@@ -1,0 +1,29 @@
+package controllerutils
+
+import "testing"
+
+func TestNormalizeArchToK8s(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"amd64", "amd64"},
+		{"x86_64", "amd64"},
+		{"X86_64", "amd64"},
+		{" amd64 ", "amd64"},
+		{"arm64", "arm64"},
+		{"aarch64", "arm64"},
+		{"AARCH64", "arm64"},
+		{" arm64 ", "arm64"},
+		{"s390x", "s390x"},
+		{"ppc64le", "ppc64le"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := NormalizeArchToK8s(tt.input); got != tt.want {
+				t.Errorf("NormalizeArchToK8s(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/controller/imagebuild/controller.go
+++ b/internal/controller/imagebuild/controller.go
@@ -1458,7 +1458,7 @@ func (r *ImageBuildReconciler) createBuildTaskRun(
 						{
 							Key:      corev1.LabelArchStable,
 							Operator: corev1.NodeSelectorOpIn,
-							Values:   []string{imageBuild.Spec.Architecture},
+							Values:   []string{controllerutils.NormalizeArchToK8s(imageBuild.Spec.Architecture)},
 						},
 					},
 				},
@@ -2557,7 +2557,7 @@ func (r *ImageBuildReconciler) createUploadPod(ctx context.Context, imageBuild *
 								{
 									Key:      corev1.LabelArchStable,
 									Operator: corev1.NodeSelectorOpIn,
-									Values:   []string{imageBuild.Spec.Architecture},
+									Values:   []string{controllerutils.NormalizeArchToK8s(imageBuild.Spec.Architecture)},
 								},
 							},
 						},

--- a/internal/controller/imagereseal/controller.go
+++ b/internal/controller/imagereseal/controller.go
@@ -525,15 +525,13 @@ func (r *Reconciler) createSealedPipelineRun(ctx context.Context, sealed *automo
 }
 
 // archToNodeArch maps ImageReseal.Spec.Architecture to Kubernetes node label (kubernetes.io/arch).
+// Returns empty string for unrecognized architectures so callers can skip node selection.
 func archToNodeArch(arch string) string {
-	switch strings.ToLower(strings.TrimSpace(arch)) {
-	case "amd64", "x86_64":
-		return "amd64"
-	case "arm64", "aarch64":
-		return "arm64"
-	default:
+	normalized := controllerutils.NormalizeArchToK8s(arch)
+	if normalized == arch && normalized != "amd64" && normalized != "arm64" {
 		return ""
 	}
+	return normalized
 }
 
 // validateStages checks that every entry in stages is a known sealed operation.

--- a/internal/controller/workspace/controller.go
+++ b/internal/controller/workspace/controller.go
@@ -460,7 +460,7 @@ chown -R 1000:1000 /workspace/src /workspace/cache /workspace/.cache /workspace/
 								{
 									Key:      "kubernetes.io/arch",
 									Operator: corev1.NodeSelectorOpIn,
-									Values:   []string{arch},
+									Values:   []string{controllerutils.NormalizeArchToK8s(arch)},
 								},
 							},
 						},


### PR DESCRIPTION
accept x86_64/aarch64 and map to Go arch convention, reject other arches

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)
