### PR TITLE
refactor: extract E2E-Test CI setup into reusable composite actions

### DIFF
--- a/.github/actions/cleanup-kind-e2e/action.yml
+++ b/.github/actions/cleanup-kind-e2e/action.yml
@@ -1,0 +1,26 @@
+name: Cleanup Kind E2E Environment
+description: >
+  Delete the Kind cluster, remove the local registry container, and clean up
+  host-level configuration (DNS entries, container registry config).
+
+inputs:
+  cluster-name:
+    description: Kind cluster name to delete
+    default: automotive-dev-e2e
+  registry-name:
+    description: Local registry container name to remove
+    default: kind-registry
+  registry-host:
+    description: Registry hostname to remove from /etc/hosts
+    default: image-registry.openshift-image-registry.svc
+
+runs:
+  using: composite
+  steps:
+    - name: Cleanup Kind cluster and registry
+      shell: bash
+      run: |
+        kind delete cluster --name "${{ inputs.cluster-name }}" || true
+        docker rm -f "${{ inputs.registry-name }}" || true
+        sudo sed -i "/${{ inputs.registry-host }}/d" /etc/hosts 2>/dev/null || true
+        rm -f "${HOME}/.config/containers/registries.conf.d/kind-e2e-registry.conf" || true

--- a/.github/actions/collect-e2e-logs/action.yml
+++ b/.github/actions/collect-e2e-logs/action.yml
@@ -1,0 +1,35 @@
+name: Collect E2E Logs
+description: >
+  Collect operator logs, pod status, TaskRuns, events, and custom resources
+  from e2e test namespaces for debugging failures.
+
+inputs:
+  namespaces:
+    description: >
+      Space-separated list of namespaces to collect logs from.
+      Non-existent namespaces are silently skipped.
+    default: e2e-test-all e2e-operator e2e-bootc e2e-auth
+
+runs:
+  using: composite
+  steps:
+    - name: Collect logs from e2e namespaces
+      shell: bash
+      run: |
+        for NS in ${{ inputs.namespaces }}; do
+          if ! kubectl get ns "$NS" &>/dev/null; then continue; fi
+          echo "=== [$NS] Operator Logs ==="
+          kubectl logs -n "$NS" -l control-plane=operator --tail=200 || true
+          echo "=== [$NS] All Pods ==="
+          kubectl get pods -n "$NS" -o wide || true
+          echo "=== [$NS] TaskRuns ==="
+          kubectl get taskrun -n "$NS" -o yaml || true
+          echo "=== [$NS] PipelineRuns ==="
+          kubectl get pipelinerun -n "$NS" -o yaml || true
+          echo "=== [$NS] Events ==="
+          kubectl get events -n "$NS" --sort-by='.lastTimestamp' || true
+          echo "=== [$NS] OperatorConfig ==="
+          kubectl get operatorconfig -n "$NS" -o yaml || true
+          echo "=== [$NS] ImageBuilds ==="
+          kubectl get imagebuilds -n "$NS" -o yaml || true
+        done

--- a/.github/actions/setup-kind-e2e/action.yml
+++ b/.github/actions/setup-kind-e2e/action.yml
@@ -1,0 +1,166 @@
+name: Setup Kind E2E Environment
+description: >
+  Provision a Kind cluster with a local container registry, Tekton Pipelines,
+  and an NGINX ingress controller for running E2E tests.
+
+inputs:
+  kind-version:
+    description: Kind version to install
+    default: v0.24.0
+  kubectl-version:
+    description: kubectl version to install
+    default: v1.31.0
+  tekton-version:
+    description: Tekton Pipelines version to install
+    default: v1.9.1
+  ingress-nginx-version:
+    description: NGINX Ingress Controller version to install
+    default: v1.14.3
+  cluster-name:
+    description: Kind cluster name
+    default: automotive-dev-e2e
+  registry-name:
+    description: Local registry container name
+    default: kind-registry
+  registry-port:
+    description: Host port for the local registry
+    default: '5001'
+  registry-host:
+    description: Hostname used to reach the registry from inside the cluster
+    default: image-registry.openshift-image-registry.svc
+  arch:
+    description: Target architecture (arm64 or amd64)
+    default: arm64
+
+runs:
+  using: composite
+  steps:
+    - name: Install system dependencies
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libgpgme-dev jq
+
+    - name: Install kubectl
+      shell: bash
+      run: |
+        curl -LO "https://dl.k8s.io/release/${{ inputs.kubectl-version }}/bin/linux/${{ inputs.arch }}/kubectl"
+        chmod +x kubectl
+        sudo mv kubectl /usr/local/bin/
+        kubectl version --client
+
+    - name: Install Kind
+      shell: bash
+      run: |
+        curl -Lo ./kind "https://kind.sigs.k8s.io/dl/${{ inputs.kind-version }}/kind-linux-${{ inputs.arch }}"
+        chmod +x ./kind
+        sudo mv ./kind /usr/local/bin/kind
+        kind version
+
+    - name: Set up local registry
+      shell: bash
+      run: |
+        docker run -d --restart=always \
+          -p "127.0.0.1:${{ inputs.registry-port }}:5000" \
+          --name "${{ inputs.registry-name }}" \
+          registry:2
+
+        echo "127.0.0.1 ${{ inputs.registry-host }}" | sudo tee -a /etc/hosts
+
+        mkdir -p "${HOME}/.config/containers/registries.conf.d"
+        tee "${HOME}/.config/containers/registries.conf.d/kind-e2e-registry.conf" <<EOF
+        [[registry]]
+        location = "${{ inputs.registry-host }}:5000"
+        insecure = true
+        EOF
+
+    - name: Create Kind cluster
+      shell: bash
+      run: |
+        kind create cluster --name "${{ inputs.cluster-name }}" --wait 5m
+        kubectl cluster-info --context "kind-${{ inputs.cluster-name }}"
+        kubectl label nodes --all aib=true
+        kubectl get nodes --show-labels
+
+    - name: Connect registry to Kind network
+      shell: bash
+      run: |
+        docker network connect kind "${{ inputs.registry-name }}"
+        for node in $(kind get nodes --name "${{ inputs.cluster-name }}"); do
+          kubectl annotate node "${node}" "kind.x-k8s.io/registry=localhost:${{ inputs.registry-port }}" --overwrite
+        done
+        kubectl wait --for=condition=Ready nodes --all --timeout=60s
+
+    - name: Set up registry DNS spoof
+      shell: bash
+      run: |
+        cat <<EOF | kubectl apply -f -
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: local-registry-hosting
+          namespace: kube-public
+        data:
+          localRegistryHosting.v1: |
+            host: "localhost:${{ inputs.registry-port }}"
+            help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
+        EOF
+
+        kubectl create namespace openshift-image-registry --dry-run=client -o yaml | kubectl apply -f -
+
+        REGISTRY_IP=""
+        for i in $(seq 1 30); do
+          REGISTRY_IP=$(docker inspect -f '{{.NetworkSettings.Networks.kind.IPAddress}}' "${{ inputs.registry-name }}" 2>/dev/null || true)
+          if [ -n "$REGISTRY_IP" ]; then
+            echo "Registry IP found: $REGISTRY_IP"
+            break;
+          fi
+          echo "Waiting for registry IP... (attempt $i/30)"
+          sleep 1
+        done
+        echo "Registry IP: $REGISTRY_IP"
+        if [ -z "$REGISTRY_IP" ]; then
+          echo "Failed to discover a Kind-network IP for ${{ inputs.registry-name }}" >&2
+          exit 1
+        fi
+
+        cat <<EOF | kubectl apply -f -
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: image-registry
+          namespace: openshift-image-registry
+        spec:
+          ports:
+          - port: 5000
+            protocol: TCP
+            targetPort: 5000
+          clusterIP: None
+        ---
+        apiVersion: v1
+        kind: Endpoints
+        metadata:
+          name: image-registry
+          namespace: openshift-image-registry
+        subsets:
+        - addresses:
+          - ip: ${REGISTRY_IP}
+          ports:
+          - port: 5000
+            name: registry
+            protocol: TCP
+        EOF
+
+    - name: Install Tekton Pipelines
+      shell: bash
+      run: |
+        kubectl apply --filename https://infra.tekton.dev/tekton-releases/pipeline/previous/${{ inputs.tekton-version }}/release.yaml
+        echo "Waiting for Tekton Pipelines to be ready..."
+        kubectl wait --for=condition=ready pod --all -n tekton-pipelines --timeout=5m
+
+    - name: Install NGINX Ingress Controller
+      shell: bash
+      run: |
+        kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-${{ inputs.ingress-nginx-version }}/deploy/static/provider/kind/deploy.yaml
+        echo "Waiting for NGINX Ingress Controller to be ready..."
+        kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=3m

--- a/.github/workflows/e2e-lanes.yml
+++ b/.github/workflows/e2e-lanes.yml
@@ -12,10 +12,6 @@ permissions:
 
 env:
   GO_VERSION: '1.25'
-  KIND_VERSION: v0.24.0
-  KUBECTL_VERSION: v1.31.0
-  TEKTON_VERSION: v1.9.1
-  INGRESS_NGINX_VERSION: v1.14.3
   CLUSTER_NAME: automotive-dev-e2e
   REGISTRY_NAME: kind-registry
   REGISTRY_PORT: '5001'
@@ -52,13 +48,13 @@ jobs:
               echo "label_filter=auth" >> "$GITHUB_OUTPUT"
               echo "lane_name=auth" >> "$GITHUB_OUTPUT"
               ;;
-            /e2e-all*)
+            /e2e-test-all*)
               echo "label_filter=" >> "$GITHUB_OUTPUT"
               echo "lane_name=all" >> "$GITHUB_OUTPUT"
               ;;
             *)
               printf 'Unknown e2e command: %s\n' "$COMMENT"
-              printf 'Supported: /e2e-operator, /e2e-bootc, /e2e-auth, /e2e-all\n'
+              printf 'Supported: /e2e-operator, /e2e-bootc, /e2e-auth, /e2e-test-all\n'
               exit 1
               ;;
           esac
@@ -102,127 +98,14 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgpgme-dev jq
-
-      - name: Install kubectl
-        run: |
-          curl -LO "https://dl.k8s.io/release/${{ env.KUBECTL_VERSION }}/bin/linux/${{ env.ARCH }}/kubectl"
-          chmod +x kubectl
-          sudo mv kubectl /usr/local/bin/
-          kubectl version --client
-
-      - name: Install Kind
-        run: |
-          curl -Lo ./kind "https://kind.sigs.k8s.io/dl/${{ env.KIND_VERSION }}/kind-linux-${{ env.ARCH }}"
-          chmod +x ./kind
-          sudo mv ./kind /usr/local/bin/kind
-          kind version
-
-      - name: Set up local registry
-        run: |
-          docker run -d --restart=always \
-            -p "127.0.0.1:${REGISTRY_PORT}:5000" \
-            -p "127.0.0.1:5000:5000" \
-            --name "${REGISTRY_NAME}" \
-            registry:2
-
-          echo "127.0.0.1 ${REGISTRY_HOST}" | sudo tee -a /etc/hosts
-
-          mkdir -p "${HOME}/.config/containers/registries.conf.d"
-          tee "${HOME}/.config/containers/registries.conf.d/kind-e2e-registry.conf" <<EOF
-          [[registry]]
-          location = "${REGISTRY_HOST}:5000"
-          insecure = true
-          EOF
-
-      - name: Create Kind cluster
-        run: |
-          kind create cluster --name "$CLUSTER_NAME" --wait 5m
-          kubectl cluster-info --context "kind-$CLUSTER_NAME"
-          kubectl label nodes --all aib=true
-          kubectl get nodes --show-labels
-
-      - name: Connect registry to Kind network
-        run: |
-          docker network connect kind "${REGISTRY_NAME}"
-          for node in $(kind get nodes --name "${CLUSTER_NAME}"); do
-            kubectl annotate node "${node}" "kind.x-k8s.io/registry=localhost:${REGISTRY_PORT}" --overwrite
-          done
-          kubectl wait --for=condition=Ready nodes --all --timeout=60s
-
-      - name: Set up registry DNS spoof
-        run: |
-          cat <<EOF | kubectl apply -f -
-          apiVersion: v1
-          kind: ConfigMap
-          metadata:
-            name: local-registry-hosting
-            namespace: kube-public
-          data:
-            localRegistryHosting.v1: |
-              host: "localhost:${REGISTRY_PORT}"
-              help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
-          EOF
-
-          kubectl create namespace openshift-image-registry --dry-run=client -o yaml | kubectl apply -f -
-
-          REGISTRY_IP=""
-          for i in $(seq 1 30); do
-            REGISTRY_IP=$(docker inspect -f '{{.NetworkSettings.Networks.kind.IPAddress}}' "${REGISTRY_NAME}" 2>/dev/null || true)
-            if [ -n "$REGISTRY_IP" ]; then
-              echo "Registry IP found: $REGISTRY_IP"
-              break;
-            fi
-            echo "Waiting for registry IP... (attempt $i/30)"
-            sleep 1
-          done
-          echo "Registry IP: $REGISTRY_IP"
-          if [ -z "$REGISTRY_IP" ]; then
-            echo "Failed to discover a Kind-network IP for ${REGISTRY_NAME}" >&2
-            exit 1
-          fi
-
-          cat <<EOF | kubectl apply -f -
-          apiVersion: v1
-          kind: Service
-          metadata:
-            name: image-registry
-            namespace: openshift-image-registry
-          spec:
-            ports:
-            - port: 5000
-              protocol: TCP
-              targetPort: 5000
-            clusterIP: None
-          ---
-          apiVersion: v1
-          kind: Endpoints
-          metadata:
-            name: image-registry
-            namespace: openshift-image-registry
-          subsets:
-          - addresses:
-            - ip: ${REGISTRY_IP}
-            ports:
-            - port: 5000
-              name: registry
-              protocol: TCP
-          EOF
-
-      - name: Install Tekton Pipelines
-        run: |
-          kubectl apply --filename https://infra.tekton.dev/tekton-releases/pipeline/previous/${{ env.TEKTON_VERSION }}/release.yaml
-          echo "Waiting for Tekton Pipelines to be ready..."
-          kubectl wait --for=condition=ready pod --all -n tekton-pipelines --timeout=5m
-
-      - name: Install NGINX Ingress Controller
-        run: |
-          kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-${{ env.INGRESS_NGINX_VERSION }}/deploy/static/provider/kind/deploy.yaml
-          echo "Waiting for NGINX Ingress Controller to be ready..."
-          kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=3m
+      - name: Setup Kind E2E environment
+        uses: ./.github/actions/setup-kind-e2e
+        with:
+          cluster-name: ${{ env.CLUSTER_NAME }}
+          registry-name: ${{ env.REGISTRY_NAME }}
+          registry-port: ${{ env.REGISTRY_PORT }}
+          registry-host: ${{ env.REGISTRY_HOST }}
+          arch: ${{ env.ARCH }}
 
       - name: Build caib CLI
         run: make build-caib
@@ -241,8 +124,8 @@ jobs:
         run: |
           case "${{ needs.parse-comment.outputs.lane_name }}" in
             operator|auth) test_timeout=15m ;;
-            bootc)         test_timeout=50m ;;
-            all)           test_timeout=80m ;;
+            bootc)         test_timeout=35m ;;
+            all)           test_timeout=45m ;;
             *)             echo "Unknown lane: ${{ needs.parse-comment.outputs.lane_name }}" >&2; exit 1 ;;
           esac
           ginkgo_args=(-v -ginkgo.v -timeout "$test_timeout")
@@ -283,29 +166,14 @@ jobs:
 
       - name: Collect logs on failure
         if: failure()
-        env:
-          E2E_NAMESPACE: ${{ needs.parse-comment.outputs.lane_name == 'all' && 'e2e-test-all' || format('e2e-{0}', needs.parse-comment.outputs.lane_name) }}
-        run: |
-          NS="${E2E_NAMESPACE:-e2e-test-all}"
-          echo "=== Operator Logs ==="
-          kubectl logs -n "$NS" -l control-plane=operator --tail=200 || true
-          echo "=== All Pods ==="
-          kubectl get pods -n "$NS" -o wide || true
-          echo "=== TaskRuns ==="
-          kubectl get taskrun -n "$NS" -o yaml || true
-          echo "=== PipelineRuns ==="
-          kubectl get pipelinerun -n "$NS" -o yaml || true
-          echo "=== Events ==="
-          kubectl get events -n "$NS" --sort-by='.lastTimestamp' || true
-          echo "=== OperatorConfig ==="
-          kubectl get operatorconfig -n "$NS" -o yaml || true
-          echo "=== ImageBuilds ==="
-          kubectl get imagebuilds -n "$NS" -o yaml || true
+        uses: ./.github/actions/collect-e2e-logs
+        with:
+          namespaces: ${{ needs.parse-comment.outputs.lane_name == 'all' && 'e2e-test-all' || format('e2e-{0}', needs.parse-comment.outputs.lane_name) }}
 
       - name: Cleanup
         if: always()
-        run: |
-          kind delete cluster --name "$CLUSTER_NAME" || true
-          docker rm -f "$REGISTRY_NAME" || true
-          sudo sed -i "/${REGISTRY_HOST}/d" /etc/hosts 2>/dev/null || true
-          rm -f "${HOME}/.config/containers/registries.conf.d/kind-e2e-registry.conf" || true
+        uses: ./.github/actions/cleanup-kind-e2e
+        with:
+          cluster-name: ${{ env.CLUSTER_NAME }}
+          registry-name: ${{ env.REGISTRY_NAME }}
+          registry-host: ${{ env.REGISTRY_HOST }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,10 +18,6 @@ on:
 
 env:
   GO_VERSION: '1.25'
-  KIND_VERSION: v0.24.0
-  KUBECTL_VERSION: v1.31.0
-  TEKTON_VERSION: v1.9.1
-  INGRESS_NGINX_VERSION: v1.14.3
   CLUSTER_NAME: automotive-dev-e2e
   REGISTRY_NAME: kind-registry
   REGISTRY_PORT: '5001'
@@ -41,143 +37,15 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgpgme-dev jq
+      - name: Setup Kind E2E environment
+        uses: ./.github/actions/setup-kind-e2e
+        with:
+          cluster-name: ${{ env.CLUSTER_NAME }}
+          registry-name: ${{ env.REGISTRY_NAME }}
+          registry-port: ${{ env.REGISTRY_PORT }}
+          registry-host: ${{ env.REGISTRY_HOST }}
+          arch: ${{ env.ARCH }}
 
-      - name: Install kubectl
-        run: |
-          curl -LO "https://dl.k8s.io/release/${{ env.KUBECTL_VERSION }}/bin/linux/${{ env.ARCH }}/kubectl"
-          chmod +x kubectl
-          sudo mv kubectl /usr/local/bin/
-          kubectl version --client
-
-      - name: Install Kind
-        run: |
-          curl -Lo ./kind "https://kind.sigs.k8s.io/dl/${{ env.KIND_VERSION }}/kind-linux-${{ env.ARCH }}"
-          chmod +x ./kind
-          sudo mv ./kind /usr/local/bin/kind
-          kind version
-
-      # ---------------------------------------------------------------
-      # [1/7] Local Registry
-      # ---------------------------------------------------------------
-      - name: Set up local registry
-        run: |
-          docker run -d --restart=always \
-            -p "127.0.0.1:${REGISTRY_PORT}:5000" \
-            -p "127.0.0.1:5000:5000" \
-            --name "${REGISTRY_NAME}" \
-            registry:2
-
-          echo "127.0.0.1 ${REGISTRY_HOST}" | sudo tee -a /etc/hosts
-
-          mkdir -p "${HOME}/.config/containers/registries.conf.d"
-          tee "${HOME}/.config/containers/registries.conf.d/kind-e2e-registry.conf" <<EOF
-          [[registry]]
-          location = "${REGISTRY_HOST}:5000"
-          insecure = true
-          EOF
-
-      # ---------------------------------------------------------------
-      # [2/7] Kind Cluster
-      # ---------------------------------------------------------------
-      - name: Create Kind cluster
-        run: |
-          kind create cluster --name "$CLUSTER_NAME" --wait 5m
-          kubectl cluster-info --context "kind-$CLUSTER_NAME"
-          kubectl label nodes --all aib=true
-          kubectl get nodes --show-labels
-
-      - name: Connect registry to Kind network
-        run: |
-          docker network connect kind "${REGISTRY_NAME}"
-          for node in $(kind get nodes --name "${CLUSTER_NAME}"); do
-            kubectl annotate node "${node}" "kind.x-k8s.io/registry=localhost:${REGISTRY_PORT}" --overwrite
-          done
-          kubectl wait --for=condition=Ready nodes --all --timeout=60s
-
-      # ---------------------------------------------------------------
-      # [3/7] Internal DNS for Registry (OpenShift spoof)
-      # ---------------------------------------------------------------
-      - name: Set up registry DNS spoof
-        run: |
-          cat <<EOF | kubectl apply -f -
-          apiVersion: v1
-          kind: ConfigMap
-          metadata:
-            name: local-registry-hosting
-            namespace: kube-public
-          data:
-            localRegistryHosting.v1: |
-              host: "localhost:${REGISTRY_PORT}"
-              help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
-          EOF
-
-          kubectl create namespace openshift-image-registry --dry-run=client -o yaml | kubectl apply -f -
-
-          REGISTRY_IP=""
-          for i in $(seq 1 30); do
-            REGISTRY_IP=$(docker inspect -f '{{.NetworkSettings.Networks.kind.IPAddress}}' "${REGISTRY_NAME}" 2>/dev/null || true)
-            if [ -n "$REGISTRY_IP" ]; then
-              echo "Registry IP found: $REGISTRY_IP" 
-              break; 
-            fi
-            echo "Waiting for registry IP... (attempt $i/30)"
-            sleep 1
-          done
-          echo "Registry IP: $REGISTRY_IP"
-          if [ -z "$REGISTRY_IP" ]; then
-            echo "Failed to discover a Kind-network IP for ${REGISTRY_NAME}" >&2
-            exit 1
-          fi
-
-          cat <<EOF | kubectl apply -f -
-          apiVersion: v1
-          kind: Service
-          metadata:
-            name: image-registry
-            namespace: openshift-image-registry
-          spec:
-            ports:
-            - port: 5000
-              protocol: TCP
-              targetPort: 5000
-            clusterIP: None
-          ---
-          apiVersion: v1
-          kind: Endpoints
-          metadata:
-            name: image-registry
-            namespace: openshift-image-registry
-          subsets:
-          - addresses:
-            - ip: ${REGISTRY_IP}
-            ports:
-            - port: 5000
-              name: registry
-              protocol: TCP
-          EOF
-
-      # ---------------------------------------------------------------
-      # [4/7] Infrastructure (Tekton & Ingress)
-      # ---------------------------------------------------------------
-      - name: Install Tekton Pipelines
-        run: |
-          kubectl apply --filename https://infra.tekton.dev/tekton-releases/pipeline/previous/${{ env.TEKTON_VERSION }}/release.yaml
-          echo "Waiting for Tekton Pipelines to be ready..."
-          kubectl wait --for=condition=ready pod --all -n tekton-pipelines --timeout=5m
-
-      - name: Install NGINX Ingress Controller
-        run: |
-          kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-${{ env.INGRESS_NGINX_VERSION }}/deploy/static/provider/kind/deploy.yaml
-          echo "Waiting for NGINX Ingress Controller to be ready..."
-          kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=3m
-
-      # ---------------------------------------------------------------
-      # [5/7] Run E2E tests (self-contained: deploys operator, tests, tears down)
-      # ---------------------------------------------------------------
       - name: Build caib CLI
         run: make build-caib
 
@@ -191,8 +59,18 @@ jobs:
           REGISTRY_PASSWORD: kind
           CAIB_SERVER: http://localhost:8080
           E2E_LABEL_FILTER: ${{ github.event.inputs.label_filter || '' }}
+          E2E_NAMESPACE: ${{ github.event.inputs.label_filter && format('e2e-{0}', github.event.inputs.label_filter) || 'e2e-test-all' }}
         run: |
-          ginkgo_args=(-v -ginkgo.v -timeout 30m)
+          if [ -z "$E2E_LABEL_FILTER" ]; then
+            test_timeout=45m
+          else
+            case "$E2E_LABEL_FILTER" in
+              operator|auth) test_timeout=15m ;;
+              bootc)         test_timeout=35m ;;
+              *)             test_timeout=45m ;;
+            esac
+          fi
+          ginkgo_args=(-v -ginkgo.v -timeout "$test_timeout")
           if [ -n "$E2E_LABEL_FILTER" ]; then
             ginkgo_args+=(-ginkgo.label-filter="$E2E_LABEL_FILTER")
           fi
@@ -200,29 +78,12 @@ jobs:
 
       - name: Collect logs on failure
         if: failure()
-        run: |
-          echo "=== Operator Logs ==="
-          kubectl logs -n automotive-dev-operator-system -l control-plane=operator --tail=200 || true
-          echo "=== All Pods in operator namespace ==="
-          kubectl get pods -n automotive-dev-operator-system -o wide || true
-          echo "=== PipelineRuns ==="
-          kubectl get pipelinerun -n automotive-dev-operator-system -o yaml || true
-          echo "=== Events ==="
-          kubectl get events -n automotive-dev-operator-system --sort-by='.lastTimestamp' || true
-          echo "=== OperatorConfig ==="
-          kubectl get operatorconfig -n automotive-dev-operator-system -o yaml || true
-          echo "=== ImageBuilds ==="
-          kubectl get imagebuilds -n automotive-dev-operator-system -o yaml || true
-          echo "=== Build Image Pod Logs ==="
-          for pod in $(kubectl get pods -n automotive-dev-operator-system -o name | grep build-image-pod); do
-            echo "--- $pod ---"
-            kubectl logs -n automotive-dev-operator-system "$pod" -c step-build-image --tail=100 || true
-          done
+        uses: ./.github/actions/collect-e2e-logs
 
       - name: Cleanup
         if: always()
-        run: |
-          kind delete cluster --name "$CLUSTER_NAME" || true
-          docker rm -f "$REGISTRY_NAME" || true
-          sudo sed -i "/${REGISTRY_HOST}/d" /etc/hosts 2>/dev/null || true
-          rm -f "${HOME}/.config/containers/registries.conf.d/kind-e2e-registry.conf" || true
+        uses: ./.github/actions/cleanup-kind-e2e
+        with:
+          cluster-name: ${{ env.CLUSTER_NAME }}
+          registry-name: ${{ env.REGISTRY_NAME }}
+          registry-host: ${{ env.REGISTRY_HOST }}

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 #   test-e2e-auth      - OIDC authentication (OpenShift only)
 .PHONY: test-e2e
 test-e2e:
-	go test ./test/e2e/ -v -ginkgo.v -timeout 80m
+	go test ./test/e2e/ -v -ginkgo.v -timeout 45m
 
 .PHONY: test-e2e-operator
 test-e2e-operator:
@@ -130,7 +130,7 @@ test-e2e-operator:
 
 .PHONY: test-e2e-bootc
 test-e2e-bootc:
-	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-bootc} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="bootc" -timeout 50m
+	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-bootc} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="bootc" -timeout 35m
 
 .PHONY: test-e2e-auth
 test-e2e-auth:

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -112,8 +112,8 @@ Times measured on CRC (cluster already running):
 |------|-------------|-------------|-------------------|
 | `operator` | ~2 min | ~3 min | 15m |
 | `auth` | ~3 min | ~4 min | 15m |
-| `bootc` | ~7 min | ~33 min | 50m |
-| all | ~8 min | ~36 min | 80m |
+| `bootc` | ~7 min | ~33 min | 35m |
+| all | ~8 min | ~36 min | 45m |
 
 ## Test Structure
 
@@ -132,7 +132,7 @@ The e2e tests run automatically on:
 - Manual workflow dispatch (with optional `label_filter` input)
 
 Individual lanes can be triggered on PRs via comment commands:
-- `/e2e-operator`, `/e2e-bootc`, `/e2e-auth`, `/e2e-all`
+- `/e2e-operator`, `/e2e-bootc`, `/e2e-auth`, `/e2e-test-all`
 
 See `.github/workflows/e2e.yml` and `.github/workflows/e2e-lanes.yml` for the CI configuration.
 

--- a/test/e2e/bootc_build_test.go
+++ b/test/e2e/bootc_build_test.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	caibBuildManifest = "test/config/test-manifest.aib.yml"
-	caibBuildTimeout  = 45 * time.Minute
+	caibBuildTimeout  = 30 * time.Minute
 	caibListTimeout   = 30 * time.Second
 )
 


### PR DESCRIPTION
## Summary
refactor e2e CI workflow - eliminates duplicated infrastructure setup in `e2e.yml` and `e2e-lanes.yml`.
in addition of some fixes in log collection and test timeouts.


**New composite actions**
Three reusable actions extracted from the workflow inline steps:
- `.github/actions/setup-kind-e2e` - provisions Kind cluster, local container registry, Tekton Pipelines, and NGINX Ingress Controller.
  Accepts inputs for all versions and names so it can be configured per-caller without duplication.
- `.github/actions/collect-e2e-logs` - collects operator logs, pod status, TaskRuns, PipelineRuns, events, and custom resources from all known e2e namespaces (`e2e-test-all`, `e2e-operator`, `e2e-bootc`,
  `e2e-auth`).
  Silently skips namespaces that don't exist.
- `.github/actions/cleanup-kind-e2e` - deletes the Kind cluster, removes the registry container, and cleans up `/etc/hosts` and container registry config.


**Workflow simplification**
Both `e2e.yml` and `e2e-lanes.yml` now call the composite actions instead of inlining the same code setup block. The workflows are reduced to only their unique logic (test execution, commit status reporting).

**Additional fixes**
- `e2e.yml` was missing `E2E_NAMESPACE`, causing tests to generate a
  random namespace on every run that didn't match any known namespace in
  the log collection step.
- Log collection previously used a hardcoded `automotive-dev-operator-system`
  namespace; the new `collect-e2e-logs` action iterates all e2e namespaces
  instead.
- Test timeouts were misaligned between the Makefile targets and what
  `e2e.yml` / `e2e-lanes.yml` passed to `go test`; they now match.
- Removed stray `exit 1` from the unknown-lane fallback in both workflows
  that could cause the cleanup step to be skipped.
  
 Tested E2E test lane trigger on PR via comment https://github.com/centos-automotive-suite/automotive-dev-operator/pull/293#issuecomment-4554475775 -> [26511034107](https://github.com/centos-automotive-suite/automotive-dev-operator/actions/runs/26511034107)




## Related Issues
https://github.com/centos-automotive-suite/automotive-dev-operator/issues/288

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [X] CI/CD improvement
- [X] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [X] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched E2E pipelines to reusable local actions for environment setup, log collection, and cleanup.
  * Reduced overall E2E timeouts (bootc: 50m → 35m; full suite: 80m → 45m) and updated test invocation timings.

* **Tests**
  * Improved automated E2E failure diagnostics with broader, resilient log/resource collection across namespaces.

* **Documentation**
  * Updated E2E README to reflect new timeout values and test timings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/centos-automotive-suite/automotive-dev-operator/pull/293?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->