### PR TITLE
feat: add OIDC auth e2e tests with Dex support on Kind

### DIFF
--- a/.github/workflows/e2e-lanes.yml
+++ b/.github/workflows/e2e-lanes.yml
@@ -107,6 +107,12 @@ jobs:
           registry-host: ${{ env.REGISTRY_HOST }}
           arch: ${{ env.ARCH }}
 
+      - name: Deploy Dex for OIDC tests
+        if: >
+          needs.parse-comment.outputs.lane_name == 'auth' ||
+          needs.parse-comment.outputs.lane_name == 'all'
+        run: hack/e2e/setup-dex.sh
+
       - name: Build caib CLI
         run: make build-caib
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,6 +46,12 @@ jobs:
           registry-host: ${{ env.REGISTRY_HOST }}
           arch: ${{ env.ARCH }}
 
+      - name: Deploy Dex for OIDC tests
+        if: >
+          github.event.inputs.label_filter == 'auth' ||
+          github.event.inputs.label_filter == ''
+        run: hack/e2e/setup-dex.sh
+
       - name: Build caib CLI
         run: make build-caib
 

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ catalog/automotive-dev-operator.yaml
 /bundle/
 /build-api/
 _output/
+
+# Generated e2e test artifacts (Dex certs, etc.)
+.e2e/

--- a/hack/e2e/dex.values.yaml
+++ b/hack/e2e/dex.values.yaml
@@ -1,0 +1,41 @@
+https:
+  enabled: true
+config:
+  issuer: https://dex.dex.svc.cluster.local:5556
+  web:
+    tlsCert: /etc/dex/tls/tls.crt
+    tlsKey: /etc/dex/tls/tls.key
+  storage:
+    type: kubernetes
+    config:
+      inCluster: true
+  staticClients:
+    - id: caib-cli
+      name: Automotive Dev CLI
+      public: true
+      redirectURIs: []
+  oauth2:
+    responseTypes: ["code", "token", "id_token", "id_token token"]
+    passwordConnector: local
+  enablePasswordDB: true
+  staticPasswords:
+    - email: "test-user@example.com"
+      # bcrypt hash of "password"
+      hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+      username: "test-user"
+      userID: "73bca0b9-9be6-4e73-a8fb-347c2ac23255"
+volumes:
+  - name: tls
+    secret:
+      secretName: dex-tls
+volumeMounts:
+  - name: tls
+    mountPath: /etc/dex/tls
+service:
+  type: NodePort
+  ports:
+    http:
+      port: 5554
+    https:
+      port: 5556
+      nodePort: 32000

--- a/hack/e2e/setup-dex.sh
+++ b/hack/e2e/setup-dex.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Deploy Dex as an OIDC provider on a Kind cluster for auth e2e tests.
+# Generates TLS certificates, installs Dex via Helm, and stores the CA cert
+# in a ConfigMap for test consumption.
+#
+# Usage: ./hack/e2e/setup-dex.sh
+# Prerequisites: kubectl, helm, openssl, and a running Kind cluster.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+CERT_DIR="$REPO_ROOT/.e2e/dex-certs"
+
+log_info()  { echo "[INFO]  $*"; }
+log_error() { echo "[ERROR] $*" >&2; }
+
+check_prerequisites() {
+    local missing=()
+    for cmd in kubectl helm openssl; do
+        command -v "$cmd" &>/dev/null || missing+=("$cmd")
+    done
+    if [ ${#missing[@]} -gt 0 ]; then
+        log_error "Missing required tools: ${missing[*]}"
+        exit 1
+    fi
+}
+
+generate_certs() {
+    if [ -f "$CERT_DIR/ca.pem" ] && [ -f "$CERT_DIR/server.pem" ] && [ -f "$CERT_DIR/server-key.pem" ]; then
+        log_info "Certificates already exist in $CERT_DIR, reusing"
+        return
+    fi
+
+    log_info "Generating TLS certificates..."
+    mkdir -p "$CERT_DIR"
+
+    openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 \
+        -keyout "$CERT_DIR/ca-key.pem" -out "$CERT_DIR/ca.pem" \
+        -days 365 -nodes -subj "/CN=e2e-dex-ca" 2>/dev/null
+
+    cat > "$CERT_DIR/san.cnf" <<EOF
+[req]
+distinguished_name = req_dn
+req_extensions     = v3_req
+prompt             = no
+
+[req_dn]
+CN = dex.dex.svc.cluster.local
+
+[v3_req]
+subjectAltName = DNS:dex.dex.svc.cluster.local
+
+[v3_ext]
+subjectAltName = DNS:dex.dex.svc.cluster.local
+EOF
+
+    openssl req -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 \
+        -keyout "$CERT_DIR/server-key.pem" -out "$CERT_DIR/server.csr" \
+        -nodes -config "$CERT_DIR/san.cnf" 2>/dev/null
+
+    openssl x509 -req -in "$CERT_DIR/server.csr" \
+        -CA "$CERT_DIR/ca.pem" -CAkey "$CERT_DIR/ca-key.pem" \
+        -CAcreateserial -out "$CERT_DIR/server.pem" -days 365 \
+        -extensions v3_ext -extfile "$CERT_DIR/san.cnf" 2>/dev/null
+
+    log_info "Certificates generated in $CERT_DIR"
+}
+
+deploy_dex() {
+    log_info "Deploying Dex..."
+
+    kubectl create namespace dex --dry-run=client -o yaml | kubectl apply -f -
+
+    kubectl -n dex create secret tls dex-tls \
+        --cert="$CERT_DIR/server.pem" \
+        --key="$CERT_DIR/server-key.pem" \
+        --dry-run=client -o yaml | kubectl apply -f -
+
+    kubectl create configmap dex-ca -n dex \
+        --from-file=ca.crt="$CERT_DIR/ca.pem" \
+        --dry-run=client -o yaml | kubectl apply -f -
+
+    helm repo add dex https://charts.dexidp.io 2>/dev/null || true
+    helm repo update dex
+    helm upgrade --install --namespace dex --wait --version 0.21.0 \
+        -f "$SCRIPT_DIR/dex.values.yaml" dex dex/dex
+
+    log_info "Waiting for Dex to be ready..."
+    kubectl wait --namespace dex --for=condition=available \
+        deployment/dex --timeout=120s
+
+    log_info "Dex deployed successfully"
+}
+
+main() {
+    log_info "=== Dex OIDC Setup for E2E Tests ==="
+
+    check_prerequisites
+    generate_certs
+    deploy_dex
+
+    log_info ""
+    log_info "Dex is ready."
+    log_info "  Issuer:  https://dex.dex.svc.cluster.local:5556"
+    log_info "  CA cert: $CERT_DIR/ca.pem"
+    log_info ""
+    log_info "Run auth e2e tests:"
+    log_info "  go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter=auth"
+}
+
+main "$@"

--- a/hack/run-e2e-local.sh
+++ b/hack/run-e2e-local.sh
@@ -17,7 +17,7 @@ usage() {
   printf 'Lanes:\n'
   printf '  operator  - operator health, Tekton tasks, Build API\n'
   printf '  bootc     - bootc container build via caib\n'
-  printf '  auth      - OIDC authentication (OpenShift only)\n'
+  printf '  auth      - OIDC authentication (OpenShift or Kind+Dex)\n'
   printf '  all       - run all tests (default)\n\n'
   printf 'Options:\n'
   printf '  -h, --help    Show this help message and exit\n\n'

--- a/test/e2e/auth_test.go
+++ b/test/e2e/auth_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package e2e
 
 import (
-	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -32,59 +31,62 @@ import (
 )
 
 var _ = Describe("OIDC Authentication", Label("auth"), Ordered, func() {
+	var dexAvailable bool
+
 	BeforeAll(func() {
-		if !utils.IsOpenShiftCluster() {
-			Skip("OIDC e2e requires OpenShift; skipping on Kind")
-		}
 		ensureOperatorDeployed()
-		// ensureRegistryConfigured is intentionally omitted: OIDC tests do not push
-		// artifacts and do not require osBuilds.clusterRegistryRoute to be set.
 		ensureBuildAPIAccess()
-		if utils.GetBuildAPIURL(testNamespace) == "" {
-			Skip("OIDC e2e requires OpenShift Route (ado-build-api)")
+
+		dexAvailable = isDexDeployed()
+
+		if !openShiftCluster && !dexAvailable {
+			Skip("auth tests require either OpenShift or Dex; run hack/e2e/setup-dex.sh for Kind")
 		}
 	})
 
+	AfterAll(func() {
+		cmd := exec.Command("kubectl", "patch", "operatorconfig", "config",
+			"-n", testNamespace, "--type=json",
+			"-p", `[{"op": "remove", "path": "/spec/buildAPI/authentication"}]`)
+		out, err := utils.Run(cmd)
+		if err != nil {
+			_, _ = fmt.Fprintf(GinkgoWriter, "OIDC cleanup patch failed (non-fatal): %v\n%s\n", err, string(out))
+		}
+	})
+
+	// -----------------------------------------------------------------
+	// OIDC config propagation (runs before any OIDC config is applied)
+	// -----------------------------------------------------------------
 	Context("Build API OIDC Configuration", func() {
 		It("should return 404 when OIDC is not configured", func() {
-			apiURL := utils.GetBuildAPIURL(testNamespace)
-
-			client := &http.Client{
-				Timeout: 5 * time.Second,
-				Transport: &http.Transport{
-					TLSClientConfig: &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12},
-				},
-			}
-			resp, err := client.Get(apiURL + "/v1/auth/config")
+			client := newInsecureHTTPClient()
+			resp, err := client.Get(caibServer + "/v1/auth/config")
 			Expect(err).NotTo(HaveOccurred())
 			defer func() { _ = resp.Body.Close() }()
-			Expect(resp.StatusCode).To(Or(Equal(404), Equal(200)))
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
 		})
 
-		It("should handle OIDC configuration when provided", func() {
-			By("patching OperatorConfig to add OIDC authentication")
-			oidcPatch := `{"spec":{"buildAPI":{"authentication":{"clientId":"test-client-id","jwt":[{"issuer":{"url":"https://issuer.example.com","audiences":["test-audience"]},"claimMappings":{"username":{"claim":"preferred_username","prefix":""}}}]}}}}`
-			cmd := exec.Command("kubectl", "patch", "operatorconfig", "config",
-				"-n", testNamespace, "--type=merge", "-p", oidcPatch)
-			_, err := utils.Run(cmd)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-			By("checking /v1/auth/config endpoint returns OIDC config")
-			apiURL := utils.GetBuildAPIURL(testNamespace)
-			httpClient := &http.Client{
-				Timeout: 5 * time.Second,
-				Transport: &http.Transport{
-					TLSClientConfig: &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12},
-				},
+		It("should serve OIDC config on /v1/auth/config", func() {
+			if dexAvailable {
+				ensureDexOIDC()
+			} else {
+				By("patching OperatorConfig with test OIDC configuration")
+				oidcPatch := `{"spec":{"buildAPI":{"authentication":{"clientId":"test-client-id","jwt":[{"issuer":{"url":"https://issuer.example.com","audiences":["test-audience"]},"claimMappings":{"username":{"claim":"preferred_username","prefix":""}}}]}}}}`
+				cmd := exec.Command("kubectl", "patch", "operatorconfig", "config",
+					"-n", testNamespace, "--type=merge", "-p", oidcPatch)
+				_, err := utils.Run(cmd)
+				ExpectWithOffset(1, err).NotTo(HaveOccurred())
 			}
+
+			client := newInsecureHTTPClient()
 			var authBody string
 			EventuallyWithOffset(1, func() error {
-				resp, httpErr := httpClient.Get(apiURL + "/v1/auth/config")
-				if httpErr != nil {
-					return httpErr
+				resp, err := client.Get(caibServer + "/v1/auth/config")
+				if err != nil {
+					return err
 				}
 				defer func() { _ = resp.Body.Close() }()
-				if resp.StatusCode != 200 {
+				if resp.StatusCode != http.StatusOK {
 					return fmt.Errorf("unexpected status %d from /v1/auth/config", resp.StatusCode)
 				}
 				b, readErr := io.ReadAll(resp.Body)
@@ -99,17 +101,66 @@ var _ = Describe("OIDC Authentication", Label("auth"), Ordered, func() {
 			}, 2*time.Minute, 5*time.Second).Should(Succeed(),
 				"Build API did not serve OIDC config in time")
 			Expect(authBody).To(And(ContainSubstring("jwt"), ContainSubstring("clientId")))
-
-			By("cleaning up OIDC configuration from OperatorConfig")
-			cmd = exec.Command("kubectl", "patch", "operatorconfig", "config",
-				"-n", testNamespace, "--type=json", "-p", `[{"op": "remove", "path": "/spec/buildAPI/authentication"}]`)
-			out, cleanupErr := utils.Run(cmd)
-			if cleanupErr != nil {
-				_, _ = fmt.Fprintf(GinkgoWriter, "OIDC cleanup patch failed (non-fatal): %v\n%s\n", cleanupErr, string(out))
-			}
 		})
 	})
 
+	// -----------------------------------------------------------------
+	// Token validation (Dex OIDC token on Kind, SA TokenReview on OpenShift)
+	// -----------------------------------------------------------------
+	Context("Token Validation", func() {
+		It("should authenticate with valid token", func() {
+			var token string
+			if dexAvailable {
+				ensureDexOIDC()
+				token = getDexToken("test-user@example.com", "password")
+			} else {
+				By("creating a ServiceAccount token for TokenReview authentication")
+				cmd := exec.Command("kubectl", "create", "token", "default",
+					"-n", testNamespace, "--duration=10m")
+				output, err := utils.Run(cmd)
+				ExpectWithOffset(1, err).NotTo(HaveOccurred())
+				token = strings.TrimSpace(string(output))
+			}
+
+			client := newInsecureHTTPClient()
+			req, err := http.NewRequest("GET", caibServer+"/v1/builds", nil)
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Authorization", "Bearer "+token)
+
+			resp, err := client.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = resp.Body.Close() }()
+			Expect(resp.StatusCode).To(Equal(http.StatusOK),
+				fmt.Sprintf("expected 200 with valid token, got %d", resp.StatusCode))
+		})
+
+		It("should reject invalid token with 401", func() {
+			client := newInsecureHTTPClient()
+			req, err := http.NewRequest("GET", caibServer+"/v1/builds", nil)
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Authorization", "Bearer invalid-token-12345")
+
+			resp, err := client.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = resp.Body.Close() }()
+			Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+		})
+
+		It("should reject request without token with 401", func() {
+			client := newInsecureHTTPClient()
+			req, err := http.NewRequest("GET", caibServer+"/v1/builds", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			resp, err := client.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = resp.Body.Close() }()
+			Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+		})
+	})
+
+	// -----------------------------------------------------------------
+	// Build API health
+	// -----------------------------------------------------------------
 	Context("Internal JWT Validation", func() {
 		It("should have Build API pod running", func() {
 			EventuallyWithOffset(1, func() error {

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -18,9 +18,12 @@ package e2e
 
 import (
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"regexp"
@@ -43,6 +46,7 @@ const (
 	artifactImageRepo              = "automotive-os-test1"
 	artifactImageName              = artifactImageRepo + ":latest"
 	kindPushNamespace              = "myorg"
+	defaultHTTPClientTimeout       = 5 * time.Second
 )
 
 // Shared state populated lazily via sync.Once and consumed by test lanes.
@@ -60,12 +64,19 @@ var (
 	buildAPIOnce  sync.Once
 	registryOnce  sync.Once
 	caibCredsOnce sync.Once
+	dexOnce       sync.Once
 
 	// Error flags: set when a setup panic is caught so subsequent lanes fail fast.
 	operatorSetupErr  error
 	buildAPISetupErr  error
 	registrySetupErr  error
 	caibCredsSetupErr error
+	dexSetupErr       error
+
+	// Dex OIDC state (populated by ensureDexOIDC).
+	dexEndpoint   string
+	dexPortFwdCmd *exec.Cmd
+	dexCACert     string
 )
 
 // resolveNamespace returns the E2E_NAMESPACE env var if set, otherwise generates a random "e2e-test-<hex>" namespace.
@@ -300,12 +311,7 @@ func setupBuildAPIRoute() {
 	}, 2*time.Minute, 5*time.Second).ShouldNot(BeEmpty())
 
 	By("waiting for Build API route to respond")
-	httpClient := &http.Client{
-		Timeout: 2 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12},
-		},
-	}
+	httpClient := newInsecureHTTPClient()
 	waitForBuildAPI := func() error {
 		resp, httpErr := httpClient.Get(caibServer + "/v1/healthz")
 		if httpErr != nil {
@@ -335,7 +341,7 @@ func setupBuildAPIPortForward() {
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 	By("waiting for Build API to respond on port-forward")
-	httpClient := &http.Client{Timeout: 2 * time.Second}
+	httpClient := newInsecureHTTPClient()
 	waitForBuildAPI := func() error {
 		resp, httpErr := httpClient.Get("http://localhost:8080/v1/healthz")
 		if httpErr != nil {
@@ -430,23 +436,180 @@ func setupCaibCredentials() {
 	}
 }
 
-// cleanupPortForward safely terminates the port-forward process.
-func cleanupPortForward() {
-	if portForwardCmd != nil {
-		if portForwardCmd.Process != nil {
-			_ = portForwardCmd.Process.Kill()
+// isDexDeployed returns true when the Dex deployment exists in the dex namespace.
+func isDexDeployed() bool {
+	cmd := exec.Command("kubectl", "get", "deployment", "dex", "-n", "dex", "--no-headers")
+	_, err := utils.Run(cmd)
+	return err == nil
+}
+
+// ensureDexOIDC configures Dex-based OIDC authentication for the Build API.
+// It sets up a port-forward to Dex, patches OperatorConfig with Dex JWT settings,
+// and waits for the Build API to serve the OIDC config. Runs once per test run.
+func ensureDexOIDC() {
+	dexOnce.Do(func() {
+		defer func() {
+			if r := recover(); r != nil {
+				dexSetupErr = fmt.Errorf("Dex OIDC setup panicked: %v", r)
+				panic(r)
+			}
+		}()
+		setupDexOIDC()
+	})
+	if dexSetupErr != nil {
+		Fail("Dex OIDC setup failed in a previous step; cannot proceed")
+	}
+}
+
+func setupDexOIDC() {
+	By("verifying Dex deployment is available")
+	cmd := exec.Command("kubectl", "wait", "--for=condition=available",
+		"--timeout=2m", "deployment/dex", "-n", "dex")
+	_, err := utils.Run(cmd)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	By("reading Dex CA certificate from ConfigMap")
+	cmd = exec.Command("kubectl", "get", "configmap", "dex-ca", "-n", "dex",
+		"-o", "jsonpath={.data.ca\\.crt}")
+	output, err := utils.Run(cmd)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	dexCACert = strings.TrimSpace(string(output))
+	ExpectWithOffset(1, dexCACert).NotTo(BeEmpty(), "Dex CA cert not found in dex-ca ConfigMap")
+
+	By("setting up port-forward to Dex")
+	setupDexPortForward()
+
+	By("patching OperatorConfig with Dex OIDC configuration")
+	patchOperatorConfigWithDex()
+
+	By("waiting for Build API to serve Dex OIDC config")
+	waitForOIDCConfig()
+}
+
+func setupDexPortForward() {
+	dexEndpoint = "https://localhost:5556"
+
+	if conn, dialErr := net.DialTimeout("tcp", "localhost:5556", 500*time.Millisecond); dialErr == nil {
+		_ = conn.Close()
+		_, _ = fmt.Fprintf(GinkgoWriter, "port 5556 already in use, validating existing Dex endpoint\n")
+		validateDexEndpoint()
+		return
+	}
+
+	dexPortFwdCmd = exec.Command("kubectl", "port-forward",
+		"-n", "dex", "svc/dex", "5556:5556")
+	err := dexPortFwdCmd.Start()
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	validateDexEndpoint()
+}
+
+func validateDexEndpoint() {
+	httpClient := newInsecureHTTPClient()
+	EventuallyWithOffset(2, func() error {
+		resp, httpErr := httpClient.Get(dexEndpoint + "/.well-known/openid-configuration")
+		if httpErr != nil {
+			return httpErr
 		}
-		_ = portForwardCmd.Wait()
-		portForwardCmd = nil
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("Dex OIDC discovery returned %d", resp.StatusCode)
+		}
+		return nil
+	}, 30*time.Second, 1*time.Second).Should(Succeed(), "Dex endpoint did not become ready")
+}
+
+func patchOperatorConfigWithDex() {
+	escapedCA := strings.ReplaceAll(dexCACert, "\n", "\\n")
+	oidcPatch := fmt.Sprintf(
+		`{"spec":{"buildAPI":{"authentication":{"clientId":"caib-cli","jwt":[{"issuer":{"url":"https://dex.dex.svc.cluster.local:5556","audiences":["caib-cli"],"certificateAuthority":"%s"},"claimMappings":{"username":{"claim":"name","prefix":"dex:"}}}]}}}}`,
+		escapedCA,
+	)
+	cmd := exec.Command("kubectl", "patch", "operatorconfig", "config",
+		"-n", testNamespace, "--type=merge", "-p", oidcPatch)
+	_, err := utils.Run(cmd)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+}
+
+func waitForOIDCConfig() {
+	httpClient := newInsecureHTTPClient()
+	EventuallyWithOffset(1, func() error {
+		resp, err := httpClient.Get(caibServer + "/v1/auth/config")
+		if err != nil {
+			return err
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("/v1/auth/config returned %d, waiting for OIDC config", resp.StatusCode)
+		}
+		b, _ := io.ReadAll(resp.Body)
+		if !strings.Contains(string(b), "dex.dex.svc.cluster.local") {
+			return fmt.Errorf("OIDC config does not contain Dex issuer yet: %s", string(b))
+		}
+		return nil
+	}, 3*time.Minute, 5*time.Second).Should(Succeed(),
+		"Build API did not serve Dex OIDC config in time")
+}
+
+// getDexToken obtains an OIDC id_token from Dex using the password grant.
+func getDexToken(username, password string) string {
+	httpClient := newInsecureHTTPClient()
+
+	data := url.Values{
+		"grant_type": {"password"},
+		"username":   {username},
+		"password":   {password},
+		"client_id":  {"caib-cli"},
+		"scope":      {"openid profile email"},
+	}
+
+	resp, err := httpClient.PostForm(dexEndpoint+"/token", data)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	ExpectWithOffset(1, resp.StatusCode).To(Equal(http.StatusOK),
+		fmt.Sprintf("Dex token request failed (%d): %s", resp.StatusCode, string(body)))
+
+	var tokenResp struct {
+		IDToken string `json:"id_token"`
+	}
+	err = json.Unmarshal(body, &tokenResp)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	ExpectWithOffset(1, tokenResp.IDToken).NotTo(BeEmpty(), "Dex returned empty id_token")
+
+	return tokenResp.IDToken
+}
+
+// killPortForwardCmd safely terminates a port-forward process and nils the pointer.
+func killPortForwardCmd(cmd **exec.Cmd) {
+	if *cmd != nil {
+		if (*cmd).Process != nil {
+			_ = (*cmd).Process.Kill()
+		}
+		_ = (*cmd).Wait()
+		*cmd = nil
 	}
 }
 
 // teardownOperator cleans up all test resources. Called from AfterSuite.
 func teardownOperator() {
-	cleanupPortForward()
+	killPortForwardCmd(&portForwardCmd)
+	killPortForwardCmd(&dexPortFwdCmd)
 
 	if testNamespace != "" {
 		By("removing test namespace")
 		utils.CleanupNamespace(testNamespace)
+	}
+}
+
+// newInsecureHTTPClient returns an HTTP client that skips TLS verification.
+func newInsecureHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: defaultHTTPClientTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12}, //nolint:gosec // e2e test
+		},
 	}
 }


### PR DESCRIPTION
## Summary
Extends the OIDC auth e2e suite to run on Kind clusters by deploying Dex as an OIDC provider, in addition to the existing OpenShift/TokenReview path.
Previously auth tests were skipped entirely on Kind.

**Dex provisioning**
- Add `hack/e2e/setup-dex.sh`: generates self-signed TLS certificates, creates the `dex` namespace/Secret/ConfigMap, and installs Dex via Helm (`dexidp/dex v0.21.0`) with a static password connector. `dex-ca` ConfigMap is stored in-cluster for test consumption.
- Add `hack/e2e/dex.values.yaml`: Helm values enabling HTTPS, local password connector, a static test user (`test-user@example.com`), and a `caib-cli` OIDC client exposed on NodePort 32000.
- Ignore generated `.e2e/` artifacts (certs etc.) in `.gitignore`.

**CI integration**
- `e2e-lanes.yml`: run `setup-dex.sh` before CLI build when lane is `auth` or `all`.
- `e2e.yml`: run `setup-dex.sh` before CLI build when `label_filter` is `auth` or empty.

**Auth e2e tests**
- Remove the hard OpenShift-only skip; suite now runs on Kind when Dex is deployed, skips only when neither is present.
- Add `AfterAll` that always removes `/spec/buildAPI/authentication` from `OperatorConfig` (idempotent) to prevent auth state leaking into other lanes.
- OIDC config propagation: assert `404` when unconfigured, assert `200` with `jwt`/`clientId` fields after configuring via Dex (Kind) or a direct `OperatorConfig` patch (OpenShift).
- Token Validation (new): valid token → `200` on `GET /v1/builds`; invalid token → `401`; missing `Authorization` header → `401`.

**Helper refactors**
- `ensureDexOIDC`/`setupDexOIDC`: read `dex-ca` ConfigMap, port-forward `svc/dex` to `localhost:5556`, patch `OperatorConfig`, wait for `/v1/auth/config` to reflect the new config.
- `validateDexEndpoint`: shared OIDC discovery probe ensuring `dexEndpoint` is only accepted after a confirmed Dex `/.well-known/openid-configuration` response - covers both the fresh port-forward and the already-in-use port path.
- `getDexToken`: password-grant token fetch against Dex's `/token` endpoint.
- `killPortForwardCmd`: single generic helper replacing separate `cleanupPortForward`/`cleanupDexPortForward` functions.
- `newInsecureHTTPClient`: remove unused `timeout` parameter; all callers passed `defaultHTTPClientTimeout`, so it is now hardcoded.

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] CI/CD improvement
- [x] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [x] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated Dex deployment for OIDC testing in CI and local Kind-based test lanes, enabling OIDC auth tests outside OpenShift.

* **Tests**
  * Expanded e2e auth suite with Dex-aware flows and token validation: successful auth, invalid token rejection, and missing token handling.
  * Tests now detect and use Dex when available and skip appropriately otherwise.

* **Chores**
  * Ignore generated e2e artifacts (e.g., Dex certs) in VCS.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/centos-automotive-suite/automotive-dev-operator/pull/301?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->