### PR TITLE
feat(cli): add --quiet/-q flag to suppress informational output

### DIFF
--- a/cmd/caib/buildcmd/build.go
+++ b/cmd/caib/buildcmd/build.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	common "github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/common"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/registryauth"
 	buildapitypes "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi"
@@ -220,7 +221,7 @@ func (h *Handler) resolveTarget(cmd *cobra.Command, manifestTarget string) {
 
 	if manifestTarget != "" {
 		*h.opts.Target = manifestTarget
-		fmt.Printf("Using target %q from manifest\n", manifestTarget)
+		clilog.Infof("Using target %q from manifest\n", manifestTarget)
 		return
 	}
 
@@ -280,18 +281,18 @@ func ApplyTargetDefaults(cmd *cobra.Command, config *buildapitypes.OperatorConfi
 
 	if defaults.Architecture != "" && !cmd.Flags().Changed("arch") {
 		req.Architecture = buildapitypes.Architecture(defaults.Architecture)
-		fmt.Printf("Using architecture %q from target defaults for %q\n", defaults.Architecture, req.Target)
+		clilog.Infof("Using architecture %q from target defaults for %q\n", defaults.Architecture, req.Target)
 	}
 
 	if len(defaults.ExtraArgs) > 0 {
 		// Default args come first, user args appended.
 		req.AIBExtraArgs = append(defaults.ExtraArgs, req.AIBExtraArgs...)
-		fmt.Printf("Prepending extra args %v from target defaults for %q\n", defaults.ExtraArgs, req.Target)
+		clilog.Infof("Prepending extra args %v from target defaults for %q\n", defaults.ExtraArgs, req.Target)
 	}
 
 	if defaults.DefaultFormat != "" && !cmd.Flags().Changed("format") {
 		req.ExportFormat = buildapitypes.ExportFormat(defaults.DefaultFormat)
-		fmt.Printf("Using format %q from target defaults for %q\n", defaults.DefaultFormat, req.Target)
+		clilog.Infof("Using format %q from target defaults for %q\n", defaults.DefaultFormat, req.Target)
 	}
 }
 
@@ -335,11 +336,11 @@ func (h *Handler) displayBuildResults(ctx context.Context, api *buildapiclient.C
 				credsFile, credsErr := common.WriteRegistryCredentialsFile(st.RegistryToken)
 				if credsErr != nil {
 					fmt.Fprintf(os.Stderr, "Warning: failed to write registry credentials file: %v\n", credsErr)
-					fmt.Printf("\n%s\n", labelColor("Registry credentials (valid ~4 hours):"))
-					fmt.Printf("  %s %s\n", labelColor("Username:"), valueColor("serviceaccount"))
-					fmt.Printf("  %s %s\n", labelColor("Token:"), valueColor(st.RegistryToken))
+					clilog.Infof("\n%s\n", labelColor("Registry credentials (valid ~4 hours):"))
+					clilog.Infof("  %s %s\n", labelColor("Username:"), valueColor("serviceaccount"))
+					clilog.Infof("  %s %s\n", labelColor("Token:"), valueColor(st.RegistryToken))
 				} else {
-					fmt.Printf("\n%s %s (valid ~4 hours)\n",
+					clilog.Infof("\n%s %s (valid ~4 hours)\n",
 						labelColor("Registry credentials written to:"),
 						valueColor(credsFile),
 					)
@@ -349,7 +350,6 @@ func (h *Handler) displayBuildResults(ctx context.Context, api *buildapiclient.C
 		return
 	}
 
-	// Only show push confirmations when the server reports actual artifact locations.
 	if st.ContainerImage != "" && *h.opts.ContainerPush != "" {
 		fmt.Printf("%s %s\n", labelColor("Container image pushed to:"), valueColor(*h.opts.ContainerPush))
 	}
@@ -391,7 +391,7 @@ func (h *Handler) applyFlashOptions(req *buildapitypes.BuildRequest, pushRequire
 	if err != nil {
 		return fmt.Errorf("--flash: %w", err)
 	}
-	fmt.Printf("Using Jumpstarter client %q (endpoint: %s)\n", clientInfo.Name, clientInfo.Endpoint)
+	clilog.Infof("Using Jumpstarter client %q (endpoint: %s)\n", clientInfo.Name, clientInfo.Endpoint)
 	req.FlashEnabled = true
 	req.FlashClientConfig = base64.StdEncoding.EncodeToString(clientInfo.Data)
 	req.FlashLeaseName = *h.opts.LeaseName
@@ -404,6 +404,9 @@ func (h *Handler) applyFlashOptions(req *buildapitypes.BuildRequest, pushRequire
 }
 
 func (h *Handler) displayBuildLogsCommand(buildName string) {
+	if clilog.IsQuiet() {
+		return
+	}
 	labelColor := func(a ...any) string { return fmt.Sprint(a...) }
 	commandColor := func(a ...any) string { return fmt.Sprint(a...) }
 	if h.supportsColorOutput() {
@@ -456,7 +459,7 @@ func (h *Handler) RunBuild(cmd *cobra.Command, args []string) {
 		base = strings.TrimSuffix(base, ".mpp.yml")
 		sanitized := common.SanitizeBuildName(base)
 		*h.opts.BuildName = sanitized
-		fmt.Printf("Auto-generated build name: %s\n", *h.opts.BuildName)
+		clilog.Infof("Auto-generated build name: %s\n", *h.opts.BuildName)
 	} else if err := common.ValidateBuildName(*h.opts.BuildName); err != nil {
 		h.handleError(err)
 		return
@@ -540,7 +543,7 @@ func (h *Handler) RunBuild(cmd *cobra.Command, args []string) {
 		h.handleError(err)
 		return
 	}
-	fmt.Printf("Build %s accepted: %s - %s\n", resp.Name, resp.Phase, resp.Message)
+	clilog.Infof("Build %s accepted: %s - %s\n", resp.Name, resp.Phase, resp.Message)
 	h.displayBuildLogsCommand(resp.Name)
 
 	if len(localRefs) > 0 {
@@ -588,7 +591,7 @@ func (h *Handler) RunDisk(cmd *cobra.Command, args []string) {
 		imagePart = strings.Split(imagePart, ":")[0]
 		sanitized := common.SanitizeBuildName(imagePart)
 		*h.opts.BuildName = fmt.Sprintf("disk-%s", sanitized)
-		fmt.Printf("Auto-generated build name: %s\n", *h.opts.BuildName)
+		clilog.Infof("Auto-generated build name: %s\n", *h.opts.BuildName)
 	} else if err := common.ValidateBuildName(*h.opts.BuildName); err != nil {
 		h.handleError(err)
 		return
@@ -648,7 +651,7 @@ func (h *Handler) RunDisk(cmd *cobra.Command, args []string) {
 		h.handleError(err)
 		return
 	}
-	fmt.Printf("Build %s accepted: %s - %s\n", resp.Name, resp.Phase, resp.Message)
+	clilog.Infof("Build %s accepted: %s - %s\n", resp.Name, resp.Phase, resp.Message)
 	h.displayBuildLogsCommand(resp.Name)
 
 	if *h.opts.WaitForBuild || *h.opts.FollowLogs || *h.opts.OutputDir != "" || *h.opts.FlashAfterBuild {
@@ -699,7 +702,7 @@ func (h *Handler) RunBuildDev(cmd *cobra.Command, args []string) {
 		base = strings.TrimSuffix(base, ".mpp.yml")
 		sanitized := common.SanitizeBuildName(base)
 		*h.opts.BuildName = sanitized
-		fmt.Printf("Auto-generated build name: %s\n", *h.opts.BuildName)
+		clilog.Infof("Auto-generated build name: %s\n", *h.opts.BuildName)
 	} else if err := common.ValidateBuildName(*h.opts.BuildName); err != nil {
 		h.handleError(err)
 		return
@@ -799,7 +802,7 @@ func (h *Handler) RunBuildDev(cmd *cobra.Command, args []string) {
 		h.handleError(err)
 		return
 	}
-	fmt.Printf("Build %s accepted: %s - %s\n", resp.Name, resp.Phase, resp.Message)
+	clilog.Infof("Build %s accepted: %s - %s\n", resp.Name, resp.Phase, resp.Message)
 	h.displayBuildLogsCommand(resp.Name)
 
 	if len(localRefs) > 0 {
@@ -830,7 +833,7 @@ func (h *Handler) handleFileUploads(
 		}
 	}
 
-	fmt.Println("Waiting for upload server to be ready...")
+	clilog.Infoln("Waiting for upload server to be ready...")
 	readyCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
 	for {
@@ -883,7 +886,7 @@ func (h *Handler) handleFileUploads(
 				strings.Contains(lower, "service unavailable") ||
 				strings.Contains(lower, "upload pod not ready")
 			if isServiceUnavailable {
-				fmt.Println("Upload server not ready yet. Retrying...")
+				clilog.Infoln("Upload server not ready yet. Retrying...")
 				time.Sleep(5 * time.Second)
 				continue
 			}
@@ -891,7 +894,7 @@ func (h *Handler) handleFileUploads(
 		}
 		break
 	}
-	fmt.Println("Local files uploaded. Build will proceed.")
+	clilog.Infoln("Local files uploaded. Build will proceed.")
 	return nil
 }
 
@@ -926,5 +929,5 @@ func (h *Handler) runBuildAction(buildName, verb string, action func(context.Con
 		return
 	}
 
-	fmt.Printf("Build %q %s\n", buildName, verb)
+	clilog.Infof("Build %q %s\n", buildName, verb)
 }

--- a/cmd/caib/buildcmd/flash_feedback.go
+++ b/cmd/caib/buildcmd/flash_feedback.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	buildapitypes "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi"
 	"github.com/fatih/color"
 )
@@ -33,6 +34,9 @@ func hasUnresolvedFlashImagePlaceholder(cmd string) bool {
 
 // displayFlashInstructions shows flash instructions when flash is not executed or fails.
 func (h *Handler) displayFlashInstructions(st *buildapitypes.BuildResponse, isFailure bool) {
+	if clilog.IsQuiet() {
+		return
+	}
 	if st.Jumpstarter == nil || !st.Jumpstarter.Available {
 		return
 	}

--- a/cmd/caib/buildcmd/logs.go
+++ b/cmd/caib/buildcmd/logs.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	common "github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/common"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/logstream"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/ui"
@@ -22,7 +23,7 @@ import (
 
 //nolint:gocyclo // Complex state machine for build progress tracking with log streaming.
 func (h *Handler) waitForBuildCompletion(ctx context.Context, api *buildapiclient.Client, name string) error {
-	fmt.Println("Waiting for build to complete...")
+	clilog.Infoln("Waiting for build to complete...")
 	timeoutCtx, cancel := context.WithTimeout(ctx, time.Duration(*h.opts.Timeout)*time.Minute)
 	defer cancel()
 	ticker := time.NewTicker(5 * time.Second)
@@ -64,11 +65,11 @@ func (h *Handler) waitForBuildCompletion(ctx context.Context, api *buildapiclien
 			st, err := api.GetBuild(reqCtx, name)
 			cancelReq()
 			if err != nil {
-				fmt.Printf("status check failed: %v\n", err)
+				fmt.Fprintf(os.Stderr, "status check failed: %v\n", err)
 				continue
 			}
 
-			if !*h.opts.FollowLogs && !streamState.Active {
+			if !clilog.IsQuiet() && !*h.opts.FollowLogs && !streamState.Active {
 				progressCtx, progressCancel := context.WithTimeout(timeoutCtx, 10*time.Second)
 				progress, _ := api.GetBuildProgress(progressCtx, name)
 				progressCancel()
@@ -84,7 +85,7 @@ func (h *Handler) waitForBuildCompletion(ctx context.Context, api *buildapiclien
 				pb.Render(displayPhase, step)
 			} else if !streamState.Active && (!userFollowRequested || !streamState.CanRetry(maxLogRetries)) {
 				if st.Phase != lastPhase || st.Message != lastMessage {
-					fmt.Printf("status: %s - %s\n", st.Phase, st.Message)
+					clilog.Infof("status: %s - %s\n", st.Phase, st.Message)
 					lastPhase = st.Phase
 					lastMessage = st.Message
 				}
@@ -93,70 +94,45 @@ func (h *Handler) waitForBuildCompletion(ctx context.Context, api *buildapiclien
 			if st.Phase == phaseCompleted {
 				pb.Complete()
 				flashWasExecuted := strings.Contains(strings.ToLower(st.Message), "flash")
-				if flashWasExecuted {
-					bannerColor := func(a ...any) string { return fmt.Sprint(a...) }
-					infoColor := func(a ...any) string { return fmt.Sprint(a...) }
-					commandColor := func(a ...any) string { return fmt.Sprint(a...) }
-					if h.supportsColorOutput() {
-						bannerColor = color.New(color.FgHiGreen, color.Bold).SprintFunc()
-						infoColor = color.New(color.FgHiWhite).SprintFunc()
-						commandColor = color.New(color.FgHiYellow, color.Bold).SprintFunc()
-					}
 
-					divider := strings.Repeat("=", 50)
-					fmt.Println("\n" + bannerColor(divider))
-					fmt.Println(bannerColor("Build and flash completed successfully!"))
-					fmt.Println(bannerColor(divider))
-					fmt.Println("\n" + infoColor("The device has been flashed and a lease has been acquired."))
-
-					leaseID := ""
-					if st.Jumpstarter != nil && st.Jumpstarter.LeaseID != "" {
-						leaseID = st.Jumpstarter.LeaseID
-					} else if streamState.LeaseID != "" {
-						leaseID = streamState.LeaseID
+				leaseID := ""
+				if st.Jumpstarter != nil && st.Jumpstarter.LeaseID != "" {
+					leaseID = st.Jumpstarter.LeaseID
+				} else if streamState.LeaseID != "" {
+					leaseID = streamState.LeaseID
+				}
+				if leaseID != "" && h.opts.Workspace != nil && *h.opts.Workspace != "" {
+					leaseCtx, cancelLease := context.WithTimeout(ctx, 10*time.Second)
+					leaseErr := api.SetWorkspaceLease(leaseCtx, *h.opts.Workspace, leaseID)
+					cancelLease()
+					if leaseErr != nil {
+						fmt.Fprintf(os.Stderr, "Warning: failed to update workspace lease: %v\n", leaseErr)
 					}
-					if leaseID != "" {
-						// Update workspace lease if --workspace was specified
-						if h.opts.Workspace != nil && *h.opts.Workspace != "" {
-							leaseCtx, cancelLease := context.WithTimeout(ctx, 10*time.Second)
-							leaseErr := api.SetWorkspaceLease(leaseCtx, *h.opts.Workspace, leaseID)
-							cancelLease()
-							if leaseErr != nil {
-								fmt.Printf("\nWarning: failed to update workspace lease: %v\n", leaseErr)
-							}
-						}
-						fmt.Printf("\n%s %s\n", infoColor("Lease ID:"), commandColor(leaseID))
-						fmt.Printf("\n%s\n", infoColor("To access the device:"))
-						fmt.Printf("  %s\n", commandColor(fmt.Sprintf("jmp shell --lease %s", leaseID)))
-						fmt.Printf("\n%s\n", infoColor("To release the lease when done:"))
-						fmt.Printf("  %s\n", commandColor(fmt.Sprintf("jmp delete leases %s", leaseID)))
+				}
+
+				if !clilog.IsQuiet() {
+					if flashWasExecuted {
+						h.displayFlashCompletionBanner(leaseID)
 					} else {
-						fmt.Println(infoColor("Check the logs above for lease details, or use:"))
-						fmt.Printf("  %s\n", commandColor("jmp list leases"))
-						fmt.Printf("\n%s\n", infoColor("To access the device:"))
-						fmt.Printf("  %s\n", commandColor("jmp shell --lease <lease-id>"))
-						fmt.Printf("\n%s\n", infoColor("To release the lease when done:"))
-						fmt.Printf("  %s\n", commandColor("jmp delete leases <lease-id>"))
+						fmt.Println("Build completed successfully!")
+						if *h.opts.FlashAfterBuild {
+							fmt.Println("\nWarning: --flash was requested but flash was not executed.")
+							fmt.Println("This may be because no Jumpstarter target mapping exists for this target.")
+							fmt.Println("Check OperatorConfig for JumpstarterTargetMappings configuration.")
+						}
+						h.displayFlashInstructions(st, false)
 					}
-				} else {
-					fmt.Println("Build completed successfully!")
-					if *h.opts.FlashAfterBuild {
-						fmt.Println("\nWarning: --flash was requested but flash was not executed.")
-						fmt.Println("This may be because no Jumpstarter target mapping exists for this target.")
-						fmt.Println("Check OperatorConfig for JumpstarterTargetMappings configuration.")
-					}
-					h.displayFlashInstructions(st, false)
 				}
 				return nil
 			}
 			if st.Phase == phaseCancelled {
 				pb.Clear()
-				fmt.Println("Build was cancelled.")
+				fmt.Fprintln(os.Stderr, "Build was cancelled.")
 				return fmt.Errorf("build cancelled")
 			}
 			if st.Phase == automotivev1alpha1.ImageBuildPhaseExpired {
 				pb.Clear()
-				fmt.Printf("Build expired: %s\n", st.Message)
+				fmt.Fprintf(os.Stderr, "Build expired: %s\n", st.Message)
 				return fmt.Errorf("build expired")
 			}
 			if st.Phase == phaseFailed {
@@ -191,7 +167,7 @@ func (h *Handler) waitForBuildCompletion(ctx context.Context, api *buildapiclien
 			if st.Phase == phasePending {
 				streamState.Reset()
 				if userFollowRequested && !pendingWarningShown {
-					fmt.Println("Waiting for build to start before streaming logs...")
+					clilog.Infoln("Waiting for build to start before streaming logs...")
 					pendingWarningShown = true
 				}
 				continue
@@ -199,7 +175,7 @@ func (h *Handler) waitForBuildCompletion(ctx context.Context, api *buildapiclien
 
 			if isBuildActive(st.Phase) {
 				if streamState.RetryCount == 0 {
-					fmt.Println("Build is active. Attempting to stream logs...")
+					clilog.Infoln("Build is active. Attempting to stream logs...")
 					pendingWarningShown = false
 				}
 
@@ -207,7 +183,7 @@ func (h *Handler) waitForBuildCompletion(ctx context.Context, api *buildapiclien
 					streamState.RetryCount++
 					if !streamState.CanRetry(maxLogRetries) && !retryLimitWarningShown {
 						msg := "Log streaming failed after %d attempts (~2 minutes). Falling back to status updates only.\n"
-						fmt.Printf(msg, maxLogRetries)
+						clilog.Infof(msg, maxLogRetries)
 						retryLimitWarningShown = true
 					}
 				} else {
@@ -260,6 +236,38 @@ func (h *Handler) buildLogURL(buildName string, startTime time.Time) string {
 	return logURL
 }
 
+func (h *Handler) displayFlashCompletionBanner(leaseID string) {
+	bannerColor := func(a ...any) string { return fmt.Sprint(a...) }
+	infoColor := func(a ...any) string { return fmt.Sprint(a...) }
+	commandColor := func(a ...any) string { return fmt.Sprint(a...) }
+	if h.supportsColorOutput() {
+		bannerColor = color.New(color.FgHiGreen, color.Bold).SprintFunc()
+		infoColor = color.New(color.FgHiWhite).SprintFunc()
+		commandColor = color.New(color.FgHiYellow, color.Bold).SprintFunc()
+	}
+
+	divider := strings.Repeat("=", 50)
+	fmt.Println("\n" + bannerColor(divider))
+	fmt.Println(bannerColor("Build and flash completed successfully!"))
+	fmt.Println(bannerColor(divider))
+	fmt.Println("\n" + infoColor("The device has been flashed and a lease has been acquired."))
+
+	if leaseID != "" {
+		fmt.Printf("\n%s %s\n", infoColor("Lease ID:"), commandColor(leaseID))
+		fmt.Printf("\n%s\n", infoColor("To access the device:"))
+		fmt.Printf("  %s\n", commandColor(fmt.Sprintf("jmp shell --lease %s", leaseID)))
+		fmt.Printf("\n%s\n", infoColor("To release the lease when done:"))
+		fmt.Printf("  %s\n", commandColor(fmt.Sprintf("jmp delete leases %s", leaseID)))
+	} else {
+		fmt.Println(infoColor("Check the logs above for lease details, or use:"))
+		fmt.Printf("  %s\n", commandColor("jmp list leases"))
+		fmt.Printf("\n%s\n", infoColor("To access the device:"))
+		fmt.Printf("  %s\n", commandColor("jmp shell --lease <lease-id>"))
+		fmt.Printf("\n%s\n", infoColor("To release the lease when done:"))
+		fmt.Printf("  %s\n", commandColor("jmp delete leases <lease-id>"))
+	}
+}
+
 // RunLogs handles `caib image logs`.
 func (h *Handler) RunLogs(_ *cobra.Command, args []string) {
 	ctx := context.Background()
@@ -281,7 +289,7 @@ func (h *Handler) RunLogs(_ *cobra.Command, args []string) {
 		h.handleError(fmt.Errorf("failed to get build: %w", err))
 		return
 	}
-	fmt.Printf("Build %s: %s - %s\n", name, st.Phase, st.Message)
+	clilog.Infof("Build %s: %s - %s\n", name, st.Phase, st.Message)
 
 	if isTerminalPhase(st.Phase) {
 		logTransport := &http.Transport{
@@ -299,7 +307,7 @@ func (h *Handler) RunLogs(_ *cobra.Command, args []string) {
 		}
 		streamState := &logstream.State{}
 		if err := h.tryLogStreaming(ctx, logClient, name, streamState); err != nil {
-			fmt.Printf("Could not retrieve logs (pods may have been cleaned up). Use 'caib image show %s' for details.\n", name)
+			clilog.Infof("Could not retrieve logs (pods may have been cleaned up). Use 'caib image show %s' for details.\n", name)
 		}
 		return
 	}

--- a/cmd/caib/catalog/add.go
+++ b/cmd/caib/catalog/add.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/config"
 	"github.com/spf13/cobra"
 )
@@ -112,8 +113,8 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		ns = defaultNamespace
 	}
 
-	fmt.Printf("Adding image to catalog...\n")
-	fmt.Printf("✓ Validating registry URL\n")
+	clilog.Infof("Adding image to catalog...\n")
+	clilog.Infof("✓ Validating registry URL\n")
 
 	reqBody := createRequest{
 		Name:           name,
@@ -173,17 +174,17 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	fmt.Printf("✓ Creating catalog image %q\n", name)
-	fmt.Println("✓ Added successfully")
-	fmt.Println()
-	fmt.Printf("Catalog Image: %s\n", result.Name)
-	fmt.Printf("Registry URL:  %s\n", result.RegistryURL)
-	fmt.Printf("Architecture:  %s\n", result.Architecture)
-	fmt.Printf("Distro:        %s\n", result.Distro)
+	clilog.Infof("✓ Creating catalog image %q\n", name)
+	clilog.Infoln("✓ Added successfully")
+	clilog.Infoln()
+	clilog.Infof("Catalog Image: %s\n", result.Name)
+	clilog.Infof("Registry URL:  %s\n", result.RegistryURL)
+	clilog.Infof("Architecture:  %s\n", result.Architecture)
+	clilog.Infof("Distro:        %s\n", result.Distro)
 	if len(result.Targets) > 0 {
-		fmt.Printf("Target:        %s\n", result.Targets[0].Name)
+		clilog.Infof("Target:        %s\n", result.Targets[0].Name)
 	}
-	fmt.Printf("Status:        %s\n", result.Phase)
+	clilog.Infof("Status:        %s\n", result.Phase)
 
 	return nil
 }

--- a/cmd/caib/catalog/publish.go
+++ b/cmd/caib/catalog/publish.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/config"
 	"github.com/spf13/cobra"
 )
@@ -79,7 +80,7 @@ func runPublish(cmd *cobra.Command, args []string) error {
 		ns = defaultNamespace
 	}
 
-	fmt.Printf("Publishing ImageBuild %q to catalog...\n", imageBuildName)
+	clilog.Infof("Publishing ImageBuild %q to catalog...\n", imageBuildName)
 
 	reqBody := publishRequest{
 		ImageBuildName:      imageBuildName,
@@ -130,16 +131,16 @@ func runPublish(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	fmt.Println("✓ Published successfully")
-	fmt.Println()
-	fmt.Printf("Catalog Image: %s\n", result.Name)
-	fmt.Printf("Registry URL:  %s\n", result.RegistryURL)
-	fmt.Printf("Architecture:  %s\n", result.Architecture)
-	fmt.Printf("Distro:        %s\n", result.Distro)
+	clilog.Infoln("✓ Published successfully")
+	clilog.Infoln()
+	clilog.Infof("Catalog Image: %s\n", result.Name)
+	clilog.Infof("Registry URL:  %s\n", result.RegistryURL)
+	clilog.Infof("Architecture:  %s\n", result.Architecture)
+	clilog.Infof("Distro:        %s\n", result.Distro)
 	if len(result.Targets) > 0 {
-		fmt.Printf("Target:        %s\n", result.Targets[0].Name)
+		clilog.Infof("Target:        %s\n", result.Targets[0].Name)
 	}
-	fmt.Printf("Status:        %s\n", result.Phase)
+	clilog.Infof("Status:        %s\n", result.Phase)
 
 	return nil
 }

--- a/cmd/caib/catalog/remove.go
+++ b/cmd/caib/catalog/remove.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/config"
 	"github.com/spf13/cobra"
 )
@@ -70,13 +71,13 @@ func runRemove(cmd *cobra.Command, args []string) error {
 
 	// Confirm deletion
 	if !removeForce {
-		fmt.Printf("Removing catalog image %q...\n", name)
+		clilog.Infof("Removing catalog image %q...\n", name)
 		fmt.Print("Are you sure you want to remove this image from the catalog? (y/N): ")
 		reader := bufio.NewReader(os.Stdin)
 		response, _ := reader.ReadString('\n')
 		response = strings.TrimSpace(strings.ToLower(response))
 		if response != "y" && response != "yes" {
-			fmt.Println("Cancelled")
+			clilog.Infoln("Cancelled")
 			return nil
 		}
 	}
@@ -111,6 +112,6 @@ func runRemove(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
-	fmt.Println("✓ Removed successfully")
+	clilog.Infoln("✓ Removed successfully")
 	return nil
 }

--- a/cmd/caib/catalog/verify.go
+++ b/cmd/caib/catalog/verify.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/config"
 	"github.com/spf13/cobra"
 )
@@ -72,7 +73,7 @@ func runVerify(cmd *cobra.Command, args []string) error {
 		ns = defaultNamespace
 	}
 
-	fmt.Printf("Verifying catalog image %q...\n", name)
+	clilog.Infof("Verifying catalog image %q...\n", name)
 
 	reqURL := fmt.Sprintf("%s/v1/catalog/images/%s/verify?namespace=%s", server, name, ns)
 	req, err := http.NewRequest(http.MethodPost, reqURL, nil)
@@ -111,9 +112,9 @@ func runVerify(cmd *cobra.Command, args []string) error {
 	}
 
 	if result.Triggered {
-		fmt.Println("✓ Verification triggered successfully")
+		clilog.Infoln("✓ Verification triggered successfully")
 	} else {
-		fmt.Printf("Note: %s\n", result.Message)
+		clilog.Infof("Note: %s\n", result.Message)
 	}
 
 	// Optionally get updated status
@@ -134,16 +135,16 @@ func runVerify(cmd *cobra.Command, args []string) error {
 				getBody, _ := io.ReadAll(getResp.Body)
 				var img CatalogImageResponse
 				if json.Unmarshal(getBody, &img) == nil {
-					fmt.Println()
-					fmt.Printf("Registry URL:  %s\n", img.RegistryURL)
-					fmt.Printf("Status:        %s\n", img.Phase)
+					clilog.Infoln()
+					clilog.Infof("Registry URL:  %s\n", img.RegistryURL)
+					clilog.Infof("Status:        %s\n", img.Phase)
 					if img.SizeBytes > 0 {
 						sizeMB := float64(img.SizeBytes) / (1024 * 1024)
 						sizeGB := float64(img.SizeBytes) / (1024 * 1024 * 1024)
 						if sizeGB >= 1 {
-							fmt.Printf("Size:          %.1f GB\n", sizeGB)
+							clilog.Infof("Size:          %.1f GB\n", sizeGB)
 						} else {
-							fmt.Printf("Size:          %.1f MB\n", sizeMB)
+							clilog.Infof("Size:          %.1f MB\n", sizeMB)
 						}
 					}
 				}

--- a/cmd/caib/clilog/clilog.go
+++ b/cmd/caib/clilog/clilog.go
@@ -1,0 +1,28 @@
+// Package clilog provides centralized output control for CLI informational messages.
+// When quiet mode is enabled, informational output is suppressed while errors
+// (stderr) and structured data output (json/yaml/table) remain visible.
+package clilog
+
+import "fmt"
+
+var quiet bool
+
+// SetQuiet enables or disables quiet mode globally.
+func SetQuiet(q bool) { quiet = q }
+
+// IsQuiet returns whether quiet mode is currently enabled.
+func IsQuiet() bool { return quiet }
+
+// Infof prints a formatted informational message to stdout unless quiet mode is enabled.
+func Infof(format string, a ...any) {
+	if !quiet {
+		fmt.Printf(format, a...)
+	}
+}
+
+// Infoln prints an informational message line to stdout unless quiet mode is enabled.
+func Infoln(a ...any) {
+	if !quiet {
+		fmt.Println(a...)
+	}
+}

--- a/cmd/caib/clilog/clilog_test.go
+++ b/cmd/caib/clilog/clilog_test.go
@@ -1,0 +1,73 @@
+package clilog
+
+import (
+	"bytes"
+	"os"
+	"testing"
+)
+
+func TestSetQuietAndIsQuiet(t *testing.T) {
+	SetQuiet(false)
+	if IsQuiet() {
+		t.Error("expected IsQuiet() to be false")
+	}
+	SetQuiet(true)
+	if !IsQuiet() {
+		t.Error("expected IsQuiet() to be true")
+	}
+	SetQuiet(false)
+}
+
+func captureStdout(fn func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	fn()
+	_ = w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	return buf.String()
+}
+
+func TestInfofOutputWhenNotQuiet(t *testing.T) {
+	SetQuiet(false)
+	out := captureStdout(func() {
+		Infof("hello %s\n", "world")
+	})
+	if out != "hello world\n" {
+		t.Errorf("expected 'hello world\\n', got %q", out)
+	}
+}
+
+func TestInfofSuppressedWhenQuiet(t *testing.T) {
+	SetQuiet(true)
+	defer SetQuiet(false)
+	out := captureStdout(func() {
+		Infof("should not appear")
+	})
+	if out != "" {
+		t.Errorf("expected empty output, got %q", out)
+	}
+}
+
+func TestInfolnOutputWhenNotQuiet(t *testing.T) {
+	SetQuiet(false)
+	out := captureStdout(func() {
+		Infoln("hello", "world")
+	})
+	if out != "hello world\n" {
+		t.Errorf("expected 'hello world\\n', got %q", out)
+	}
+}
+
+func TestInfolnSuppressedWhenQuiet(t *testing.T) {
+	SetQuiet(true)
+	defer SetQuiet(false)
+	out := captureStdout(func() {
+		Infoln("should not appear")
+	})
+	if out != "" {
+		t.Errorf("expected empty output, got %q", out)
+	}
+}

--- a/cmd/caib/container/build.go
+++ b/cmd/caib/container/build.go
@@ -34,6 +34,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/config"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/registryauth"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/ui"
@@ -135,8 +136,8 @@ func runBuildContainer(_ *cobra.Command, args []string) {
 	}
 
 	absContextDir, containerfile := resolveContainerBuildContext(contextDir)
-	fmt.Printf("Context: %s\n", absContextDir)
-	fmt.Printf("Containerfile: %s\n", filepath.Join(absContextDir, containerfile))
+	clilog.Infof("Context: %s\n", absContextDir)
+	clilog.Infof("Containerfile: %s\n", filepath.Join(absContextDir, containerfile))
 
 	if serverURL == "" {
 		handleError(fmt.Errorf("server URL required (use --server, CAIB_SERVER, run 'caib login <server-url>' or 'jmp login <endpoint>')"))
@@ -152,7 +153,7 @@ func runBuildContainer(_ *cobra.Command, args []string) {
 	if buildName == "" {
 		dirName := filepath.Base(absContextDir)
 		buildName = fmt.Sprintf("cb-%s-%s", sanitizeBuildName(dirName), uuid.New().String()[:5])
-		fmt.Printf("Auto-generated build name: %s\n", buildName)
+		clilog.Infof("Auto-generated build name: %s\n", buildName)
 	} else {
 		validateBuildName(buildName)
 	}
@@ -176,9 +177,9 @@ func runBuildContainer(_ *cobra.Command, args []string) {
 
 	// Create the container build
 	if useInternalRegistry {
-		fmt.Println("Using OpenShift internal registry")
+		clilog.Infoln("Using OpenShift internal registry")
 	}
-	fmt.Println("Creating container build...")
+	clilog.Infoln("Creating container build...")
 	var createResp *buildapitypes.ContainerBuildResponse
 	err := executeWithReauth(serverURL, &authToken, func(client *buildapiclient.Client) error {
 		resp, cerr := client.CreateContainerBuild(ctx, buildapitypes.ContainerBuildRequest{
@@ -203,21 +204,22 @@ func runBuildContainer(_ *cobra.Command, args []string) {
 	}
 
 	colorFormatter := NewColorFormatter()
-	fmt.Printf("%s %s - %s\n", colorFormatter.LabelColor("Build "+createResp.Name+" accepted:"), createResp.Phase, createResp.Message)
+	clilog.Infof("%s %s - %s\n", colorFormatter.LabelColor("Build "+createResp.Name+" accepted:"), createResp.Phase, createResp.Message)
 	if createResp.OutputImage != "" {
-		fmt.Printf("%s %s\n", colorFormatter.LabelColor("Output image:"), colorFormatter.ValueColor(createResp.OutputImage))
+		clilog.Infof("%s %s\n", colorFormatter.LabelColor("Output image:"), colorFormatter.ValueColor(createResp.OutputImage))
 	}
-	fmt.Printf("\n%s\n  %s\n\n", colorFormatter.LabelColor("View build logs:"), colorFormatter.CommandColor("caib container logs "+createResp.Name))
+	if !clilog.IsQuiet() {
+		fmt.Printf("\n%s\n  %s\n\n", colorFormatter.LabelColor("View build logs:"), colorFormatter.CommandColor("caib container logs "+createResp.Name))
+	}
 
-	// Create tarball and upload
-	fmt.Printf("Packaging context directory: %s\n", absContextDir)
+	clilog.Infof("Packaging context directory: %s\n", absContextDir)
 	tarball, err := createContextTarball(absContextDir)
 	if err != nil {
 		handleError(fmt.Errorf("failed to create context tarball: %w", err))
 	}
 	tarballPath := tarball.Name()
 	if info, err := tarball.Stat(); err == nil {
-		fmt.Printf("Context tarball: %s (%.1f MB)\n", tarballPath, float64(info.Size())/(1024*1024))
+		clilog.Infof("Context tarball: %s (%.1f MB)\n", tarballPath, float64(info.Size())/(1024*1024))
 	}
 	defer func() {
 		if err := tarball.Close(); err != nil {
@@ -439,8 +441,24 @@ func waitForContainerBuildCompletion(ctx context.Context, name string, pb *ui.Pr
 	}
 }
 
-// displayContainerBuildResult shows the final build result.
 func displayContainerBuildResult(finalStatus *buildapitypes.ContainerBuildResponse) {
+	if clilog.IsQuiet() {
+		if finalStatus.Phase == phaseFailed {
+			handleError(fmt.Errorf("build failed"))
+		}
+		if finalStatus.OutputImage != "" {
+			fmt.Println(finalStatus.OutputImage)
+		}
+		if finalStatus.RegistryToken != "" {
+			credsFile, err := writeRegistryCredentialsFile(finalStatus.RegistryToken)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: failed to write registry credentials file: %v\n", err)
+			} else {
+				fmt.Println(credsFile)
+			}
+		}
+		return
+	}
 	colorFormatter := NewColorFormatter()
 
 	fmt.Printf("\n%s %s\n", colorFormatter.LabelColor("Build "+finalStatus.Name+":"), finalStatus.Phase)

--- a/cmd/caib/container/logs.go
+++ b/cmd/caib/container/logs.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/config"
 )
 
@@ -84,7 +85,7 @@ func runContainerLogs(_ *cobra.Command, args []string) {
 	if err != nil {
 		handleError(fmt.Errorf("failed to get container build: %w", err))
 	}
-	fmt.Printf("Build %s: %s - %s\n", name, status.Phase, status.Message)
+	clilog.Infof("Build %s: %s - %s\n", name, status.Phase, status.Message)
 
 	logTransport := &http.Transport{
 		ResponseHeaderTimeout: 30 * time.Second,
@@ -102,14 +103,14 @@ func runContainerLogs(_ *cobra.Command, args []string) {
 		defer cancel()
 		streamState := &logStreamState{}
 		if err := tryContainerLogStreaming(fetchCtx, logClient, name, streamState, false); err != nil {
-			fmt.Printf("Could not retrieve logs (pods may have been cleaned up): %v\n", err)
+			clilog.Infof("Could not retrieve logs (pods may have been cleaned up): %v\n", err)
 		}
 		return
 	}
 
 	// Build is still active — wait for logs to become available, then stream
 	if status.Phase == phasePending || status.Phase == phaseUploading {
-		fmt.Println("Waiting for build to start...")
+		clilog.Infoln("Waiting for build to start...")
 		ticker := time.NewTicker(3 * time.Second)
 		defer ticker.Stop()
 		for status.Phase == phasePending || status.Phase == phaseUploading {
@@ -119,11 +120,11 @@ func runContainerLogs(_ *cobra.Command, args []string) {
 				continue
 			}
 			if isContainerBuildTerminal(status.Phase) {
-				fmt.Printf("Build %s: %s - %s\n", name, status.Phase, status.Message)
+				clilog.Infof("Build %s: %s - %s\n", name, status.Phase, status.Message)
 				return
 			}
 		}
-		fmt.Printf("Build %s: %s - %s\n", name, status.Phase, status.Message)
+		clilog.Infof("Build %s: %s - %s\n", name, status.Phase, status.Message)
 	}
 
 	// Stream logs
@@ -239,7 +240,7 @@ func handleLogStreamError(resp *http.Response, state *logStreamState) error {
 
 	if resp.StatusCode == http.StatusServiceUnavailable || resp.StatusCode == http.StatusGatewayTimeout {
 		if !state.warningShown {
-			fmt.Printf("log stream not ready (HTTP %d). Retrying... (attempt %d/%d)\n",
+			clilog.Infof("log stream not ready (HTTP %d). Retrying... (attempt %d/%d)\n",
 				resp.StatusCode, state.retryCount+1, maxLogRetries)
 			state.warningShown = true
 		}

--- a/cmd/caib/container/utilities.go
+++ b/cmd/caib/container/utilities.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/auth"
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	buildapiclient "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi/client"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -53,7 +54,7 @@ func executeWithReauth(serverURL string, authToken *string, fn func(*buildapicli
 	}
 
 	// Auth error (401) - try re-authentication; token may be rejected, not necessarily expired
-	fmt.Println("Authentication failed (401), re-authenticating...")
+	clilog.Infoln("Authentication failed (401), re-authenticating...")
 
 	newToken, _, err := auth.GetTokenWithReauth(ctx, serverURL, *authToken, insecureSkipTLS)
 	if err != nil {
@@ -69,7 +70,7 @@ func executeWithReauth(serverURL string, authToken *string, fn func(*buildapicli
 			if err != nil {
 				return err
 			}
-			fmt.Println("Using kubeconfig token, retrying...")
+			clilog.Infoln("Using kubeconfig token, retrying...")
 			return fn(client)
 		}
 	}
@@ -79,7 +80,7 @@ func executeWithReauth(serverURL string, authToken *string, fn func(*buildapicli
 		return err
 	}
 
-	fmt.Println("Retrying request...")
+	clilog.Infoln("Retrying request...")
 	err = fn(client)
 	if err == nil {
 		return nil
@@ -95,7 +96,7 @@ func executeWithReauth(serverURL string, authToken *string, fn func(*buildapicli
 		if err != nil {
 			return err
 		}
-		fmt.Println("Attempting kubeconfig fallback...")
+		clilog.Infoln("Attempting kubeconfig fallback...")
 		return fn(client)
 	}
 
@@ -118,7 +119,7 @@ func createBuildAPIClient(serverURL string, authToken *string) (*buildapiclient.
 			oidcErr := err
 			fmt.Printf("Error: OIDC authentication failed: %v\n", oidcErr)
 			// Only try kubeconfig as last resort, but warn the user
-			fmt.Println("Attempting kubeconfig fallback (this may use a different identity)")
+			clilog.Infoln("Attempting kubeconfig fallback (this may use a different identity)")
 			if tok, kerr := loadTokenFromKubeconfig(); kerr == nil && strings.TrimSpace(tok) != "" {
 				*authToken = tok
 			} else {
@@ -129,7 +130,7 @@ func createBuildAPIClient(serverURL string, authToken *string) (*buildapiclient.
 			// OIDC succeeded
 			*authToken = token
 			if didAuth {
-				fmt.Println("OIDC authentication successful")
+				clilog.Infoln("OIDC authentication successful")
 			}
 		} else {
 			// OIDC not configured in OperatorConfig

--- a/cmd/caib/downloadcmd/download.go
+++ b/cmd/caib/downloadcmd/download.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	common "github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/common"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/registryauth"
 	buildapitypes "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi"
@@ -105,7 +106,7 @@ func (h *Handler) RunDownload(_ *cobra.Command, args []string) {
 		}
 	}
 
-	fmt.Printf("Downloading disk image from %s\n", ociRef)
+	clilog.Infof("Downloading disk image from %s\n", ociRef)
 	if err := common.PullOCIArtifact(ociRef, outputDir, registryUsername, registryPassword, insecureSkipTLS); err != nil {
 		h.handleError(fmt.Errorf("download failed: %w", err))
 		return

--- a/cmd/caib/flashcmd/flash.go
+++ b/cmd/caib/flashcmd/flash.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	common "github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/common"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/logstream"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/registryauth"
@@ -95,7 +96,7 @@ func (h *Handler) RunFlash(cmd *cobra.Command, args []string) {
 		h.handleError(err)
 		return
 	}
-	fmt.Printf("Using Jumpstarter client %q (endpoint: %s)\n", clientInfo.Name, clientInfo.Endpoint)
+	clilog.Infof("Using Jumpstarter client %q (endpoint: %s)\n", clientInfo.Name, clientInfo.Endpoint)
 
 	// Validate that either target or exporter is specified.
 	if strings.TrimSpace(*h.opts.Target) == "" && strings.TrimSpace(*h.opts.ExporterSelector) == "" {
@@ -150,7 +151,7 @@ func (h *Handler) RunFlash(cmd *cobra.Command, args []string) {
 		h.handleError(err)
 		return
 	}
-	fmt.Printf("Flash job %s accepted: %s - %s\n", resp.Name, resp.Phase, resp.Message)
+	clilog.Infof("Flash job %s accepted: %s - %s\n", resp.Name, resp.Phase, resp.Message)
 
 	if *h.opts.WaitForBuild || *h.opts.FollowLogs {
 		h.waitForFlashCompletion(ctx, api, resp.Name)
@@ -185,7 +186,7 @@ func parseLeaseDuration(duration string) (time.Duration, error) {
 
 // waitForFlashCompletion waits for a flash job to complete, optionally streaming logs.
 func (h *Handler) waitForFlashCompletion(ctx context.Context, _ *buildapiclient.Client, name string) {
-	fmt.Println("Waiting for flash to complete...")
+	clilog.Infoln("Waiting for flash to complete...")
 
 	var timeoutDuration time.Duration
 	if *h.opts.LeaseName != "" {
@@ -235,18 +236,18 @@ func (h *Handler) waitForFlashCompletion(ctx context.Context, _ *buildapiclient.
 			})
 			cancelReq()
 			if err != nil {
-				fmt.Printf("status check failed: %v\n", err)
+				fmt.Fprintf(os.Stderr, "status check failed: %v\n", err)
 				continue
 			}
 
 			if !streamState.Active && (st.Phase != lastPhase || st.Message != lastMessage) {
-				fmt.Printf("status: %s - %s\n", st.Phase, st.Message)
+				clilog.Infof("status: %s - %s\n", st.Phase, st.Message)
 				lastPhase = st.Phase
 				lastMessage = st.Message
 			}
 
 			if st.Phase == phaseCompleted {
-				fmt.Println("Flash completed successfully!")
+				clilog.Infoln("Flash completed successfully!")
 				return
 			}
 			if st.Phase == phaseFailed {
@@ -261,7 +262,7 @@ func (h *Handler) waitForFlashCompletion(ctx context.Context, _ *buildapiclient.
 			if st.Phase == phasePending {
 				streamState.Reset()
 				if !pendingWarningShown {
-					fmt.Println("Waiting for flash to start before streaming logs...")
+					clilog.Infoln("Waiting for flash to start before streaming logs...")
 					pendingWarningShown = true
 				}
 				continue
@@ -269,7 +270,7 @@ func (h *Handler) waitForFlashCompletion(ctx context.Context, _ *buildapiclient.
 
 			if st.Phase == phaseRunning {
 				if streamState.RetryCount == 0 {
-					fmt.Println("Flash is running. Attempting to stream logs...")
+					clilog.Infoln("Flash is running. Attempting to stream logs...")
 					pendingWarningShown = false
 				}
 				if err := h.tryFlashLogStreaming(timeoutCtx, logClient, name, streamState); err != nil {

--- a/cmd/caib/inspectcmd/inspect.go
+++ b/cmd/caib/inspectcmd/inspect.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	"github.com/containers/image/v5/docker"
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
@@ -453,7 +454,7 @@ func (h *Handler) downloadReferrers(ociRef, _ string, referrers []referrerInfo, 
 
 		destPath := filepath.Join(outputDir, filename)
 		pullRef := repo + "@" + ref.Digest
-		fmt.Printf("Downloading %s → %s\n", ref.ArtifactType, destPath)
+		clilog.Infof("Downloading %s → %s\n", ref.ArtifactType, destPath)
 		if err := caibcommon.PullOCIArtifact(pullRef, destPath, username, password, insecure, authFile); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to download %s: %v\n", filename, err)
 		}

--- a/cmd/caib/login.go
+++ b/cmd/caib/login.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/auth"
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/config"
 	"github.com/spf13/cobra"
 )
@@ -93,7 +94,7 @@ func runLogin(_ *cobra.Command, args []string) {
 	if err := config.SaveServerURL(server); err != nil {
 		handleError(fmt.Errorf("failed to save server URL: %w", err))
 	}
-	fmt.Printf("Server saved: %s\n", server)
+	clilog.Infof("Server saved: %s\n", server)
 
 	ctx := context.Background()
 	token, didAuth, err := auth.GetTokenWithReauth(ctx, server, "", insecureSkipTLS)
@@ -102,8 +103,8 @@ func runLogin(_ *cobra.Command, args []string) {
 		return
 	}
 	if token != "" && didAuth {
-		fmt.Println("OIDC authentication successful. Token cached for subsequent commands.")
+		clilog.Infoln("OIDC authentication successful. Token cached for subsequent commands.")
 	} else if token != "" {
-		fmt.Println("Using existing or kubeconfig token. You can run build/list/disk commands without --server.")
+		clilog.Infoln("Using existing or kubeconfig token. You can run build/list/disk commands without --server.")
 	}
 }

--- a/cmd/caib/logstream/logstream.go
+++ b/cmd/caib/logstream/logstream.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 )
 
 // State stores reconnect and stream progress state.
@@ -47,7 +49,7 @@ func StreamLogsToStdout(body io.Reader, state *State, captureLeaseID bool) error
 	firstStream := state.StartTime.IsZero()
 	if firstStream {
 		state.StartTime = time.Now()
-		fmt.Println("Streaming logs...")
+		clilog.Infoln("Streaming logs...")
 	}
 	state.Active = true
 	state.Reset()

--- a/cmd/caib/main.go
+++ b/cmd/caib/main.go
@@ -71,6 +71,9 @@ var (
 	// Build TTL
 	buildTTL string
 
+	// Output options
+	quiet bool
+
 	// TLS options
 	insecureSkipTLS bool
 

--- a/cmd/caib/main_test.go
+++ b/cmd/caib/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"testing"
 
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	buildapitypes "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi"
 	"github.com/spf13/cobra"
 )
@@ -328,5 +329,52 @@ func TestApplyTargetDefaults_MappingWithEmptyArchDoesNotOverride(t *testing.T) {
 
 	if req.Architecture != buildapitypes.Architecture(archAMD64) {
 		t.Errorf("expected architecture to remain amd64 when mapping has no arch, got %s", req.Architecture)
+	}
+}
+
+func TestQuietFlagRegistered(t *testing.T) {
+	rootCmd := newRootCmd()
+	flag := rootCmd.PersistentFlags().Lookup("quiet")
+	if flag == nil {
+		t.Fatal("expected --quiet persistent flag on root command")
+	}
+	if flag.Shorthand != "q" {
+		t.Errorf("expected shorthand 'q', got %q", flag.Shorthand)
+	}
+	if flag.DefValue != "false" {
+		t.Errorf("expected default value 'false', got %q", flag.DefValue)
+	}
+}
+
+func TestQuietFlagActivatesClilog(t *testing.T) {
+	clilog.SetQuiet(false)
+	t.Cleanup(func() { clilog.SetQuiet(false) })
+
+	rootCmd := newRootCmd()
+	noop := &cobra.Command{Use: "noop", RunE: func(_ *cobra.Command, _ []string) error { return nil }}
+	rootCmd.AddCommand(noop)
+	rootCmd.SetArgs([]string{"-q", "noop"})
+	_ = rootCmd.Execute()
+
+	if !clilog.IsQuiet() {
+		t.Error("expected clilog.IsQuiet() == true after -q flag parsed")
+	}
+}
+
+func TestQuietFlagWorksOnImageSubcommand(t *testing.T) {
+	clilog.SetQuiet(false)
+	t.Cleanup(func() { clilog.SetQuiet(false) })
+
+	rootCmd := newRootCmd()
+	// Add a noop under image to test that cobra.OnInitialize fires
+	// even when image's PersistentPreRunE overrides root's
+	imageCmd, _, _ := rootCmd.Find([]string{"image"})
+	noop := &cobra.Command{Use: "noop", RunE: func(_ *cobra.Command, _ []string) error { return nil }}
+	imageCmd.AddCommand(noop)
+	rootCmd.SetArgs([]string{"image", "noop", "-q"})
+	_ = rootCmd.Execute()
+
+	if !clilog.IsQuiet() {
+		t.Error("expected clilog.IsQuiet() == true for 'image noop -q' (child PersistentPreRunE must not override quiet)")
 	}
 }

--- a/cmd/caib/registryauth/credentials.go
+++ b/cmd/caib/registryauth/credentials.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	buildapitypes "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi"
 )
 
@@ -19,11 +20,6 @@ func ExtractRegistryCredentials(primaryRef, secondaryRef string) (string, string
 	}
 	if ref == "" {
 		return os.Getenv("REGISTRY_URL"), username, password
-	}
-
-	if username == "" || password == "" {
-		fmt.Fprintln(os.Stderr, "Warning: No registry credentials provided via environment variables.")
-		fmt.Fprintln(os.Stderr, "Will attempt to use local auth.json files as fallback.")
 	}
 
 	parts := strings.SplitN(ref, "/", 2)
@@ -57,7 +53,7 @@ func ResolveRegistryCredentials(
 		if err != nil {
 			return nil, err
 		}
-		fmt.Printf("Using registry credentials from auth file: %s\n", sourcePath)
+		clilog.Infof("Using registry credentials from auth file: %s\n", sourcePath)
 		return &buildapitypes.RegistryCredentials{
 			Enabled:      true,
 			AuthType:     "docker-config",
@@ -94,7 +90,7 @@ func ResolveRegistryCredentials(
 		return nil, nil
 	}
 
-	fmt.Printf("Using registry credentials from auth file: %s\n", sourcePath)
+	clilog.Infof("Using registry credentials from auth file: %s\n", sourcePath)
 	return &buildapitypes.RegistryCredentials{
 		Enabled:      true,
 		AuthType:     "docker-config",

--- a/cmd/caib/root.go
+++ b/cmd/caib/root.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/authcmd"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/catalog"
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/container"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/image"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/workspace"
@@ -65,6 +66,18 @@ func newRootCmd() *cobra.Command {
 		"table",
 		"output format: table, json, yaml",
 	)
+	rootCmd.PersistentFlags().BoolVarP(
+		&quiet,
+		"quiet",
+		"q",
+		false,
+		"suppress informational output (errors and structured data are still shown)",
+	)
+
+	cobra.OnInitialize(func() {
+		clilog.SetQuiet(quiet)
+	})
+
 	state := newRuntimeState()
 	handlers := state.newHandlers()
 

--- a/cmd/caib/sealedcmd/sealed.go
+++ b/cmd/caib/sealedcmd/sealed.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	common "github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/common"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/registryauth"
 	buildapitypes "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi"
@@ -189,7 +190,7 @@ func (h *Handler) sealedRunViaAPI(op buildapitypes.SealedOperation, inputRef, ou
 		h.handleError(err)
 		return
 	}
-	fmt.Printf("Job %s accepted: %s - %s\n", resp.Name, resp.Phase, resp.Message)
+	clilog.Infof("Job %s accepted: %s - %s\n", resp.Name, resp.Phase, resp.Message)
 
 	if *h.opts.WaitForBuild || *h.opts.FollowLogs {
 		h.sealedWaitForCompletion(ctx, api, op, resp.Name)
@@ -202,7 +203,7 @@ func (h *Handler) sealedWaitForCompletion(
 	op buildapitypes.SealedOperation,
 	name string,
 ) {
-	fmt.Println("Waiting for job to complete...")
+	clilog.Infoln("Waiting for job to complete...")
 	sealedTimeout := time.Duration(*h.opts.Timeout) * time.Minute
 	waitCtx, cancel := context.WithTimeout(ctx, sealedTimeout)
 	defer cancel()
@@ -230,19 +231,19 @@ func (h *Handler) sealedWaitForCompletion(
 					h.handleError(fmt.Errorf("timed out after %v", sealedTimeout))
 					return
 				}
-				fmt.Printf("status check failed: %v\n", err)
+				fmt.Fprintf(os.Stderr, "status check failed: %v\n", err)
 				continue
 			}
 
 			if st.Phase != lastPhase {
-				fmt.Printf("status: %s - %s\n", st.Phase, st.Message)
+				clilog.Infof("status: %s - %s\n", st.Phase, st.Message)
 				lastPhase = st.Phase
 			}
 
 			if st.Phase == phaseCompleted {
-				fmt.Println("Job completed successfully.")
+				clilog.Infoln("Job completed successfully.")
 				if st.OutputRef != "" {
-					fmt.Printf("Output: %s\n", st.OutputRef)
+					clilog.Infof("Output: %s\n", st.OutputRef)
 				}
 				return
 			}
@@ -259,13 +260,13 @@ func (h *Handler) sealedWaitForCompletion(
 					if streamErr != nil {
 						logRetries++
 						if logRetries == 1 {
-							fmt.Printf("Waiting for logs... (attempt %d/%d)\n", logRetries, maxSealedLogRetries)
+							clilog.Infof("Waiting for logs... (attempt %d/%d)\n", logRetries, maxSealedLogRetries)
 						}
 					} else {
 						logStreaming = true
 					}
 				} else if !logRetryWarningShown {
-					fmt.Printf("Log streaming failed after %d attempts. Falling back to status updates.\n", maxSealedLogRetries)
+					clilog.Infof("Log streaming failed after %d attempts. Falling back to status updates.\n", maxSealedLogRetries)
 					logRetryWarningShown = true
 					logStreaming = false
 					*h.opts.FollowLogs = false
@@ -314,7 +315,7 @@ func (h *Handler) sealedStreamLogs(ctx context.Context, op buildapitypes.SealedO
 		return fmt.Errorf("log stream error: HTTP %d", resp.StatusCode)
 	}
 
-	fmt.Println("Streaming logs...")
+	clilog.Infoln("Streaming logs...")
 	scanner := bufio.NewScanner(resp.Body)
 	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {

--- a/cmd/caib/ui/progress.go
+++ b/cmd/caib/ui/progress.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	buildapitypes "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi"
 	"golang.org/x/term"
 )
@@ -44,6 +45,9 @@ func NewProgressBar() *ProgressBar {
 
 // Render displays the progress bar with monotonic progress enforcement
 func (pb *ProgressBar) Render(phase string, step *buildapitypes.BuildStep) {
+	if clilog.IsQuiet() {
+		return
+	}
 	// Work on a local copy to avoid mutating the caller's BuildStep
 	var renderStep *buildapitypes.BuildStep
 	if step != nil {
@@ -117,7 +121,7 @@ func (pb *ProgressBar) renderPlain(phase string, step *buildapitypes.BuildStep) 
 // Complete renders a fully-filled progress bar and moves to a new line so the
 // final state is visible after the build finishes.
 func (pb *ProgressBar) Complete() {
-	if pb.lastLine == "" {
+	if clilog.IsQuiet() || pb.lastLine == "" {
 		return
 	}
 	total := 8
@@ -135,7 +139,7 @@ func (pb *ProgressBar) Complete() {
 
 // Clear clears the progress bar (TTY mode only)
 func (pb *ProgressBar) Clear() {
-	if !pb.isTTY || pb.lastLine == "" {
+	if clilog.IsQuiet() || !pb.isTTY || pb.lastLine == "" {
 		return
 	}
 	width, _, err := term.GetSize(int(os.Stdout.Fd()))

--- a/cmd/caib/ui/progress_test.go
+++ b/cmd/caib/ui/progress_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	buildapitypes "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi"
 )
 
@@ -84,5 +85,65 @@ func TestComplete_NoopWhenNothingRendered(t *testing.T) {
 
 	if out != "" {
 		t.Errorf("Complete() with no prior render should produce no output, got: %q", out)
+	}
+}
+
+func TestRender_QuietModeSuppressesOutput(t *testing.T) {
+	clilog.SetQuiet(true)
+	defer clilog.SetQuiet(false)
+
+	pb := &ProgressBar{isTTY: false}
+	out := captureStdout(t, func() {
+		pb.Render("Building", &buildapitypes.BuildStep{
+			Stage: "Building image",
+			Done:  4,
+			Total: 8,
+		})
+	})
+
+	if out != "" {
+		t.Errorf("Render() in quiet mode should produce no output, got: %q", out)
+	}
+}
+
+func TestComplete_QuietModeSuppressesOutput(t *testing.T) {
+	clilog.SetQuiet(false)
+	pb := &ProgressBar{isTTY: false}
+	pb.Render("Building", &buildapitypes.BuildStep{
+		Stage: "Building image",
+		Done:  4,
+		Total: 8,
+	})
+
+	clilog.SetQuiet(true)
+	defer clilog.SetQuiet(false)
+
+	out := captureStdout(t, func() {
+		pb.Complete()
+	})
+
+	if out != "" {
+		t.Errorf("Complete() in quiet mode should produce no output, got: %q", out)
+	}
+}
+
+func TestClear_QuietModeSuppressesOutput(t *testing.T) {
+	clilog.SetQuiet(false)
+	pb := &ProgressBar{isTTY: true}
+	pb.Render("Building", &buildapitypes.BuildStep{
+		Stage: "Building image",
+		Done:  4,
+		Total: 8,
+	})
+
+	clilog.SetQuiet(true)
+	defer clilog.SetQuiet(false)
+
+	out := captureStdout(t, func() {
+		pb.Clear()
+	})
+
+	if out != "" {
+		t.Errorf("Clear() in quiet mode should produce no output, got: %q", out)
 	}
 }

--- a/cmd/caib/workspace/workspace.go
+++ b/cmd/caib/workspace/workspace.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	caibcommon "github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/common"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/config"
 	buildapitypes "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi"
@@ -279,7 +280,7 @@ func runCreate(_ *cobra.Command, args []string) {
 	var clientConfigB64 string
 	clientInfo, err := caibcommon.ResolveJumpstarterClient(strings.TrimSpace(clientConfigFile))
 	if err == nil {
-		fmt.Printf("Using Jumpstarter client %q (endpoint: %s)\n", clientInfo.Name, clientInfo.Endpoint)
+		clilog.Infof("Using Jumpstarter client %q (endpoint: %s)\n", clientInfo.Name, clientInfo.Endpoint)
 		clientConfigB64 = base64.StdEncoding.EncodeToString(clientInfo.Data)
 	}
 
@@ -315,16 +316,16 @@ func runCreate(_ *cobra.Command, args []string) {
 		handleError(fmt.Errorf("failed to create workspace: %w", err))
 	}
 
-	fmt.Printf("Workspace %q created\n", resp.Name)
-	fmt.Printf("  Architecture: %s\n", resp.Arch)
+	clilog.Infof("Workspace %q created\n", resp.Name)
+	clilog.Infof("  Architecture: %s\n", resp.Arch)
 	if resp.Lease != "" {
-		fmt.Printf("  Lease:        %s\n", resp.Lease)
+		clilog.Infof("  Lease:        %s\n", resp.Lease)
 	}
 
 	if waitForRunningFlag {
 		waitForRunning(resp.Name)
 	} else {
-		fmt.Printf("  Phase:        %s\n", resp.Phase)
+		clilog.Infof("  Phase:        %s\n", resp.Phase)
 	}
 }
 
@@ -409,7 +410,7 @@ func runDelete(_ *cobra.Command, args []string) {
 		handleError(fmt.Errorf("failed to delete workspace: %w", err))
 	}
 
-	fmt.Printf("Workspace %q deleted\n", name)
+	clilog.Infof("Workspace %q deleted\n", name)
 }
 
 func runStart(_ *cobra.Command, args []string) {
@@ -430,10 +431,10 @@ func runStart(_ *cobra.Command, args []string) {
 	}
 
 	if waitForRunningFlag {
-		fmt.Printf("Workspace %q starting...\n", resp.Name)
+		clilog.Infof("Workspace %q starting...\n", resp.Name)
 		waitForRunning(resp.Name)
 	} else {
-		fmt.Printf("Workspace %q starting (phase: %s)\n", resp.Name, resp.Phase)
+		clilog.Infof("Workspace %q starting (phase: %s)\n", resp.Name, resp.Phase)
 	}
 }
 
@@ -454,7 +455,7 @@ func runStop(_ *cobra.Command, args []string) {
 		handleError(fmt.Errorf("failed to stop workspace: %w", err))
 	}
 
-	fmt.Printf("Workspace %q stopped (storage preserved)\n", resp.Name)
+	clilog.Infof("Workspace %q stopped (storage preserved)\n", resp.Name)
 }
 
 func runSync(_ *cobra.Command, args []string) {
@@ -498,17 +499,17 @@ func runSync(_ *cobra.Command, args []string) {
 	if err != nil {
 		// Fall back to full sync — warn so users know why delta didn't work
 		fmt.Fprintf(os.Stderr, "Warning: sync plan unavailable (%v), uploading all files\n", err)
-		fmt.Printf("Syncing %d tracked files to workspace %q...\n", len(files), name)
+		clilog.Infof("Syncing %d tracked files to workspace %q...\n", len(files), name)
 		uploadFiles(name, absDir, files)
 		return
 	}
 
 	if len(plan.Changed) == 0 {
-		fmt.Printf("Workspace %q is up to date (%d files)\n", name, plan.Unchanged)
+		clilog.Infof("Workspace %q is up to date (%d files)\n", name, plan.Unchanged)
 		return
 	}
 
-	fmt.Printf("Syncing %d changed files to workspace %q (%d unchanged)...\n",
+	clilog.Infof("Syncing %d changed files to workspace %q (%d unchanged)...\n",
 		len(plan.Changed), name, plan.Unchanged)
 	uploadFiles(name, absDir, plan.Changed)
 }
@@ -532,7 +533,7 @@ func uploadFiles(name, absDir string, files []string) {
 	if err != nil {
 		handleError(fmt.Errorf("failed to sync workspace: %w", err))
 	}
-	fmt.Println("Files synced")
+	clilog.Infoln("Files synced")
 }
 
 func computeManifest(baseDir string, files []string) map[string]string {
@@ -745,9 +746,9 @@ func runDeploy(_ *cobra.Command, args []string) {
 	}
 
 	if len(artifacts) == 1 {
-		fmt.Printf("Deploying %s -> %s\n", artifacts[0].Src, artifacts[0].Dest)
+		clilog.Infof("Deploying %s -> %s\n", artifacts[0].Src, artifacts[0].Dest)
 	} else {
-		fmt.Printf("Deploying %d artifacts to board...\n", len(artifacts))
+		clilog.Infof("Deploying %d artifacts to board...\n", len(artifacts))
 	}
 
 	var body io.ReadCloser
@@ -800,23 +801,26 @@ func waitForRunning(name string) {
 				continue // transient error, retry
 			}
 
+			showProgress := !clilog.IsQuiet()
 			if ws.Phase != lastPhase {
 				lastPhase = ws.Phase
-				if isTTY {
-					fmt.Printf("\r  Phase:        %-20s", ws.Phase)
-				} else {
-					fmt.Printf("  Phase: %s\n", ws.Phase)
+				if showProgress {
+					if isTTY {
+						fmt.Printf("\r  Phase:        %-20s", ws.Phase)
+					} else {
+						fmt.Printf("  Phase: %s\n", ws.Phase)
+					}
 				}
 			}
 
 			switch ws.Phase {
 			case "Running":
-				if isTTY {
+				if isTTY && showProgress {
 					fmt.Println()
 				}
 				return
 			case "Failed":
-				if isTTY {
+				if isTTY && showProgress {
 					fmt.Println()
 				}
 				handleError(fmt.Errorf("workspace %q failed", name))
@@ -840,7 +844,7 @@ func streamToStdout(r io.Reader) {
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
-		fmt.Println(scanner.Text())
+		clilog.Infoln(scanner.Text())
 	}
 	if err := scanner.Err(); err != nil {
 		fmt.Fprintf(os.Stderr, "stream error: %v\n", err)


### PR DESCRIPTION
Adds a clilog package with a global quiet gate. When --quiet is set, progress bars, status messages, and banners are suppressed while errors (stderr), structured data output (json/yaml/table), and interactive prompts remain visible. Enables agent/automation use of caib without parsing noise.

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [X] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global --quiet / -q flag to suppress informational output across commands.
  * Informational messages (build/flash/container/catalog/download/login/workspace/etc.), progress bars, and log-stream hints now obey quiet mode.
  * When quiet is enabled, progress rendering and some non-essential confirmations/hints are suppressed and log-following behavior is adjusted for quieter output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->