### PR TITLE
refactor: extract OCI artifact contract into shared spec

### DIFF
--- a/cmd/caib/common/oci_artifact.go
+++ b/cmd/caib/common/oci_artifact.go
@@ -15,6 +15,8 @@ import (
 	"github.com/containers/image/v5/oci/layout"
 	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/types"
+
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/oci"
 )
 
 // PullOCIArtifact pulls and extracts an OCI artifact to local destination.
@@ -183,7 +185,7 @@ func extractOCIArtifactBlob(ociLayoutPath, destPath string) error {
 		return fmt.Errorf("no layers found in manifest")
 	}
 
-	annotationMultiLayer := manifest.Annotations["automotive.sdv.cloud.redhat.com/multi-layer"] == "true"
+	annotationMultiLayer := manifest.Annotations[oci.Get().AnnotationKey("multi-layer")] == "true"
 	isMultiLayer := annotationMultiLayer || len(manifest.Layers) > 1
 	if isMultiLayer {
 		if !annotationMultiLayer && len(manifest.Layers) > 1 {

--- a/cmd/caib/inspectcmd/inspect.go
+++ b/cmd/caib/inspectcmd/inspect.go
@@ -25,34 +25,26 @@ import (
 
 	caibcommon "github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/common"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/registryauth"
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/oci"
 )
 
-const annotationPrefix = "automotive.sdv.cloud.redhat.com/"
+var ociSpec = oci.Get()
 
-var knownAnnotations = []struct {
-	key   string
-	label string
-}{
-	{"distro", "Distro"},
-	{"target", "Target"},
-	{"arch", "Arch"},
-	{"automotive-image-builder", "AIB Image"},
-	{"builder-image", "Builder Image"},
-	{"aib-version", "AIB Version"},
-	{"task-bundle-ref", "Task Bundle"},
-	{"custom-defines", "Custom Defines"},
-	{"aib-extra-args", "AIB Extra Args"},
-	{"export-format", "Export Format"},
-	{"aib-command", "AIB Command"},
-}
-
-var knownReferrerTypes = []struct {
-	artifactType string
-	label        string
-}{
-	{"application/vnd.automotive.manifest.v1+yaml", "AIB Manifest"},
-	{"application/vnd.automotive.sources.v1+tar+gzip", "Build Sources"},
-	{"application/vnd.osbuild.manifest.v1+json", "osbuild Manifest"},
+// annotationDisplayLabels maps spec annotation keys to human-readable labels
+// for provenance display. Keys not listed here (parts, multi-layer,
+// default-partitions) are tooling-only metadata and intentionally omitted.
+var annotationDisplayLabels = map[string]string{
+	"distro":                   "Distro",
+	"target":                   "Target",
+	"arch":                     "Arch",
+	"automotive-image-builder": "AIB Image",
+	"builder-image":            "Builder Image",
+	"aib-version":              "AIB Version",
+	"task-bundle-ref":          "Task Bundle",
+	"custom-defines":           "Custom Defines",
+	"aib-extra-args":           "AIB Extra Args",
+	"export-format":            "Export Format",
+	"aib-command":              "AIB Command",
 }
 
 // Options wires inspect handler dependencies.
@@ -156,8 +148,8 @@ func (h *Handler) RunInspect(_ *cobra.Command, args []string) {
 func (h *Handler) printStructured(format, ociRef, digest string, annotations map[string]string, referrers []referrerInfo, referrerTypes map[string]bool) {
 	stripped := make(map[string]string)
 	for k, v := range annotations {
-		if strings.HasPrefix(k, annotationPrefix) {
-			stripped[strings.TrimPrefix(k, annotationPrefix)] = v
+		if strings.HasPrefix(k, ociSpec.AnnotationPrefix) {
+			stripped[strings.TrimPrefix(k, ociSpec.AnnotationPrefix)] = v
 		}
 	}
 
@@ -322,11 +314,15 @@ func (h *Handler) printProvenance(ociRef, digest string, annotations map[string]
 	fmt.Println()
 
 	hasAnnotations := false
-	for _, a := range knownAnnotations {
-		val := annotations[annotationPrefix+a.key]
+	for _, ak := range ociSpec.AllManifestAnnotationKeys() {
+		label := annotationDisplayLabels[ak.Key]
+		if label == "" {
+			continue
+		}
+		val := annotations[ociSpec.AnnotationKey(ak.Key)]
 		if val != "" {
 			hasAnnotations = true
-			fmt.Printf("  %-16s %s\n", bold(a.label+":"), green(val))
+			fmt.Printf("  %-16s %s\n", bold(label+":"), green(val))
 		}
 	}
 	if !hasAnnotations {
@@ -337,11 +333,11 @@ func (h *Handler) printProvenance(ociRef, digest string, annotations map[string]
 	fmt.Println(bold("Saved Artifacts"))
 	fmt.Println(bold(strings.Repeat("═", 50)))
 
-	for _, rt := range knownReferrerTypes {
-		if referrerTypes[rt.artifactType] {
-			fmt.Printf("  %s %s  (%s)\n", green("✓"), bold(rt.label), rt.artifactType)
+	for _, rt := range ociSpec.ReferrerTypes {
+		if referrerTypes[rt.ArtifactType] {
+			fmt.Printf("  %s %s  (%s)\n", green("✓"), bold(rt.Label), rt.ArtifactType)
 		} else {
-			fmt.Printf("  %s %s\n", yellow("✗"), rt.label)
+			fmt.Printf("  %s %s\n", yellow("✗"), rt.Label)
 		}
 	}
 
@@ -355,7 +351,7 @@ func (h *Handler) printProvenance(ociRef, digest string, annotations map[string]
 }
 
 func buildRebuildCommand(ociRef, digest string, annotations map[string]string, referrerTypes map[string]bool) string {
-	get := func(key string) string { return annotations[annotationPrefix+key] }
+	get := func(key string) string { return annotations[ociSpec.AnnotationKey(key)] }
 
 	aibCmd := get("aib-command")
 	isDevBuild := strings.HasPrefix(aibCmd, "aib-dev")
@@ -367,7 +363,7 @@ func buildRebuildCommand(ociRef, digest string, annotations map[string]string, r
 		parts = append(parts, "caib image build")
 	}
 
-	hasManifest := referrerTypes["application/vnd.automotive.manifest.v1+yaml"]
+	hasManifest := referrerTypes[ociSpec.ReferrerArtifactTypeByLabel("AIB Manifest")]
 	if hasManifest {
 		parts = append(parts, "manifest.aib.yml")
 	} else {
@@ -408,7 +404,7 @@ func buildRebuildCommand(ociRef, digest string, annotations map[string]string, r
 			}
 		}
 	}
-	hasSources := referrerTypes["application/vnd.automotive.sources.v1+tar+gzip"]
+	hasSources := referrerTypes[ociSpec.ReferrerArtifactTypeByLabel("Build Sources")]
 	taskBundleRef := get("task-bundle-ref")
 	if taskBundleRef != "" {
 		parts = append(parts, fmt.Sprintf("  --task-bundle-ref %s", taskBundleRef))
@@ -439,11 +435,7 @@ func (h *Handler) downloadReferrers(ociRef, _ string, referrers []referrerInfo, 
 	repo := splitReference(ociRef)
 	insecure := h.opts.InsecureSkipTLS != nil && *h.opts.InsecureSkipTLS
 
-	fileMap := map[string]string{
-		"application/vnd.automotive.manifest.v1+yaml":    "manifest.aib.yml",
-		"application/vnd.automotive.sources.v1+tar+gzip": "build-sources.tar.gz",
-		"application/vnd.osbuild.manifest.v1+json":       "image.json",
-	}
+	fileMap := ociSpec.ReferrerFileMap()
 
 	for _, ref := range referrers {
 		filename, known := fileMap[ref.ArtifactType]

--- a/cmd/caib/inspectcmd/inspect_test.go
+++ b/cmd/caib/inspectcmd/inspect_test.go
@@ -41,14 +41,14 @@ func TestSplitReference(t *testing.T) {
 
 func fullAnnotations() map[string]string {
 	return map[string]string{
-		annotationPrefix + "distro":                   "autosd",
-		annotationPrefix + "target":                   "qemu",
-		annotationPrefix + "arch":                     "amd64",
-		annotationPrefix + "automotive-image-builder": "quay.io/aib@sha256:abc",
-		annotationPrefix + "builder-image":            "quay.io/builder@sha256:def",
-		annotationPrefix + "aib-version":              "1.3.0",
-		annotationPrefix + "task-bundle-ref":          "quay.io/tasks@sha256:789",
-		annotationPrefix + "aib-command":              "aib build --distro autosd --target qemu",
+		ociSpec.AnnotationPrefix + "distro":                   "autosd",
+		ociSpec.AnnotationPrefix + "target":                   "qemu",
+		ociSpec.AnnotationPrefix + "arch":                     "amd64",
+		ociSpec.AnnotationPrefix + "automotive-image-builder": "quay.io/aib@sha256:abc",
+		ociSpec.AnnotationPrefix + "builder-image":            "quay.io/builder@sha256:def",
+		ociSpec.AnnotationPrefix + "aib-version":              "1.3.0",
+		ociSpec.AnnotationPrefix + "task-bundle-ref":          "quay.io/tasks@sha256:789",
+		ociSpec.AnnotationPrefix + "aib-command":              "aib build --distro autosd --target qemu",
 	}
 }
 
@@ -82,7 +82,7 @@ func TestBuildRebuildCommand_Bootc(t *testing.T) {
 
 func TestBuildRebuildCommand_DevBuild(t *testing.T) {
 	annotations := fullAnnotations()
-	annotations[annotationPrefix+"aib-command"] = "aib-dev --verbose build --distro autosd"
+	annotations[ociSpec.AnnotationPrefix+"aib-command"] = "aib-dev --verbose build --distro autosd"
 	referrerTypes := map[string]bool{}
 
 	cmd := buildRebuildCommand("quay.io/org/repo:v1", "sha256:abc123", annotations, referrerTypes)
@@ -100,7 +100,7 @@ func TestBuildRebuildCommand_DevBuild(t *testing.T) {
 
 func TestBuildRebuildCommand_NoSecure(t *testing.T) {
 	annotations := fullAnnotations()
-	delete(annotations, annotationPrefix+"task-bundle-ref")
+	delete(annotations, ociSpec.AnnotationPrefix+"task-bundle-ref")
 	referrerTypes := map[string]bool{}
 
 	cmd := buildRebuildCommand("quay.io/org/repo:v1", "sha256:abc123", annotations, referrerTypes)
@@ -112,7 +112,7 @@ func TestBuildRebuildCommand_NoSecure(t *testing.T) {
 
 func TestBuildRebuildCommand_CustomDefines(t *testing.T) {
 	annotations := fullAnnotations()
-	annotations[annotationPrefix+"custom-defines"] = "use_debug=true\nfoo=bar"
+	annotations[ociSpec.AnnotationPrefix+"custom-defines"] = "use_debug=true\nfoo=bar"
 	referrerTypes := map[string]bool{}
 
 	cmd := buildRebuildCommand("quay.io/org/repo:v1", "sha256:abc123", annotations, referrerTypes)
@@ -127,7 +127,7 @@ func TestBuildRebuildCommand_CustomDefines(t *testing.T) {
 
 func TestBuildRebuildCommand_ExtraArgs(t *testing.T) {
 	annotations := fullAnnotations()
-	annotations[annotationPrefix+"aib-extra-args"] = "--verbose\n--cache-max-size=unlimited"
+	annotations[ociSpec.AnnotationPrefix+"aib-extra-args"] = "--verbose\n--cache-max-size=unlimited"
 	referrerTypes := map[string]bool{}
 
 	cmd := buildRebuildCommand("quay.io/org/repo:v1", "sha256:abc123", annotations, referrerTypes)
@@ -142,7 +142,7 @@ func TestBuildRebuildCommand_ExtraArgs(t *testing.T) {
 
 func TestBuildRebuildCommand_ExportFormat(t *testing.T) {
 	annotations := fullAnnotations()
-	annotations[annotationPrefix+"export-format"] = "simg"
+	annotations[ociSpec.AnnotationPrefix+"export-format"] = "simg"
 	referrerTypes := map[string]bool{}
 
 	cmd := buildRebuildCommand("quay.io/org/repo:v1", "sha256:abc123", annotations, referrerTypes)
@@ -181,7 +181,7 @@ func TestBuildRebuildCommand_NoRestoreSourcesWithoutReferrer(t *testing.T) {
 
 func TestBuildRebuildCommand_NoBuilderImage(t *testing.T) {
 	annotations := fullAnnotations()
-	delete(annotations, annotationPrefix+"builder-image")
+	delete(annotations, ociSpec.AnnotationPrefix+"builder-image")
 	referrerTypes := map[string]bool{}
 
 	cmd := buildRebuildCommand("quay.io/org/repo:v1", "sha256:abc123", annotations, referrerTypes)
@@ -311,7 +311,7 @@ func TestPrintProvenance_FullAIBCommand(t *testing.T) {
 
 	longCmd := strings.Repeat("x", 200)
 	annotations := map[string]string{
-		annotationPrefix + "aib-command": longCmd,
+		ociSpec.AnnotationPrefix + "aib-command": longCmd,
 	}
 	referrerTypes := map[string]bool{}
 

--- a/internal/common/oci/spec.go
+++ b/internal/common/oci/spec.go
@@ -1,0 +1,150 @@
+// Package oci defines the shared OCI artifact contract (media types, annotations, referrer types).
+package oci
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+//go:embed spec.json
+var specJSON []byte
+
+var spec Spec
+
+func init() {
+	if err := json.Unmarshal(specJSON, &spec); err != nil {
+		panic(fmt.Sprintf("oci: failed to parse spec.json: %v", err))
+	}
+}
+
+// Spec is the top-level OCI artifact specification.
+type Spec struct {
+	AnnotationPrefix string         `json:"annotationPrefix"`
+	Annotations      AnnotationSpec `json:"annotations"`
+	MediaTypes       MediaTypeSpec  `json:"mediaTypes"`
+	ReferrerTypes    []ReferrerType `json:"referrerTypes"`
+}
+
+// AnnotationSpec groups manifest-level and layer-level annotation keys.
+type AnnotationSpec struct {
+	Manifest ManifestAnnotations `json:"manifest"`
+	Layer    LayerAnnotations    `json:"layer"`
+}
+
+// ManifestAnnotations separates required from optional annotation keys.
+type ManifestAnnotations struct {
+	Required []AnnotationKey `json:"required"`
+	Optional []AnnotationKey `json:"optional"`
+}
+
+// LayerAnnotations separates custom (prefixed) from standard OCI keys.
+type LayerAnnotations struct {
+	Custom   []AnnotationKey `json:"custom"`
+	Standard []AnnotationKey `json:"standard"`
+}
+
+// AnnotationKey pairs an annotation key with its shell variable name.
+type AnnotationKey struct {
+	Key string `json:"key"`
+	Var string `json:"var"`
+}
+
+// MediaTypeSpec contains all media type families.
+type MediaTypeSpec struct {
+	DiskFormats         map[string]string `json:"diskFormats"`
+	CompressionSuffixes map[string]string `json:"compressionSuffixes"`
+	ContainerLayers     map[string]string `json:"containerLayers"`
+	Generic             map[string]string `json:"generic"`
+}
+
+// ReferrerType defines an OCI referrer artifact type with display label and default filename.
+type ReferrerType struct {
+	ArtifactType string `json:"artifactType"`
+	Label        string `json:"label"`
+	Var          string `json:"var"`
+	Filename     string `json:"filename"`
+}
+
+// Get returns the parsed OCI artifact specification.
+func Get() *Spec { return &spec }
+
+// AnnotationKey returns a fully-qualified annotation key (prefix + short name).
+func (s *Spec) AnnotationKey(short string) string {
+	return s.AnnotationPrefix + short
+}
+
+// ReferrerFileMap returns a map from artifact type to default filename.
+func (s *Spec) ReferrerFileMap() map[string]string {
+	m := make(map[string]string, len(s.ReferrerTypes))
+	for _, r := range s.ReferrerTypes {
+		m[r.ArtifactType] = r.Filename
+	}
+	return m
+}
+
+// AllManifestAnnotationKeys returns all annotation keys (required + optional).
+func (s *Spec) AllManifestAnnotationKeys() []AnnotationKey {
+	result := make([]AnnotationKey, 0, len(s.Annotations.Manifest.Required)+len(s.Annotations.Manifest.Optional))
+	result = append(result, s.Annotations.Manifest.Required...)
+	result = append(result, s.Annotations.Manifest.Optional...)
+	return result
+}
+
+// ReferrerArtifactTypeByLabel returns the artifact type string for a given display label.
+func (s *Spec) ReferrerArtifactTypeByLabel(label string) string {
+	for _, r := range s.ReferrerTypes {
+		if r.Label == label {
+			return r.ArtifactType
+		}
+	}
+	return ""
+}
+
+// ShellVars generates deterministic shell variable assignments for all OCI constants.
+func (s *Spec) ShellVars() string {
+	var b strings.Builder
+	b.WriteString("# --- OCI Artifact Constants (generated from spec.json) ---\n")
+
+	fmt.Fprintf(&b, "OCI_ANNOTATION_PREFIX=%q\n", s.AnnotationPrefix)
+
+	for _, ak := range s.Annotations.Manifest.Required {
+		fmt.Fprintf(&b, "OCI_ANN_%s=%q\n", ak.Var, s.AnnotationPrefix+ak.Key)
+	}
+	for _, ak := range s.Annotations.Manifest.Optional {
+		fmt.Fprintf(&b, "OCI_ANN_%s=%q\n", ak.Var, s.AnnotationPrefix+ak.Key)
+	}
+
+	for _, ak := range s.Annotations.Layer.Custom {
+		fmt.Fprintf(&b, "OCI_LAYER_ANN_%s=%q\n", ak.Var, s.AnnotationPrefix+ak.Key)
+	}
+	for _, ak := range s.Annotations.Layer.Standard {
+		fmt.Fprintf(&b, "OCI_LAYER_ANN_%s=%q\n", ak.Var, ak.Key)
+	}
+
+	writeMapSorted(&b, "OCI_MEDIA_DISK_", s.MediaTypes.DiskFormats)
+	writeMapSorted(&b, "OCI_COMPRESS_SUFFIX_", s.MediaTypes.CompressionSuffixes)
+	writeMapSorted(&b, "OCI_MEDIA_LAYER_", s.MediaTypes.ContainerLayers)
+	writeMapSorted(&b, "OCI_MEDIA_", s.MediaTypes.Generic)
+
+	for _, r := range s.ReferrerTypes {
+		fmt.Fprintf(&b, "OCI_REFERRER_TYPE_%s=%q\n", r.Var, r.ArtifactType)
+		fmt.Fprintf(&b, "OCI_REFERRER_FILE_%s=%q\n", r.Var, r.Filename)
+	}
+
+	b.WriteString("# --- End OCI Artifact Constants ---\n")
+	return b.String()
+}
+
+func writeMapSorted(b *strings.Builder, prefix string, m map[string]string) {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		fmt.Fprintf(b, "%s%s=%q\n", prefix, strings.ToUpper(k), m[k])
+	}
+}

--- a/internal/common/oci/spec.json
+++ b/internal/common/oci/spec.json
@@ -1,0 +1,81 @@
+{
+  "annotationPrefix": "automotive.sdv.cloud.redhat.com/",
+
+  "annotations": {
+    "manifest": {
+      "required": [
+        {"key": "distro", "var": "DISTRO"},
+        {"key": "target", "var": "TARGET"},
+        {"key": "arch", "var": "ARCH"}
+      ],
+      "optional": [
+        {"key": "parts", "var": "PARTS"},
+        {"key": "multi-layer", "var": "MULTI_LAYER"},
+        {"key": "default-partitions", "var": "DEFAULT_PARTITIONS"},
+        {"key": "builder-image", "var": "BUILDER_IMAGE"},
+        {"key": "aib-version", "var": "AIB_VERSION"},
+        {"key": "automotive-image-builder", "var": "AUTOMOTIVE_IMAGE_BUILDER"},
+        {"key": "aib-command", "var": "AIB_COMMAND"},
+        {"key": "task-bundle-ref", "var": "TASK_BUNDLE_REF"},
+        {"key": "custom-defines", "var": "CUSTOM_DEFINES"},
+        {"key": "aib-extra-args", "var": "AIB_EXTRA_ARGS"},
+        {"key": "export-format", "var": "EXPORT_FORMAT"}
+      ]
+    },
+    "layer": {
+      "custom": [
+        {"key": "partition", "var": "PARTITION"},
+        {"key": "decompressed-size", "var": "DECOMPRESSED_SIZE"}
+      ],
+      "standard": [
+        {"key": "org.opencontainers.image.title", "var": "ORG_OPENCONTAINERS_IMAGE_TITLE"}
+      ]
+    }
+  },
+
+  "mediaTypes": {
+    "diskFormats": {
+      "raw": "application/vnd.automotive.disk.raw",
+      "qcow2": "application/vnd.automotive.disk.qcow2",
+      "simg": "application/vnd.automotive.disk.simg"
+    },
+    "compressionSuffixes": {
+      "gzip": "+gzip",
+      "lz4": "+lz4",
+      "xz": "+xz"
+    },
+    "containerLayers": {
+      "base": "application/vnd.oci.image.layer.v1.tar",
+      "gzip": "application/vnd.oci.image.layer.v1.tar+gzip",
+      "lz4": "application/vnd.oci.image.layer.v1.tar+lz4",
+      "xz": "application/vnd.oci.image.layer.v1.tar+xz"
+    },
+    "generic": {
+      "gzip": "application/gzip",
+      "lz4": "application/x-lz4",
+      "xz": "application/x-xz",
+      "octetStream": "application/octet-stream"
+    }
+  },
+
+  "referrerTypes": [
+    {
+      "artifactType": "application/vnd.automotive.manifest.v1+yaml",
+      "label": "AIB Manifest",
+      "var": "AIB_MANIFEST",
+      "filename": "manifest.aib.yml"
+    },
+    {
+      "artifactType": "application/vnd.automotive.sources.v1+tar+gzip",
+      "label": "Build Sources",
+      "var": "BUILD_SOURCES",
+      "filename": "build-sources.tar.gz"
+    },
+    {
+      "artifactType": "application/vnd.osbuild.manifest.v1+json",
+      "label": "osbuild Manifest",
+      "var": "OSBUILD_MANIFEST",
+      "filename": "image.json"
+    }
+  ]
+}

--- a/internal/common/oci/spec_test.go
+++ b/internal/common/oci/spec_test.go
@@ -1,0 +1,151 @@
+package oci
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSpecParses(t *testing.T) {
+	s := Get()
+	if s.AnnotationPrefix == "" {
+		t.Fatal("annotationPrefix is empty")
+	}
+	if !strings.HasSuffix(s.AnnotationPrefix, "/") {
+		t.Fatalf("annotationPrefix %q must end with /", s.AnnotationPrefix)
+	}
+	if len(s.Annotations.Manifest.Required) == 0 {
+		t.Fatal("no required manifest annotations")
+	}
+	if len(s.Annotations.Manifest.Optional) == 0 {
+		t.Fatal("no optional manifest annotations")
+	}
+	if len(s.Annotations.Layer.Custom) == 0 {
+		t.Fatal("no custom layer annotations")
+	}
+	if len(s.MediaTypes.DiskFormats) == 0 {
+		t.Fatal("no disk format media types")
+	}
+	if len(s.MediaTypes.CompressionSuffixes) == 0 {
+		t.Fatal("no compression suffixes")
+	}
+	if len(s.MediaTypes.ContainerLayers) == 0 {
+		t.Fatal("no container layer media types")
+	}
+	if len(s.ReferrerTypes) == 0 {
+		t.Fatal("no referrer types")
+	}
+}
+
+func TestAnnotationKey(t *testing.T) {
+	s := Get()
+	got := s.AnnotationKey("distro")
+	want := "automotive.sdv.cloud.redhat.com/distro"
+	if got != want {
+		t.Fatalf("AnnotationKey(distro) = %q, want %q", got, want)
+	}
+}
+
+func TestReferrerFileMap(t *testing.T) {
+	m := Get().ReferrerFileMap()
+	expected := map[string]string{
+		"application/vnd.automotive.manifest.v1+yaml":    "manifest.aib.yml",
+		"application/vnd.automotive.sources.v1+tar+gzip": "build-sources.tar.gz",
+		"application/vnd.osbuild.manifest.v1+json":       "image.json",
+	}
+	for artType, filename := range expected {
+		if m[artType] != filename {
+			t.Errorf("ReferrerFileMap[%q] = %q, want %q", artType, m[artType], filename)
+		}
+	}
+}
+
+func TestAllManifestAnnotationKeys(t *testing.T) {
+	keys := Get().AllManifestAnnotationKeys()
+	required := map[string]bool{"distro": true, "target": true, "arch": true}
+	optional := map[string]bool{
+		"parts": true, "multi-layer": true, "default-partitions": true,
+		"builder-image": true, "aib-version": true, "automotive-image-builder": true,
+		"aib-command": true, "task-bundle-ref": true, "custom-defines": true,
+		"aib-extra-args": true, "export-format": true,
+	}
+
+	for _, ak := range keys {
+		if !required[ak.Key] && !optional[ak.Key] {
+			t.Errorf("unexpected annotation key %q", ak.Key)
+		}
+		if ak.Var == "" {
+			t.Errorf("annotation key %q has empty var name", ak.Key)
+		}
+	}
+	for k := range required {
+		found := false
+		for _, ak := range keys {
+			if ak.Key == k {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("missing required annotation key %q", k)
+		}
+	}
+}
+
+func TestMediaTypeComposition(t *testing.T) {
+	s := Get()
+	cases := []struct {
+		format      string
+		compression string
+		want        string
+	}{
+		{"raw", "gzip", "application/vnd.automotive.disk.raw+gzip"},
+		{"raw", "lz4", "application/vnd.automotive.disk.raw+lz4"},
+		{"raw", "xz", "application/vnd.automotive.disk.raw+xz"},
+		{"qcow2", "gzip", "application/vnd.automotive.disk.qcow2+gzip"},
+		{"qcow2", "lz4", "application/vnd.automotive.disk.qcow2+lz4"},
+		{"qcow2", "xz", "application/vnd.automotive.disk.qcow2+xz"},
+		{"simg", "gzip", "application/vnd.automotive.disk.simg+gzip"},
+		{"simg", "lz4", "application/vnd.automotive.disk.simg+lz4"},
+		{"simg", "xz", "application/vnd.automotive.disk.simg+xz"},
+	}
+	for _, tc := range cases {
+		got := s.MediaTypes.DiskFormats[tc.format] + s.MediaTypes.CompressionSuffixes[tc.compression]
+		if got != tc.want {
+			t.Errorf("%s+%s = %q, want %q", tc.format, tc.compression, got, tc.want)
+		}
+	}
+}
+
+func TestShellVarsContainsExpectedAssignments(t *testing.T) {
+	vars := Get().ShellVars()
+	expected := []string{
+		`OCI_ANNOTATION_PREFIX="automotive.sdv.cloud.redhat.com/"`,
+		`OCI_ANN_DISTRO="automotive.sdv.cloud.redhat.com/distro"`,
+		`OCI_ANN_MULTI_LAYER="automotive.sdv.cloud.redhat.com/multi-layer"`,
+		`OCI_MEDIA_DISK_RAW="application/vnd.automotive.disk.raw"`,
+		`OCI_MEDIA_DISK_QCOW2="application/vnd.automotive.disk.qcow2"`,
+		`OCI_MEDIA_DISK_SIMG="application/vnd.automotive.disk.simg"`,
+		`OCI_COMPRESS_SUFFIX_GZIP="+gzip"`,
+		`OCI_MEDIA_LAYER_GZIP="application/vnd.oci.image.layer.v1.tar+gzip"`,
+		`OCI_MEDIA_OCTETSTREAM="application/octet-stream"`,
+		`OCI_LAYER_ANN_PARTITION="automotive.sdv.cloud.redhat.com/partition"`,
+		`OCI_LAYER_ANN_ORG_OPENCONTAINERS_IMAGE_TITLE="org.opencontainers.image.title"`,
+		`OCI_REFERRER_TYPE_AIB_MANIFEST="application/vnd.automotive.manifest.v1+yaml"`,
+		`OCI_REFERRER_FILE_AIB_MANIFEST="manifest.aib.yml"`,
+		`OCI_REFERRER_TYPE_BUILD_SOURCES="application/vnd.automotive.sources.v1+tar+gzip"`,
+		`OCI_REFERRER_TYPE_OSBUILD_MANIFEST="application/vnd.osbuild.manifest.v1+json"`,
+	}
+	for _, e := range expected {
+		if !strings.Contains(vars, e) {
+			t.Errorf("ShellVars() missing: %s", e)
+		}
+	}
+}
+
+func TestShellVarsDeterministic(t *testing.T) {
+	a := Get().ShellVars()
+	b := Get().ShellVars()
+	if a != b {
+		t.Fatal("ShellVars() output is not deterministic")
+	}
+}

--- a/internal/common/tasks/oci_contract_test.go
+++ b/internal/common/tasks/oci_contract_test.go
@@ -1,0 +1,61 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/oci"
+)
+
+func TestNoHardcodedOCIStringsInScripts(t *testing.T) {
+	spec := oci.Get()
+	generatedBlock := spec.ShellVars()
+
+	scripts := map[string]string{
+		"PushArtifactScript":    PushArtifactScript,
+		"BuildImageScript":      BuildImageScript,
+		"SealedOperationScript": SealedOperationScript,
+	}
+
+	forbiddenMediaTypes := []string{
+		"application/vnd.automotive.disk.",
+		"application/vnd.automotive.manifest.",
+		"application/vnd.automotive.sources.",
+		"application/vnd.osbuild.manifest.",
+	}
+
+	allKeys := spec.AllManifestAnnotationKeys()
+	forbiddenAnnotationKeys := make([]string, 0, len(allKeys)+len(spec.Annotations.Layer.Custom))
+	for _, ak := range allKeys {
+		forbiddenAnnotationKeys = append(forbiddenAnnotationKeys, `"`+spec.AnnotationKey(ak.Key)+`"`)
+	}
+	for _, ak := range spec.Annotations.Layer.Custom {
+		forbiddenAnnotationKeys = append(forbiddenAnnotationKeys, `"`+spec.AnnotationKey(ak.Key)+`"`)
+	}
+
+	for name, script := range scripts {
+		stripped := stripGeneratedBlock(script, generatedBlock)
+
+		for _, pattern := range forbiddenMediaTypes {
+			if strings.Contains(stripped, pattern) {
+				t.Errorf("%s contains hardcoded OCI media type %q — use OCI_* shell variables from spec.json instead",
+					name, pattern)
+			}
+		}
+
+		for _, key := range forbiddenAnnotationKeys {
+			if strings.Contains(stripped, key) {
+				t.Errorf("%s contains hardcoded annotation key %s — use $OCI_ANN_* shell variables from spec.json instead",
+					name, key)
+			}
+		}
+	}
+}
+
+func stripGeneratedBlock(script, block string) string {
+	idx := strings.Index(script, block)
+	if idx < 0 {
+		return script
+	}
+	return script[:idx] + script[idx+len(block):]
+}

--- a/internal/common/tasks/scripts.go
+++ b/internal/common/tasks/scripts.go
@@ -3,6 +3,8 @@ package tasks
 
 import (
 	_ "embed"
+
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/oci"
 )
 
 //go:embed scripts/common.sh
@@ -39,11 +41,12 @@ var flashImageScript string
 var FlashImageScript = ""
 
 func init() {
-	BuildImageScript = commonScript + "\n" + buildImageScript
+	ociVars := oci.Get().ShellVars()
+	BuildImageScript = commonScript + "\n" + ociVars + "\n" + buildImageScript
 	BuildBuilderScript = commonScript + "\n" + buildBuilderScript
-	PushArtifactScript = commonScript + "\n" + pushArtifactScript
+	PushArtifactScript = commonScript + "\n" + ociVars + "\n" + pushArtifactScript
 	FlashImageScript = commonScript + "\n" + flashImageScript
-	SealedOperationScript = commonScript + "\n" + sealedOperationScript
+	SealedOperationScript = commonScript + "\n" + ociVars + "\n" + sealedOperationScript
 }
 
 //go:embed scripts/sealed_operation.sh

--- a/internal/common/tasks/scripts/build_image.sh
+++ b/internal/common/tasks/scripts/build_image.sh
@@ -122,7 +122,7 @@ if [ -n "$RESTORE_SOURCES_REF" ]; then
     ORAS_AUTH_FLAGS=(--registry-config "$REGISTRY_AUTH_FILE")
   fi
 
-  SOURCES_TYPE="application/vnd.automotive.sources.v1+tar+gzip"
+  SOURCES_TYPE="$OCI_REFERRER_TYPE_BUILD_SOURCES"
   SOURCES_DIGEST=$(oras discover "${ORAS_AUTH_FLAGS[@]}" "$RESTORE_SOURCES_REF" \
     --artifact-type "$SOURCES_TYPE" --format json \
     | grep -o 'sha256:[a-f0-9]\{64\}' | head -1)
@@ -495,7 +495,8 @@ case "$BUILD_MODE" in
           _AIB_IMAGE_PINNED=$(cat /tmp/aib-pinned.txt 2>/dev/null || echo "$AIB_IMAGE_REF")
 
           echo "Annotating bootc container with builder image: $BUILDER_IMAGE"
-          python3 - "$OCI_DIR" "$BUILDER_IMAGE" "$_AIB_VERSION" "$_AIB_IMAGE_PINNED" "$AIB_COMMAND" <<'PYEOF'
+          python3 - "$OCI_DIR" "$BUILDER_IMAGE" "$_AIB_VERSION" "$_AIB_IMAGE_PINNED" "$AIB_COMMAND" \
+              "$OCI_ANN_BUILDER_IMAGE" "$OCI_ANN_AIB_VERSION" "$OCI_ANN_AUTOMOTIVE_IMAGE_BUILDER" "$OCI_ANN_AIB_COMMAND" <<'PYEOF'
 import json, sys, hashlib, os
 from pathlib import Path
 
@@ -510,11 +511,8 @@ def update_blob(oci_dir, old_digest, data):
         old_path.unlink()
     return new_digest, len(content)
 
-oci_dir, builder_image, aib_version, aib_image, aib_command = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5]
-key_builder  = "automotive.sdv.cloud.redhat.com/builder-image"
-key_aib_version = "automotive.sdv.cloud.redhat.com/aib-version"
-key_aib_image   = "automotive.sdv.cloud.redhat.com/automotive-image-builder"
-key_aib_command = "automotive.sdv.cloud.redhat.com/aib-command"
+oci_dir, builder_image, aib_version, aib_image, aib_command = sys.argv[1:6]
+key_builder, key_aib_version, key_aib_image, key_aib_command = sys.argv[6:10]
 
 index_path = Path(oci_dir) / "index.json"
 index = json.loads(index_path.read_text())

--- a/internal/common/tasks/scripts/push_artifact.sh
+++ b/internal/common/tasks/scripts/push_artifact.sh
@@ -79,31 +79,30 @@ echo "ORAS ${ORAS_VERSION} installed successfully"
 # Get media type based on file format and compression
 get_media_type() {
   case "$1" in
-    *.tar.gz)         echo "application/vnd.oci.image.layer.v1.tar+gzip" ;;
-    *.tar.lz4)        echo "application/vnd.oci.image.layer.v1.tar+lz4" ;;
-    *.tar.xz)         echo "application/vnd.oci.image.layer.v1.tar+xz" ;;
-    *.tar)            echo "application/vnd.oci.image.layer.v1.tar" ;;
+    *.tar.gz)         echo "$OCI_MEDIA_LAYER_GZIP" ;;
+    *.tar.lz4)        echo "$OCI_MEDIA_LAYER_LZ4" ;;
+    *.tar.xz)         echo "$OCI_MEDIA_LAYER_XZ" ;;
+    *.tar)            echo "$OCI_MEDIA_LAYER_BASE" ;;
 
-    *.simg.gz)        echo "application/vnd.automotive.disk.simg+gzip" ;;
-    *.simg.lz4)       echo "application/vnd.automotive.disk.simg+lz4" ;;
-    *.simg.xz)        echo "application/vnd.automotive.disk.simg+xz" ;;
-    *.raw.gz|*.img.gz) echo "application/vnd.automotive.disk.raw+gzip" ;;
-    *.raw.lz4|*.img.lz4) echo "application/vnd.automotive.disk.raw+lz4" ;;
-    *.raw.xz|*.img.xz) echo "application/vnd.automotive.disk.raw+xz" ;;
-    *.qcow2.gz)       echo "application/vnd.automotive.disk.qcow2+gzip" ;;
-    *.qcow2.lz4)      echo "application/vnd.automotive.disk.qcow2+lz4" ;;
-    *.qcow2.xz)       echo "application/vnd.automotive.disk.qcow2+xz" ;;
+    *.simg.gz)        echo "${OCI_MEDIA_DISK_SIMG}${OCI_COMPRESS_SUFFIX_GZIP}" ;;
+    *.simg.lz4)       echo "${OCI_MEDIA_DISK_SIMG}${OCI_COMPRESS_SUFFIX_LZ4}" ;;
+    *.simg.xz)        echo "${OCI_MEDIA_DISK_SIMG}${OCI_COMPRESS_SUFFIX_XZ}" ;;
+    *.raw.gz|*.img.gz) echo "${OCI_MEDIA_DISK_RAW}${OCI_COMPRESS_SUFFIX_GZIP}" ;;
+    *.raw.lz4|*.img.lz4) echo "${OCI_MEDIA_DISK_RAW}${OCI_COMPRESS_SUFFIX_LZ4}" ;;
+    *.raw.xz|*.img.xz) echo "${OCI_MEDIA_DISK_RAW}${OCI_COMPRESS_SUFFIX_XZ}" ;;
+    *.qcow2.gz)       echo "${OCI_MEDIA_DISK_QCOW2}${OCI_COMPRESS_SUFFIX_GZIP}" ;;
+    *.qcow2.lz4)      echo "${OCI_MEDIA_DISK_QCOW2}${OCI_COMPRESS_SUFFIX_LZ4}" ;;
+    *.qcow2.xz)       echo "${OCI_MEDIA_DISK_QCOW2}${OCI_COMPRESS_SUFFIX_XZ}" ;;
 
-    *.simg)           echo "application/vnd.automotive.disk.simg" ;;
-    *.raw|*.img)      echo "application/vnd.automotive.disk.raw" ;;
-    *.qcow2)          echo "application/vnd.automotive.disk.qcow2" ;;
+    *.simg)           echo "$OCI_MEDIA_DISK_SIMG" ;;
+    *.raw|*.img)      echo "$OCI_MEDIA_DISK_RAW" ;;
+    *.qcow2)          echo "$OCI_MEDIA_DISK_QCOW2" ;;
 
-    *.gz)             echo "application/gzip" ;;
-    *.lz4)            echo "application/x-lz4" ;;
-    *.xz)             echo "application/x-xz" ;;
+    *.gz)             echo "$OCI_MEDIA_GZIP" ;;
+    *.lz4)            echo "$OCI_MEDIA_LZ4" ;;
+    *.xz)             echo "$OCI_MEDIA_XZ" ;;
 
-    # Default fallback
-    *)                echo "application/octet-stream" ;;
+    *)                echo "$OCI_MEDIA_OCTETSTREAM" ;;
   esac
 }
 
@@ -114,10 +113,10 @@ json_escape() {
 
 get_artifact_type() {
   case "$1" in
-    *.simg.gz|*.simg.lz4|*.simg) echo "application/vnd.automotive.disk.simg" ;;
-    *.qcow2.gz|*.qcow2.lz4|*.qcow2.xz|*.qcow2) echo "application/vnd.automotive.disk.qcow2" ;;
-    *.raw.gz|*.raw.lz4|*.raw.xz|*.raw|*.img.gz|*.img.lz4|*.img.xz|*.img) echo "application/vnd.automotive.disk.raw" ;;
-    *) echo "application/octet-stream" ;;
+    *.simg.gz|*.simg.lz4|*.simg) echo "$OCI_MEDIA_DISK_SIMG" ;;
+    *.qcow2.gz|*.qcow2.lz4|*.qcow2.xz|*.qcow2) echo "$OCI_MEDIA_DISK_QCOW2" ;;
+    *.raw.gz|*.raw.lz4|*.raw.xz|*.raw|*.img.gz|*.img.lz4|*.img.xz|*.img) echo "$OCI_MEDIA_DISK_RAW" ;;
+    *) echo "$OCI_MEDIA_OCTETSTREAM" ;;
   esac
 }
 
@@ -305,9 +304,9 @@ if [ -d "${parts_dir}" ] && [ -n "$(ls -A "${parts_dir}" 2>/dev/null)" ]; then
 
       # Build JSON with properly escaped values
       if [ -n "$decompressed_size" ]; then
-        layer_annotations_json="${layer_annotations_json}\"${escaped_filename}\":{\"automotive.sdv.cloud.redhat.com/partition\":\"${escaped_partition}\",\"org.opencontainers.image.title\":\"${escaped_filename}\",\"automotive.sdv.cloud.redhat.com/decompressed-size\":\"${escaped_decompressed_size}\"}"
+        layer_annotations_json="${layer_annotations_json}\"${escaped_filename}\":{\"${OCI_LAYER_ANN_PARTITION}\":\"${escaped_partition}\",\"${OCI_LAYER_ANN_ORG_OPENCONTAINERS_IMAGE_TITLE}\":\"${escaped_filename}\",\"${OCI_LAYER_ANN_DECOMPRESSED_SIZE}\":\"${escaped_decompressed_size}\"}"
       else
-        layer_annotations_json="${layer_annotations_json}\"${escaped_filename}\":{\"automotive.sdv.cloud.redhat.com/partition\":\"${escaped_partition}\",\"org.opencontainers.image.title\":\"${escaped_filename}\"}"
+        layer_annotations_json="${layer_annotations_json}\"${escaped_filename}\":{\"${OCI_LAYER_ANN_PARTITION}\":\"${escaped_partition}\",\"${OCI_LAYER_ANN_ORG_OPENCONTAINERS_IMAGE_TITLE}\":\"${escaped_filename}\"}"
       fi
     fi
   done
@@ -326,25 +325,30 @@ if [ -d "${parts_dir}" ] && [ -n "$(ls -A "${parts_dir}" 2>/dev/null)" ]; then
   manifest_annotations_json=$(python3 - \
       "$distro" "$target" "$arch" "$file_list" \
       "$default_partitions" "$builder_image_used" "$aib_version" "$aib_image" "$aib_command" "$TASK_BUNDLE_REF" \
-      "$CUSTOM_DEFINES" "$AIB_EXTRA_ARGS" "$EXPORT_FORMAT" <<'PYEOF'
+      "$CUSTOM_DEFINES" "$AIB_EXTRA_ARGS" "$EXPORT_FORMAT" \
+      "$OCI_ANN_MULTI_LAYER" "$OCI_ANN_PARTS" "$OCI_ANN_DISTRO" "$OCI_ANN_TARGET" "$OCI_ANN_ARCH" \
+      "$OCI_ANN_DEFAULT_PARTITIONS" "$OCI_ANN_BUILDER_IMAGE" "$OCI_ANN_AIB_VERSION" \
+      "$OCI_ANN_AUTOMOTIVE_IMAGE_BUILDER" "$OCI_ANN_AIB_COMMAND" "$OCI_ANN_TASK_BUNDLE_REF" \
+      "$OCI_ANN_CUSTOM_DEFINES" "$OCI_ANN_AIB_EXTRA_ARGS" "$OCI_ANN_EXPORT_FORMAT" <<'PYEOF'
 import json, sys
 distro, target, arch, parts, default_parts, builder, aib_ver, aib_img, aib_cmd, task_bundle, custom_defs, extra_args, export_fmt = sys.argv[1:14]
+k_multi, k_parts, k_distro, k_target, k_arch, k_default_parts, k_builder, k_aib_ver, k_aib_img, k_aib_cmd, k_task_bundle, k_custom_defs, k_extra_args, k_export_fmt = sys.argv[14:28]
 a = {
-    "automotive.sdv.cloud.redhat.com/multi-layer": "true",
-    "automotive.sdv.cloud.redhat.com/parts":       parts,
-    "automotive.sdv.cloud.redhat.com/distro":      distro,
-    "automotive.sdv.cloud.redhat.com/target":      target,
-    "automotive.sdv.cloud.redhat.com/arch":        arch,
+    k_multi:  "true",
+    k_parts:  parts,
+    k_distro: distro,
+    k_target: target,
+    k_arch:   arch,
 }
-if default_parts: a["automotive.sdv.cloud.redhat.com/default-partitions"]      = default_parts
-if builder:       a["automotive.sdv.cloud.redhat.com/builder-image"]            = builder
-if aib_ver:       a["automotive.sdv.cloud.redhat.com/aib-version"]              = aib_ver
-if aib_img:       a["automotive.sdv.cloud.redhat.com/automotive-image-builder"] = aib_img
-if aib_cmd:       a["automotive.sdv.cloud.redhat.com/aib-command"]              = aib_cmd
-if task_bundle:   a["automotive.sdv.cloud.redhat.com/task-bundle-ref"]          = task_bundle
-if custom_defs:   a["automotive.sdv.cloud.redhat.com/custom-defines"]           = custom_defs
-if extra_args:    a["automotive.sdv.cloud.redhat.com/aib-extra-args"]           = extra_args
-if export_fmt:    a["automotive.sdv.cloud.redhat.com/export-format"]            = export_fmt
+if default_parts: a[k_default_parts] = default_parts
+if builder:       a[k_builder]       = builder
+if aib_ver:       a[k_aib_ver]       = aib_ver
+if aib_img:       a[k_aib_img]       = aib_img
+if aib_cmd:       a[k_aib_cmd]       = aib_cmd
+if task_bundle:   a[k_task_bundle]   = task_bundle
+if custom_defs:   a[k_custom_defs]   = custom_defs
+if extra_args:    a[k_extra_args]    = extra_args
+if export_fmt:    a[k_export_fmt]    = export_fmt
 print(json.dumps(a))
 PYEOF
 )
@@ -406,25 +410,30 @@ else
   python3 - "$single_annotations_file" \
       "$distro" "$target" "$arch" \
       "$parts_list" "$builder_image_used" "$aib_version" "$aib_image" "$aib_command" "$TASK_BUNDLE_REF" \
-      "$CUSTOM_DEFINES" "$AIB_EXTRA_ARGS" "$EXPORT_FORMAT" <<'PYEOF'
+      "$CUSTOM_DEFINES" "$AIB_EXTRA_ARGS" "$EXPORT_FORMAT" \
+      "$OCI_ANN_DISTRO" "$OCI_ANN_TARGET" "$OCI_ANN_ARCH" \
+      "$OCI_ANN_PARTS" "$OCI_ANN_BUILDER_IMAGE" "$OCI_ANN_AIB_VERSION" \
+      "$OCI_ANN_AUTOMOTIVE_IMAGE_BUILDER" "$OCI_ANN_AIB_COMMAND" "$OCI_ANN_TASK_BUNDLE_REF" \
+      "$OCI_ANN_CUSTOM_DEFINES" "$OCI_ANN_AIB_EXTRA_ARGS" "$OCI_ANN_EXPORT_FORMAT" <<'PYEOF'
 import json, sys
 from pathlib import Path
 
 out_file, distro, target, arch, parts, builder, aib_ver, aib_img, aib_cmd, task_bundle, custom_defs, extra_args, export_fmt = sys.argv[1:14]
+k_distro, k_target, k_arch, k_parts, k_builder, k_aib_ver, k_aib_img, k_aib_cmd, k_task_bundle, k_custom_defs, k_extra_args, k_export_fmt = sys.argv[14:26]
 annotations = {
-    "automotive.sdv.cloud.redhat.com/distro":  distro,
-    "automotive.sdv.cloud.redhat.com/target":  target,
-    "automotive.sdv.cloud.redhat.com/arch":    arch,
+    k_distro: distro,
+    k_target: target,
+    k_arch:   arch,
 }
-if parts:         annotations["automotive.sdv.cloud.redhat.com/parts"]                    = parts
-if builder:       annotations["automotive.sdv.cloud.redhat.com/builder-image"]            = builder
-if aib_ver:       annotations["automotive.sdv.cloud.redhat.com/aib-version"]              = aib_ver
-if aib_img:       annotations["automotive.sdv.cloud.redhat.com/automotive-image-builder"] = aib_img
-if aib_cmd:       annotations["automotive.sdv.cloud.redhat.com/aib-command"]              = aib_cmd
-if task_bundle:   annotations["automotive.sdv.cloud.redhat.com/task-bundle-ref"]          = task_bundle
-if custom_defs:   annotations["automotive.sdv.cloud.redhat.com/custom-defines"]           = custom_defs
-if extra_args:    annotations["automotive.sdv.cloud.redhat.com/aib-extra-args"]           = extra_args
-if export_fmt:    annotations["automotive.sdv.cloud.redhat.com/export-format"]            = export_fmt
+if parts:         annotations[k_parts]       = parts
+if builder:       annotations[k_builder]     = builder
+if aib_ver:       annotations[k_aib_ver]     = aib_ver
+if aib_img:       annotations[k_aib_img]     = aib_img
+if aib_cmd:       annotations[k_aib_cmd]     = aib_cmd
+if task_bundle:   annotations[k_task_bundle] = task_bundle
+if custom_defs:   annotations[k_custom_defs] = custom_defs
+if extra_args:    annotations[k_extra_args]  = extra_args
+if export_fmt:    annotations[k_export_fmt]  = export_fmt
 Path(out_file).write_text(json.dumps({"$manifest": annotations}))
 PYEOF
 
@@ -512,9 +521,9 @@ PYEOF
 
   echo "Attaching sanitized osbuild manifest to ${repo_url}@${DISK_DIGEST}"
   if ! "$HOME/bin/oras" attach "${ORAS_EXTRA_ARGS[@]}" \
-    --artifact-type "application/vnd.osbuild.manifest.v1+json" \
+    --artifact-type "$OCI_REFERRER_TYPE_OSBUILD_MANIFEST" \
     "${repo_url}@${DISK_DIGEST}" \
-    "${SANITIZED_MANIFEST}:application/vnd.osbuild.manifest.v1+json" 2>&1; then
+    "${SANITIZED_MANIFEST}:${OCI_REFERRER_TYPE_OSBUILD_MANIFEST}" 2>&1; then
     if [ "$SECURE_BUILD" = "true" ]; then
       echo "ERROR: Failed to attach osbuild manifest (fatal in secure build mode)"
       exit 1
@@ -549,8 +558,8 @@ if [ "$REPRODUCIBLE" = "true" ] && [ -n "$DISK_DIGEST" ]; then
   cd /workspace/shared || { echo "ERROR: cannot cd to /workspace/shared"; exit 1; }
   echo "=== Attaching reproducibility artifacts ==="
   attach_referrer "./aib-manifest.yml" \
-    "application/vnd.automotive.manifest.v1+yaml" "AIB input manifest"
+    "$OCI_REFERRER_TYPE_AIB_MANIFEST" "AIB input manifest"
   attach_referrer "./build-sources.tar.gz" \
-    "application/vnd.automotive.sources.v1+tar+gzip" "osbuild sources archive"
+    "$OCI_REFERRER_TYPE_BUILD_SOURCES" "osbuild sources archive"
   echo "=== Reproducibility artifacts attached ==="
 fi

--- a/internal/common/tasks/scripts/sealed_operation.sh
+++ b/internal/common/tasks/scripts/sealed_operation.sh
@@ -191,7 +191,7 @@ resolve_and_pull_builder() {
   local builder_image="${BUILDER_IMAGE:-}"
 
   if [ -z "${builder_image:-}" ]; then
-    local annotation_key="automotive.sdv.cloud.redhat.com/builder-image"
+    local annotation_key="$OCI_ANN_BUILDER_IMAGE"
     echo "No builder image specified, checking source container labels..."
     builder_image=$(skopeo inspect "containers-storage:$source" 2>/dev/null \
       | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('Labels',{}).get('$annotation_key',''))" 2>/dev/null) || true


### PR DESCRIPTION
Define media types, annotation keys, and referrer types in a single JSON contract file (internal/common/oci/spec.json) consumed by Go via //go:embed and by shell scripts via generated variables.

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [X] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [X] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized OCI artifact/spec handling for consistent provenance display, annotation key normalization, referrer-type handling, and script-generated variables—improves reliability of provenance output and artifact metadata handling.
* **Tests**
  * Added validation ensuring generated scripts and outputs use the centralized OCI spec (no hardcoded OCI strings) and that spec-derived shell variables are stable and complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->