### PR TITLE
Couple of improvements to the install script

### DIFF
--- a/hack/install-caib.sh
+++ b/hack/install-caib.sh
@@ -41,7 +41,7 @@ esac
 ARTIFACT="caib-${VERSION}-${SUFFIX}.tar.gz"
 URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARTIFACT}"
 CHECKSUMS_URL="https://github.com/${REPO}/releases/download/${VERSION}/checksums.txt"
-INSTALL_DIR="/usr/local/bin"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT

--- a/hack/install-caib.sh
+++ b/hack/install-caib.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+# Enable debug mode if DEBUG is set
+if [ -n "${DEBUG:-}" ]; then
+    set -x
+fi
+
 REPO="centos-automotive-suite/automotive-dev-operator"
 
 # Determine version
@@ -42,6 +47,12 @@ ARTIFACT="caib-${VERSION}-${SUFFIX}.tar.gz"
 URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARTIFACT}"
 CHECKSUMS_URL="https://github.com/${REPO}/releases/download/${VERSION}/checksums.txt"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+
+if [ ! -d "$INSTALL_DIR" ]; then
+    echo "Error: Install directory does not exist: ${INSTALL_DIR}" >&2
+    echo "Please create it first or use an existing directory." >&2
+    exit 1
+fi
 
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT


### PR DESCRIPTION
## Summary
Couple of improvements to the install script

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installation destination is now customizable via the INSTALL_DIR environment variable, defaulting to /usr/local/bin.
  * Debug mode can be enabled via the DEBUG environment variable to show verbose installation steps.
  * Installer now checks that the chosen install directory exists and exits with an error if it does not.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->