### PR TITLE
feat: add actionable error messages to caib CLI

### DIFF
--- a/cmd/caib/buildcmd/build.go
+++ b/cmd/caib/buildcmd/build.go
@@ -102,7 +102,7 @@ func (h *Handler) handleError(err error) {
 		h.opts.HandleError(err)
 		return
 	}
-	fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+	fmt.Fprintln(os.Stderr, common.FormatError(err))
 	os.Exit(1)
 }
 
@@ -125,11 +125,14 @@ func (h *Handler) applyWaitFollowDefaults(cmd *cobra.Command, defaultWait, defau
 // validateBootcBuildFlags validates flag combinations for the build command.
 func (h *Handler) validateBootcBuildFlags() error {
 	if strings.TrimSpace(*h.opts.ServerURL) == "" {
-		return fmt.Errorf("server URL required (use --server, CAIB_SERVER, run 'caib login <server-url>' or 'jmp login <endpoint>')")
+		return common.ServerURLRequiredError("caib image build --server <server-url>")
 	}
 
 	if *h.opts.UseInternalRegistry && *h.opts.ExportOCI != "" {
-		return fmt.Errorf("--internal-registry cannot be used with --push-disk")
+		return common.NewActionableError(
+			fmt.Errorf("--internal-registry cannot be used with --push-disk"),
+			fmt.Sprintf("caib image build -m %s --push-disk %s", *h.opts.Manifest, *h.opts.ExportOCI),
+		)
 	}
 
 	if *h.opts.OutputDir != "" && !*h.opts.BuildDiskImage {
@@ -166,7 +169,10 @@ func (h *Handler) validateReproducibleFlags() error {
 		return err
 	}
 	if *h.opts.Reproducible && *h.opts.UseInternalRegistry {
-		return fmt.Errorf("--reproducible cannot be used with --internal-registry (internal registry does not support OCI referrers)")
+		return common.NewActionableError(
+			fmt.Errorf("--reproducible cannot be used with --internal-registry (internal registry does not support OCI referrers)"),
+			"caib image build -m <manifest> --reproducible --push-disk <registry>",
+		)
 	}
 	return nil
 }
@@ -373,7 +379,11 @@ func (h *Handler) displayBuildResults(ctx context.Context, api *buildapiclient.C
 
 func (h *Handler) validateFlashLeaseFlags(cmd *cobra.Command) error {
 	if *h.opts.FlashAfterBuild && *h.opts.LeaseName != "" && cmd.Flags().Changed("lease-duration") {
-		return fmt.Errorf("--lease and --lease-duration are mutually exclusive")
+		return common.NewActionableError(
+			fmt.Errorf("--lease and --lease-duration are mutually exclusive"),
+			fmt.Sprintf("caib image build --flash --lease %s", *h.opts.LeaseName),
+			"caib image build --flash --lease-duration <duration>",
+		)
 	}
 	return nil
 }
@@ -385,7 +395,10 @@ func (h *Handler) applyFlashOptions(req *buildapitypes.BuildRequest, pushRequire
 		return nil
 	}
 	if *h.opts.ExportOCI == "" && !*h.opts.UseInternalRegistry {
-		return fmt.Errorf("cannot enable --flash without exporting a disk image (%s)", pushRequiredFlag)
+		return common.NewActionableError(
+			fmt.Errorf("cannot enable --flash without exporting a disk image (%s)", pushRequiredFlag),
+			fmt.Sprintf("caib image build --flash %s <registry>", pushRequiredFlag),
+		)
 	}
 	clientInfo, err := common.ResolveJumpstarterClient(strings.TrimSpace(*h.opts.JumpstarterClient))
 	if err != nil {
@@ -571,7 +584,7 @@ func (h *Handler) RunDisk(cmd *cobra.Command, args []string) {
 	*h.opts.ContainerRef = containerRef
 
 	if strings.TrimSpace(*h.opts.ServerURL) == "" {
-		h.handleError(fmt.Errorf("server URL required (use --server, CAIB_SERVER, run 'caib login <server-url>' or 'jmp login <endpoint>')"))
+		h.handleError(common.ServerURLRequiredError(fmt.Sprintf("caib image disk --server <server-url> %s", containerRef)))
 		return
 	}
 
@@ -581,7 +594,10 @@ func (h *Handler) RunDisk(cmd *cobra.Command, args []string) {
 	}
 
 	if *h.opts.UseInternalRegistry && *h.opts.ExportOCI != "" {
-		h.handleError(fmt.Errorf("--internal-registry cannot be used with --push"))
+		h.handleError(common.NewActionableError(
+			fmt.Errorf("--internal-registry cannot be used with --push"),
+			fmt.Sprintf("caib image disk --push %s %s", *h.opts.ExportOCI, containerRef),
+		))
 		return
 	}
 
@@ -677,7 +693,7 @@ func (h *Handler) RunBuildDev(cmd *cobra.Command, args []string) {
 	}
 
 	if strings.TrimSpace(*h.opts.ServerURL) == "" {
-		h.handleError(fmt.Errorf("server URL required (use --server, CAIB_SERVER, run 'caib login <server-url>' or 'jmp login <endpoint>')"))
+		h.handleError(common.ServerURLRequiredError(fmt.Sprintf("caib image build-dev --server <server-url> %s", manifestPath)))
 		return
 	}
 
@@ -688,7 +704,10 @@ func (h *Handler) RunBuildDev(cmd *cobra.Command, args []string) {
 
 	if *h.opts.UseInternalRegistry {
 		if *h.opts.ExportOCI != "" {
-			h.handleError(fmt.Errorf("--internal-registry cannot be used with --push"))
+			h.handleError(common.NewActionableError(
+				fmt.Errorf("--internal-registry cannot be used with --push"),
+				fmt.Sprintf("caib image build-dev --push %s %s", *h.opts.ExportOCI, manifestPath),
+			))
 			return
 		}
 	} else if err := common.ValidateOutputRequiresPush(*h.opts.OutputDir, *h.opts.ExportOCI, "--push"); err != nil {
@@ -838,7 +857,10 @@ func (h *Handler) handleFileUploads(
 	defer cancel()
 	for {
 		if err := readyCtx.Err(); err != nil {
-			return fmt.Errorf("timed out waiting for upload server to be ready")
+			return common.NewActionableError(
+				fmt.Errorf("timed out waiting for upload server to be ready (10m)"),
+				"caib image logs "+buildName,
+			)
 		}
 		reqCtx, reqCancel := context.WithTimeout(readyCtx, 15*time.Second)
 		st, err := api.GetBuild(reqCtx, buildName)
@@ -867,7 +889,10 @@ func (h *Handler) handleFileUploads(
 	for {
 		remaining := time.Until(uploadDeadline)
 		if remaining <= 0 {
-			return fmt.Errorf("upload files failed: timed out after 10m")
+			return common.NewActionableError(
+				fmt.Errorf("upload files failed: timed out after 10m"),
+				"caib image logs "+buildName,
+			)
 		}
 		attemptTimeout := perAttemptTimeout
 		if remaining < attemptTimeout {
@@ -914,7 +939,7 @@ func (h *Handler) RunCancel(_ *cobra.Command, args []string) {
 
 func (h *Handler) runBuildAction(buildName, verb string, action func(context.Context, *buildapiclient.Client, string) error) {
 	if strings.TrimSpace(*h.opts.ServerURL) == "" {
-		h.handleError(fmt.Errorf("server URL required (use --server, CAIB_SERVER, run 'caib login <server-url>' or 'jmp login <endpoint>')"))
+		h.handleError(common.ServerURLRequiredError(fmt.Sprintf("caib image %s --server <server-url> %s", verb, buildName)))
 		return
 	}
 

--- a/cmd/caib/buildcmd/logs.go
+++ b/cmd/caib/buildcmd/logs.go
@@ -57,7 +57,10 @@ func (h *Handler) waitForBuildCompletion(ctx context.Context, api *buildapiclien
 		select {
 		case <-timeoutCtx.Done():
 			pb.Clear()
-			timeoutErr := fmt.Errorf("timed out waiting for build")
+			timeoutErr := common.NewActionableError(
+				fmt.Errorf("timed out waiting for build %s", name),
+				"caib image show "+name,
+			)
 			h.handleError(timeoutErr)
 			return timeoutErr
 		case <-ticker.C:

--- a/cmd/caib/cli_helpers.go
+++ b/cmd/caib/cli_helpers.go
@@ -6,6 +6,8 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+
+	caibcommon "github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/common"
 )
 
 // getDefaultArch returns the current system architecture in caib format.
@@ -35,6 +37,6 @@ func envBool(key string) bool {
 }
 
 func handleError(err error) {
-	fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+	fmt.Fprintln(os.Stderr, caibcommon.FormatError(err))
 	os.Exit(1)
 }

--- a/cmd/caib/common/actionable_error.go
+++ b/cmd/caib/common/actionable_error.go
@@ -1,0 +1,75 @@
+package caibcommon
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const maxFixes = 3
+
+// ActionableError wraps an error with copy-pasteable fix commands.
+// At most maxFixes commands are rendered; additional fixes are ignored.
+type ActionableError struct {
+	Err   error
+	Fixes []string
+}
+
+// NewActionableError wraps err with one or more fix commands.
+func NewActionableError(err error, fixes ...string) *ActionableError {
+	return &ActionableError{Err: err, Fixes: fixes}
+}
+
+// ServerURLRequiredError returns the standard "server URL required" error
+// with fix suggestions. cmdExample is the command-specific --server usage,
+// e.g. "caib image build --server <server-url>".
+func ServerURLRequiredError(cmdExample string) *ActionableError {
+	return NewActionableError(
+		fmt.Errorf("server URL required"),
+		"caib login <server-url>",
+		cmdExample,
+		"export CAIB_SERVER=<server-url>",
+	)
+}
+
+func (e *ActionableError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *ActionableError) Unwrap() error {
+	return e.Err
+}
+
+// FormatWithFixes renders the error with fix commands.
+// Only the outermost ActionableError's fixes are rendered;
+// if the wrapped error is also an ActionableError, its fixes are ignored.
+func (e *ActionableError) FormatWithFixes() string {
+	var b strings.Builder
+	b.WriteString("Error: ")
+	b.WriteString(e.Err.Error())
+
+	for i, fix := range e.Fixes {
+		if i >= maxFixes {
+			break
+		}
+		b.WriteByte('\n')
+		if i == 0 {
+			b.WriteString("Fix:   ")
+		} else {
+			b.WriteString("  or:  ")
+		}
+		b.WriteString(fix)
+	}
+
+	return b.String()
+}
+
+// FormatError renders err as an actionable error if it is one,
+// otherwise renders it in the standard "Error: ..." format.
+func FormatError(err error) string {
+	var ae *ActionableError
+	if errors.As(err, &ae) {
+		return ae.FormatWithFixes()
+	}
+	return fmt.Sprintf("Error: %v", err)
+}

--- a/cmd/caib/common/actionable_error_test.go
+++ b/cmd/caib/common/actionable_error_test.go
@@ -1,0 +1,121 @@
+package caibcommon
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestActionableError_OneFix(t *testing.T) {
+	ae := NewActionableError(fmt.Errorf("server URL required"), "caib login https://example.com")
+	got := ae.FormatWithFixes()
+	want := "Error: server URL required\nFix:   caib login https://example.com"
+	if got != want {
+		t.Errorf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestActionableError_ThreeFixes(t *testing.T) {
+	ae := NewActionableError(
+		fmt.Errorf("server URL required"),
+		"caib login https://example.com",
+		"caib image build --server https://example.com",
+		"export CAIB_SERVER=https://example.com",
+	)
+	got := ae.FormatWithFixes()
+	want := "Error: server URL required\n" +
+		"Fix:   caib login https://example.com\n" +
+		"  or:  caib image build --server https://example.com\n" +
+		"  or:  export CAIB_SERVER=https://example.com"
+	if got != want {
+		t.Errorf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestActionableError_ZeroFixes(t *testing.T) {
+	ae := NewActionableError(fmt.Errorf("something broke"))
+	got := ae.FormatWithFixes()
+	want := "Error: something broke"
+	if got != want {
+		t.Errorf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestActionableError_MoreThanThreeFixes_CappedAtThree(t *testing.T) {
+	ae := NewActionableError(
+		fmt.Errorf("err"),
+		"fix1", "fix2", "fix3", "fix4",
+	)
+	got := ae.FormatWithFixes()
+	if count := len(strings.Split(got, "\n")) - 1; count != 3 {
+		t.Errorf("expected 3 fix lines, got %d:\n%s", count, got)
+	}
+	if strings.Contains(got, "fix4") {
+		t.Errorf("fix4 should not appear in output:\n%s", got)
+	}
+}
+
+func TestActionableError_WrappedActionableError_InnerFixesIgnored(t *testing.T) {
+	inner := NewActionableError(fmt.Errorf("inner"), "inner-fix")
+	outer := NewActionableError(fmt.Errorf("outer: %w", inner), "outer-fix")
+
+	got := outer.FormatWithFixes()
+	want := "Error: outer: inner\nFix:   outer-fix"
+	if got != want {
+		t.Errorf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestActionableError_ErrorsAs(t *testing.T) {
+	ae := NewActionableError(fmt.Errorf("test"), "fix")
+	wrapped := fmt.Errorf("wrap: %w", ae)
+
+	var target *ActionableError
+	if !errors.As(wrapped, &target) {
+		t.Fatal("errors.As should find ActionableError in wrapped chain")
+	}
+	if target.Fixes[0] != "fix" {
+		t.Errorf("expected fix 'fix', got %q", target.Fixes[0])
+	}
+}
+
+func TestActionableError_ErrorsIs(t *testing.T) {
+	sentinel := fmt.Errorf("sentinel")
+	ae := NewActionableError(sentinel, "fix")
+
+	if !errors.Is(ae, sentinel) {
+		t.Fatal("errors.Is should find sentinel through ActionableError")
+	}
+}
+
+func TestServerURLRequiredError(t *testing.T) {
+	ae := ServerURLRequiredError("caib image build --server <server-url>")
+	if ae.Error() != "server URL required" {
+		t.Errorf("unexpected error: %s", ae.Error())
+	}
+	if len(ae.Fixes) != 3 {
+		t.Fatalf("expected 3 fixes, got %d: %v", len(ae.Fixes), ae.Fixes)
+	}
+	if ae.Fixes[0] != "caib login <server-url>" {
+		t.Errorf("unexpected first fix: %s", ae.Fixes[0])
+	}
+}
+
+func TestFormatError_ActionableError(t *testing.T) {
+	ae := NewActionableError(fmt.Errorf("bad flag"), "caib image build --arch arm64")
+	got := FormatError(ae)
+	want := "Error: bad flag\nFix:   caib image build --arch arm64"
+	if got != want {
+		t.Errorf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestFormatError_RegularError(t *testing.T) {
+	err := fmt.Errorf("plain error")
+	got := FormatError(err)
+	want := "Error: plain error"
+	if got != want {
+		t.Errorf("got: %q, want: %q", got, want)
+	}
+}

--- a/cmd/caib/common/actionable_error_test.go
+++ b/cmd/caib/common/actionable_error_test.go
@@ -1,0 +1,118 @@
+package caibcommon
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestActionableError_OneFix(t *testing.T) {
+	ae := NewActionableError(fmt.Errorf("server URL required"), "caib login https://example.com")
+	got := ae.FormatWithFixes()
+	want := "Error: server URL required\nFix:   caib login https://example.com"
+	if got != want {
+		t.Errorf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestActionableError_ThreeFixes(t *testing.T) {
+	ae := NewActionableError(
+		fmt.Errorf("server URL required"),
+		"caib login https://example.com",
+		"caib image build --server https://example.com",
+		"export CAIB_SERVER=https://example.com",
+	)
+	got := ae.FormatWithFixes()
+	want := "Error: server URL required\n" +
+		"Fix:   caib login https://example.com\n" +
+		"  or:  caib image build --server https://example.com\n" +
+		"  or:  export CAIB_SERVER=https://example.com"
+	if got != want {
+		t.Errorf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestActionableError_ZeroFixes(t *testing.T) {
+	ae := NewActionableError(fmt.Errorf("something broke"))
+	got := ae.FormatWithFixes()
+	want := "Error: something broke"
+	if got != want {
+		t.Errorf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestActionableError_MoreThanThreeFixes_CappedAtThree(t *testing.T) {
+	ae := NewActionableError(
+		fmt.Errorf("err"),
+		"fix1", "fix2", "fix3", "fix4",
+	)
+	got := ae.FormatWithFixes()
+	if count := len(strings.Split(got, "\n")) - 1; count != 3 {
+		t.Errorf("expected 3 fix lines, got %d:\n%s", count, got)
+	}
+}
+
+func TestActionableError_WrappedActionableError_InnerFixesIgnored(t *testing.T) {
+	inner := NewActionableError(fmt.Errorf("inner"), "inner-fix")
+	outer := NewActionableError(fmt.Errorf("outer: %w", inner), "outer-fix")
+
+	got := outer.FormatWithFixes()
+	want := "Error: outer: inner\nFix:   outer-fix"
+	if got != want {
+		t.Errorf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestActionableError_ErrorsAs(t *testing.T) {
+	ae := NewActionableError(fmt.Errorf("test"), "fix")
+	wrapped := fmt.Errorf("wrap: %w", ae)
+
+	var target *ActionableError
+	if !errors.As(wrapped, &target) {
+		t.Fatal("errors.As should find ActionableError in wrapped chain")
+	}
+	if target.Fixes[0] != "fix" {
+		t.Errorf("expected fix 'fix', got %q", target.Fixes[0])
+	}
+}
+
+func TestActionableError_ErrorsIs(t *testing.T) {
+	sentinel := fmt.Errorf("sentinel")
+	ae := NewActionableError(sentinel, "fix")
+
+	if !errors.Is(ae, sentinel) {
+		t.Fatal("errors.Is should find sentinel through ActionableError")
+	}
+}
+
+func TestServerURLRequiredError(t *testing.T) {
+	ae := ServerURLRequiredError("caib image build --server <server-url>")
+	if ae.Error() != "server URL required" {
+		t.Errorf("unexpected error: %s", ae.Error())
+	}
+	if len(ae.Fixes) != 3 {
+		t.Fatalf("expected 3 fixes, got %d: %v", len(ae.Fixes), ae.Fixes)
+	}
+	if ae.Fixes[0] != "caib login <server-url>" {
+		t.Errorf("unexpected first fix: %s", ae.Fixes[0])
+	}
+}
+
+func TestFormatError_ActionableError(t *testing.T) {
+	ae := NewActionableError(fmt.Errorf("bad flag"), "caib image build --arch arm64")
+	got := FormatError(ae)
+	want := "Error: bad flag\nFix:   caib image build --arch arm64"
+	if got != want {
+		t.Errorf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestFormatError_RegularError(t *testing.T) {
+	err := fmt.Errorf("plain error")
+	got := FormatError(err)
+	want := "Error: plain error"
+	if got != want {
+		t.Errorf("got: %q, want: %q", got, want)
+	}
+}

--- a/cmd/caib/container/build.go
+++ b/cmd/caib/container/build.go
@@ -35,6 +35,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
+	caibcommon "github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/common"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/config"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/registryauth"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/ui"
@@ -140,14 +141,21 @@ func runBuildContainer(_ *cobra.Command, args []string) {
 	clilog.Infof("Containerfile: %s\n", filepath.Join(absContextDir, containerfile))
 
 	if serverURL == "" {
-		handleError(fmt.Errorf("server URL required (use --server, CAIB_SERVER, run 'caib login <server-url>' or 'jmp login <endpoint>')"))
+		handleError(caibcommon.ServerURLRequiredError("caib container build --server <server-url> ."))
 	}
 
 	if containerBuildPush != "" && useInternalRegistry {
-		handleError(fmt.Errorf("--push and --internal-registry are mutually exclusive"))
+		handleError(caibcommon.NewActionableError(
+			fmt.Errorf("--push and --internal-registry are mutually exclusive"),
+			fmt.Sprintf("caib container build --push %s .", containerBuildPush),
+		))
 	}
 	if containerBuildPush == "" && !useInternalRegistry {
-		handleError(fmt.Errorf("either --push or --internal-registry is required"))
+		handleError(caibcommon.NewActionableError(
+			fmt.Errorf("either --push or --internal-registry is required"),
+			"caib container build --push <registry/image:tag> .",
+			"caib container build --internal-registry .",
+		))
 	}
 
 	if buildName == "" {

--- a/cmd/caib/container/utilities.go
+++ b/cmd/caib/container/utilities.go
@@ -25,13 +25,14 @@ import (
 
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/auth"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
+	caibcommon "github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/common"
 	buildapiclient "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi/client"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
 // handleError prints an error and exits
 func handleError(err error) {
-	fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+	fmt.Fprintln(os.Stderr, caibcommon.FormatError(err))
 	os.Exit(1)
 }
 

--- a/cmd/caib/downloadcmd/download.go
+++ b/cmd/caib/downloadcmd/download.go
@@ -50,11 +50,14 @@ func (h *Handler) RunDownload(_ *cobra.Command, args []string) {
 	downloadBuildName := args[0]
 
 	if h.opts.ServerURL == nil || strings.TrimSpace(*h.opts.ServerURL) == "" {
-		h.handleError(fmt.Errorf("server URL required (use --server, CAIB_SERVER, run 'caib login <server-url>' or 'jmp login <endpoint>')"))
+		h.handleError(common.ServerURLRequiredError(fmt.Sprintf("caib image download --server <server-url> -o <dir> %s", downloadBuildName)))
 		return
 	}
 	if h.opts.OutputDir == nil || strings.TrimSpace(*h.opts.OutputDir) == "" {
-		h.handleError(fmt.Errorf("--output / -o is required"))
+		h.handleError(common.NewActionableError(
+			fmt.Errorf("--output / -o is required"),
+			fmt.Sprintf("caib image download -o <output-dir> %s", downloadBuildName),
+		))
 		return
 	}
 	if h.opts.InsecureSkipTLS == nil {
@@ -78,7 +81,10 @@ func (h *Handler) RunDownload(_ *cobra.Command, args []string) {
 	}
 
 	if st.Phase != phaseCompleted {
-		h.handleError(fmt.Errorf("build %s is not completed (phase: %s), cannot download artifacts", downloadBuildName, st.Phase))
+		h.handleError(common.NewActionableError(
+			fmt.Errorf("build %s is not completed (phase: %s), cannot download artifacts", downloadBuildName, st.Phase),
+			"caib image logs "+downloadBuildName,
+		))
 		return
 	}
 

--- a/cmd/caib/flashcmd/flash.go
+++ b/cmd/caib/flashcmd/flash.go
@@ -64,7 +64,7 @@ func (h *Handler) handleError(err error) {
 		h.opts.HandleError(err)
 		return
 	}
-	fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+	fmt.Fprintln(os.Stderr, common.FormatError(err))
 	os.Exit(1)
 }
 

--- a/cmd/caib/inspectcmd/inspect.go
+++ b/cmd/caib/inspectcmd/inspect.go
@@ -81,7 +81,7 @@ func (h *Handler) handleError(err error) {
 		h.opts.HandleError(err)
 		return
 	}
-	fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+	fmt.Fprintln(os.Stderr, caibcommon.FormatError(err))
 	os.Exit(1)
 }
 

--- a/cmd/caib/main.go
+++ b/cmd/caib/main.go
@@ -4,6 +4,8 @@ package main
 import (
 	"fmt"
 	"os"
+
+	caibcommon "github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/common"
 )
 
 const (
@@ -92,7 +94,7 @@ var (
 func main() {
 	rootCmd := newRootCmd()
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, caibcommon.FormatError(err))
 		os.Exit(1)
 	}
 }

--- a/cmd/caib/sealedcmd/sealed.go
+++ b/cmd/caib/sealedcmd/sealed.go
@@ -68,7 +68,7 @@ func (h *Handler) handleError(err error) {
 		h.opts.HandleError(err)
 		return
 	}
-	fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+	fmt.Fprintln(os.Stderr, common.FormatError(err))
 	os.Exit(1)
 }
 

--- a/cmd/caib/workspace/workspace.go
+++ b/cmd/caib/workspace/workspace.go
@@ -786,7 +786,10 @@ func waitForRunning(name string) {
 			return
 		case <-timeout:
 			fmt.Println()
-			handleError(fmt.Errorf("timed out waiting for workspace %q to be running", name))
+			handleError(caibcommon.NewActionableError(
+				fmt.Errorf("timed out waiting for workspace %q to be running", name),
+				"caib workspace logs "+name,
+			))
 		case <-ticker.C:
 			var ws *buildapitypes.WorkspaceResponse
 			err := caibcommon.ExecuteWithReauth(serverURL, &authToken, insecureSkipTLS, func(client *buildapiclient.Client) error {
@@ -819,6 +822,14 @@ func waitForRunning(name string) {
 					fmt.Println()
 				}
 				return
+			case "Stopped":
+				if isTTY && showProgress {
+					fmt.Println()
+				}
+				handleError(caibcommon.NewActionableError(
+					fmt.Errorf("workspace %q is stopped (auto-paused due to inactivity)", name),
+					"caib workspace start "+name,
+				))
 			case "Failed":
 				if isTTY && showProgress {
 					fmt.Println()
@@ -831,12 +842,12 @@ func waitForRunning(name string) {
 
 func requireServer() {
 	if serverURL == "" {
-		handleError(fmt.Errorf("--server is required (or set CAIB_SERVER, or run 'caib login <server-url>')"))
+		handleError(caibcommon.ServerURLRequiredError("caib workspace --server <server-url>"))
 	}
 }
 
 func handleError(err error) {
-	fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+	fmt.Fprintln(os.Stderr, caibcommon.FormatError(err))
 	os.Exit(1)
 }
 


### PR DESCRIPTION
Introduce ActionableError type that wraps errors with copy-pasteable fix commands. All handleError implementations and main() now detect ActionableError and render structured "Error: / Fix: / or:" output.

Upgraded error sites: server URL (3-method resolution), flag conflicts (corrected command without conflicting flag), timeouts (diagnostic command), workspace stopped state (caib workspace start).

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [X] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Errors display consistent, formatted output on stderr and include up to three copy‑pasteable actionable fix commands.

* **Bug Fixes**
  * Validation, timeout and missing-argument messages across commands now return actionable, command-specific hints (example invocations and log/show commands).

* **Tests**
  * Added unit tests for actionable error formatting, fix-capping, and wrapping/compatibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->