### PR TITLE
add expiry to ContainerBuilds

### DIFF
--- a/api/v1alpha1/containerbuild_types.go
+++ b/api/v1alpha1/containerbuild_types.go
@@ -62,12 +62,21 @@ type ContainerBuildSpec struct {
 	// using a service account token (e.g. for the OpenShift internal registry).
 	// +optional
 	UseServiceAccountAuth bool `json:"useServiceAccountAuth,omitempty"`
+
+	// TTL is the time-to-live for this build. After this duration past its
+	// completion, the build transitions to the Expired phase and its
+	// BuildRun is cleaned up. The ContainerBuild CR itself is preserved.
+	// In-progress builds never expire.
+	// Uses Go duration format (e.g. "24h", "72h", "168h").
+	// Empty uses the OperatorConfig default. Set to "0" to disable expiry.
+	// +optional
+	TTL string `json:"ttl,omitempty"`
 }
 
 // ContainerBuildStatus defines the observed state of ContainerBuild
 type ContainerBuildStatus struct {
 	// Phase is the current lifecycle phase of the container build.
-	// One of: Pending, Uploading, Building, Completed, Failed.
+	// One of: Pending, Uploading, Building, Completed, Failed, Expired.
 	Phase string `json:"phase,omitempty"`
 
 	// BuildRunName is the name of the Shipwright BuildRun created for this build.
@@ -87,6 +96,16 @@ type ContainerBuildStatus struct {
 	// ImageDigest is the digest of the built and pushed image.
 	ImageDigest string `json:"imageDigest,omitempty"`
 
+	// ExpiresAt is when this build will transition to the Expired phase
+	// and have its BuildRun cleaned up. The ContainerBuild CR itself is
+	// preserved. Nil if expiry is disabled (TTL "0" or no-expire annotation).
+	// +optional
+	ExpiresAt *metav1.Time `json:"expiresAt,omitempty"`
+
+	// PreviousPhase is the phase the build was in before transitioning to Expired.
+	// +optional
+	PreviousPhase string `json:"previousPhase,omitempty"`
+
 	// Conditions represent the latest available observations of the build's state.
 	// +optional
 	// +listType=map
@@ -98,6 +117,7 @@ type ContainerBuildStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Output",type=string,JSONPath=`.spec.output`
+// +kubebuilder:printcolumn:name="Expires",type=date,JSONPath=`.status.expiresAt`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // ContainerBuild is the Schema for the containerbuilds API
@@ -152,6 +172,11 @@ func (s *ContainerBuildSpec) GetArchitecture() string {
 		return "amd64"
 	}
 	return s.Architecture
+}
+
+// GetTTL returns the per-build TTL string, or empty if not set.
+func (s *ContainerBuildSpec) GetTTL() string {
+	return s.TTL
 }
 
 // GetTimeout returns the timeout in minutes, defaulting to 30.

--- a/api/v1alpha1/operatorconfig_types.go
+++ b/api/v1alpha1/operatorconfig_types.go
@@ -325,6 +325,22 @@ type ContainerBuildsConfig struct {
 	// +kubebuilder:validation:Minimum=1
 	// +optional
 	UploadTimeoutMinutes int32 `json:"uploadTimeoutMinutes,omitempty"`
+
+	// DefaultBuildTTL is the default time-to-live for container builds.
+	// After this duration past completion, a build transitions to Expired
+	// and its BuildRun is cleaned up. Uses Go duration format (e.g. "24h").
+	// Set to "0" to disable expiry by default.
+	// +optional
+	DefaultBuildTTL string `json:"defaultBuildTTL,omitempty"`
+}
+
+// GetDefaultBuildTTL returns the configured default TTL for container builds,
+// falling back to the shared DefaultBuildTTL constant ("24h").
+func (c *ContainerBuildsConfig) GetDefaultBuildTTL() string {
+	if c != nil && c.DefaultBuildTTL != "" {
+		return c.DefaultBuildTTL
+	}
+	return DefaultBuildTTL
 }
 
 // WorkspacesConfig defines configuration for developer workspaces

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -440,6 +440,10 @@ func (in *ContainerBuildStatus) DeepCopyInto(out *ContainerBuildStatus) {
 		in, out := &in.CompletionTime, &out.CompletionTime
 		*out = (*in).DeepCopy()
 	}
+	if in.ExpiresAt != nil {
+		in, out := &in.ExpiresAt, &out.ExpiresAt
+		*out = (*in).DeepCopy()
+	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]v1.Condition, len(*in))

--- a/config/crd/bases/automotive.sdv.cloud.redhat.com_containerbuilds.yaml
+++ b/config/crd/bases/automotive.sdv.cloud.redhat.com_containerbuilds.yaml
@@ -21,6 +21,9 @@ spec:
     - jsonPath: .spec.output
       name: Output
       type: string
+    - jsonPath: .status.expiresAt
+      name: Expires
+      type: date
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -88,6 +91,15 @@ spec:
                   to 30.
                 format: int32
                 type: integer
+              ttl:
+                description: |-
+                  TTL is the time-to-live for this build. After this duration past its
+                  completion, the build transitions to the Expired phase and its
+                  BuildRun is cleaned up. The ContainerBuild CR itself is preserved.
+                  In-progress builds never expire.
+                  Uses Go duration format (e.g. "24h", "72h", "168h").
+                  Empty uses the OperatorConfig default. Set to "0" to disable expiry.
+                type: string
               useServiceAccountAuth:
                 description: |-
                   UseServiceAccountAuth indicates the build should authenticate to the registry
@@ -168,6 +180,13 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              expiresAt:
+                description: |-
+                  ExpiresAt is when this build will transition to the Expired phase
+                  and have its BuildRun cleaned up. The ContainerBuild CR itself is
+                  preserved. Nil if expiry is disabled (TTL "0" or no-expire annotation).
+                format: date-time
+                type: string
               imageDigest:
                 description: ImageDigest is the digest of the built and pushed image.
                 type: string
@@ -178,7 +197,11 @@ spec:
               phase:
                 description: |-
                   Phase is the current lifecycle phase of the container build.
-                  One of: Pending, Uploading, Building, Completed, Failed.
+                  One of: Pending, Uploading, Building, Completed, Failed, Expired.
+                type: string
+              previousPhase:
+                description: PreviousPhase is the phase the build was in before transitioning
+                  to Expired.
                 type: string
               startTime:
                 description: StartTime is when the build started.

--- a/config/crd/bases/automotive.sdv.cloud.redhat.com_operatorconfigs.yaml
+++ b/config/crd/bases/automotive.sdv.cloud.redhat.com_operatorconfigs.yaml
@@ -624,6 +624,13 @@ spec:
                 description: ContainerBuilds defines configuration for container build
                   operations
                 properties:
+                  defaultBuildTTL:
+                    description: |-
+                      DefaultBuildTTL is the default time-to-live for container builds.
+                      After this duration past completion, a build transitions to Expired
+                      and its BuildRun is cleaned up. Uses Go duration format (e.g. "24h").
+                      Set to "0" to disable expiry by default.
+                    type: string
                   uploadTimeoutMinutes:
                     default: 10
                     description: |-

--- a/internal/controller/containerbuild/controller.go
+++ b/internal/controller/containerbuild/controller.go
@@ -28,6 +28,7 @@ const (
 	phasePending   = "Pending"
 	phaseUploading = "Uploading"
 	phaseBuilding  = "Building"
+	phaseExpired   = "Expired"
 
 	maxK8sNameLength = 63
 
@@ -86,6 +87,10 @@ func (r *ContainerBuildReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, err
 	}
 
+	if result, expired, err := r.checkExpiry(ctx, cb); expired || err != nil {
+		return result, err
+	}
+
 	switch cb.Status.Phase {
 	case "", phasePending:
 		return r.reconcilePending(ctx, log, cb)
@@ -93,6 +98,8 @@ func (r *ContainerBuildReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return r.reconcileUploading(ctx, log, cb)
 	case phaseBuilding:
 		return r.reconcileBuilding(ctx, log, cb)
+	case phaseExpired:
+		return r.handleExpiredState(ctx, cb)
 	case phaseCompleted, phaseFailed:
 		return ctrl.Result{}, nil
 	default:
@@ -315,7 +322,10 @@ func (r *ContainerBuildReconciler) updatePhase(
 	if buildRunName != "" {
 		cb.Status.BuildRunName = buildRunName
 	}
-	if phase == phaseFailed || phase == phaseCompleted {
+	if phase == phaseExpired {
+		cb.Status.PreviousPhase = oldPhase
+	}
+	if isTerminalPhase(phase) && cb.Status.CompletionTime == nil {
 		now := metav1.Now()
 		cb.Status.CompletionTime = &now
 	}
@@ -335,7 +345,7 @@ func (r *ContainerBuildReconciler) updatePhase(
 		)
 		r.emitContainerLifecycleEvent(cb, oldPhase, phase, message)
 	}
-	if phase == phaseFailed || phase == phaseCompleted {
+	if isTerminalPhase(phase) {
 		return ctrl.Result{}, nil
 	}
 	return ctrl.Result{RequeueAfter: 3 * time.Second}, nil
@@ -392,6 +402,10 @@ func (r *ContainerBuildReconciler) emitContainerLifecycleEvent(
 			message,
 		)
 	}
+}
+
+func isTerminalPhase(phase string) bool {
+	return phase == phaseFailed || phase == phaseCompleted || phase == phaseExpired
 }
 
 func eventTypeForContainerPhase(phase string) string {

--- a/internal/controller/containerbuild/expiry.go
+++ b/internal/controller/containerbuild/expiry.go
@@ -1,0 +1,132 @@
+package containerbuild
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
+	controllerutils "github.com/centos-automotive-suite/automotive-dev-operator/internal/controller/controllerutils"
+	shipwrightv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func (r *ContainerBuildReconciler) checkExpiry(
+	ctx context.Context,
+	cb *automotivev1alpha1.ContainerBuild,
+) (ctrl.Result, bool, error) {
+	log := r.Log.WithValues("containerbuild", cb.Name, "namespace", cb.Namespace)
+
+	if cb.Status.Phase == phaseExpired {
+		return ctrl.Result{}, false, nil
+	}
+
+	if cb.Status.CompletionTime == nil {
+		return ctrl.Result{}, false, nil
+	}
+
+	if cb.Annotations[automotivev1alpha1.NoExpireAnnotation] == "true" {
+		if err := r.updateExpiresAt(ctx, cb, nil); err != nil {
+			return ctrl.Result{}, false, err
+		}
+		return ctrl.Result{}, false, nil
+	}
+
+	ttl, err := r.resolveEffectiveTTL(ctx, cb)
+	if err != nil {
+		log.Error(err, "Failed to resolve TTL, skipping expiry check")
+		r.emitEventf(cb, corev1.EventTypeWarning, "InvalidTTL",
+			"Failed to resolve TTL, expiry disabled for this build: %v", err)
+		if clearErr := r.updateExpiresAt(ctx, cb, nil); clearErr != nil {
+			return ctrl.Result{}, false, clearErr
+		}
+		return ctrl.Result{}, false, nil
+	}
+	if ttl == 0 {
+		if err := r.updateExpiresAt(ctx, cb, nil); err != nil {
+			return ctrl.Result{}, false, err
+		}
+		return ctrl.Result{}, false, nil
+	}
+	anchor := cb.Status.CompletionTime.Time
+
+	expiresAt := anchor.Add(ttl)
+	remaining := time.Until(expiresAt)
+
+	if err := r.updateExpiresAt(ctx, cb, &expiresAt); err != nil {
+		return ctrl.Result{}, false, err
+	}
+
+	if remaining > 0 {
+		log.Info("Build not yet expired", "expiresAt", expiresAt, "remaining", remaining.Truncate(time.Second))
+		return ctrl.Result{RequeueAfter: remaining}, false, nil
+	}
+
+	log.Info("Build expired, transitioning to Expired phase", "ttl", ttl, "anchor", anchor,
+		"previousPhase", cb.Status.Phase)
+	r.emitEventf(cb, corev1.EventTypeNormal, "BuildExpired",
+		"Build expired after %s, cleaning up resources", ttl)
+
+	if _, err := r.updatePhase(ctx, cb, phaseExpired, cb.Status.BuildRunName,
+		fmt.Sprintf("Build expired after %s", ttl)); err != nil {
+		return ctrl.Result{}, false, fmt.Errorf("failed to transition expired build: %w", err)
+	}
+	return ctrl.Result{}, true, nil
+}
+
+func (r *ContainerBuildReconciler) resolveEffectiveTTL(
+	ctx context.Context,
+	cb *automotivev1alpha1.ContainerBuild,
+) (time.Duration, error) {
+	operatorConfig := &automotivev1alpha1.OperatorConfig{}
+	if err := r.Get(ctx, types.NamespacedName{
+		Name: "config", Namespace: controllerutils.OperatorNamespace(),
+	}, operatorConfig); err != nil && !errors.IsNotFound(err) {
+		return 0, fmt.Errorf("failed to load OperatorConfig: %w", err)
+	}
+	return controllerutils.ResolveBuildTTL(cb.Spec.GetTTL(), operatorConfig.Spec.ContainerBuilds)
+}
+
+func (r *ContainerBuildReconciler) updateExpiresAt(
+	ctx context.Context,
+	cb *automotivev1alpha1.ContainerBuild,
+	expiresAt *time.Time,
+) error {
+	desired, needsUpdate := controllerutils.ComputeExpiresAt(cb.Status.ExpiresAt, expiresAt)
+	if !needsUpdate {
+		return nil
+	}
+	fresh := &automotivev1alpha1.ContainerBuild{}
+	if err := r.Get(ctx, types.NamespacedName{
+		Name: cb.Name, Namespace: cb.Namespace,
+	}, fresh); err != nil {
+		return err
+	}
+	fresh.Status.ExpiresAt = desired
+	return r.Status().Update(ctx, fresh)
+}
+
+func (r *ContainerBuildReconciler) handleExpiredState(
+	ctx context.Context,
+	cb *automotivev1alpha1.ContainerBuild,
+) (ctrl.Result, error) {
+	log := r.Log.WithValues("containerbuild", cb.Name, "namespace", cb.Namespace)
+
+	if name := cb.Status.BuildRunName; name != "" {
+		br := &shipwrightv1beta1.BuildRun{}
+		br.Name = name
+		br.Namespace = cb.Namespace
+		if err := r.Delete(ctx, br); err != nil {
+			if !errors.IsNotFound(err) {
+				return ctrl.Result{}, fmt.Errorf("failed to delete BuildRun %s: %w", name, err)
+			}
+		} else {
+			log.Info("Deleted BuildRun", "name", name)
+		}
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/internal/controller/containerbuild/expiry_test.go
+++ b/internal/controller/containerbuild/expiry_test.go
@@ -1,0 +1,383 @@
+package containerbuild
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
+	controllerutils "github.com/centos-automotive-suite/automotive-dev-operator/internal/controller/controllerutils"
+	"github.com/go-logr/logr"
+	shipwrightv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newTestScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(automotivev1alpha1.AddToScheme(scheme))
+	utilruntime.Must(shipwrightv1beta1.SchemeBuilder.AddToScheme(scheme))
+	return scheme
+}
+
+func newExpiryReconciler(objs ...automotivev1alpha1.ContainerBuild) *ContainerBuildReconciler {
+	scheme := newTestScheme()
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	for i := range objs {
+		builder = builder.WithStatusSubresource(&objs[i])
+		builder = builder.WithObjects(&objs[i])
+	}
+	return &ContainerBuildReconciler{
+		Client:   builder.Build(),
+		Scheme:   scheme,
+		Log:      logr.Discard(),
+		Recorder: record.NewFakeRecorder(10),
+	}
+}
+
+func newTestContainerBuildForExpiry(name, phase, ttl string, completedAgo time.Duration) automotivev1alpha1.ContainerBuild {
+	now := time.Now()
+	cb := automotivev1alpha1.ContainerBuild{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         testNamespace,
+			CreationTimestamp: metav1.NewTime(now.Add(-completedAgo - time.Hour)),
+		},
+		Spec: automotivev1alpha1.ContainerBuildSpec{
+			Output: "quay.io/test/image:latest",
+			TTL:    ttl,
+		},
+		Status: automotivev1alpha1.ContainerBuildStatus{
+			Phase: phase,
+		},
+	}
+	if phase == phaseCompleted || phase == phaseFailed {
+		ct := metav1.NewTime(now.Add(-completedAgo))
+		cb.Status.CompletionTime = &ct
+	}
+	return cb
+}
+
+func TestCheckExpiry_ExpiredBuild_TransitionsToExpiredPhase(t *testing.T) {
+	cb := newTestContainerBuildForExpiry("expired-build", phaseCompleted, "1h", 2*time.Hour)
+	r := newExpiryReconciler(cb)
+
+	_, expired, err := r.checkExpiry(context.Background(), &cb)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !expired {
+		t.Fatal("expected build to be expired")
+	}
+
+	got := &automotivev1alpha1.ContainerBuild{}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "expired-build", Namespace: testNamespace}, got); err != nil {
+		t.Fatalf("ContainerBuild should still exist after expiry: %v", err)
+	}
+	if got.Status.Phase != phaseExpired {
+		t.Errorf("expected phase %q, got %q", phaseExpired, got.Status.Phase)
+	}
+	if got.Status.PreviousPhase != phaseCompleted {
+		t.Errorf("expected previousPhase %q, got %q", phaseCompleted, got.Status.PreviousPhase)
+	}
+}
+
+func TestCheckExpiry_NotYetExpired(t *testing.T) {
+	cb := newTestContainerBuildForExpiry("fresh-build", phaseCompleted, "24h", 1*time.Hour)
+	r := newExpiryReconciler(cb)
+
+	result, expired, err := r.checkExpiry(context.Background(), &cb)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if expired {
+		t.Fatal("build should not be expired yet")
+	}
+	if result.RequeueAfter < 22*time.Hour || result.RequeueAfter > 24*time.Hour {
+		t.Errorf("expected RequeueAfter ~23h, got %v", result.RequeueAfter)
+	}
+}
+
+func TestCheckExpiry_NoExpireAnnotation(t *testing.T) {
+	cb := newTestContainerBuildForExpiry("pinned-build", phaseCompleted, "1h", 2*time.Hour)
+	cb.Annotations = map[string]string{
+		automotivev1alpha1.NoExpireAnnotation: "true",
+	}
+	r := newExpiryReconciler(cb)
+
+	_, expired, err := r.checkExpiry(context.Background(), &cb)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if expired {
+		t.Fatal("annotated build should not be expired")
+	}
+}
+
+func TestCheckExpiry_TTLZeroDisablesExpiry(t *testing.T) {
+	cb := newTestContainerBuildForExpiry("forever-build", phaseCompleted, "0", 999*time.Hour)
+	r := newExpiryReconciler(cb)
+
+	result, expired, err := r.checkExpiry(context.Background(), &cb)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if expired {
+		t.Fatal("TTL=0 build should never expire")
+	}
+	if result.RequeueAfter != 0 {
+		t.Errorf("expected no requeue, got %v", result.RequeueAfter)
+	}
+}
+
+func TestCheckExpiry_InProgressNeverExpires(t *testing.T) {
+	for _, phase := range []string{phasePending, phaseUploading, phaseBuilding} {
+		t.Run(phase, func(t *testing.T) {
+			cb := newTestContainerBuildForExpiry("build-"+phase, phase, "30m", 0)
+			r := newExpiryReconciler(cb)
+
+			_, expired, err := r.checkExpiry(context.Background(), &cb)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if expired {
+				t.Fatalf("in-progress build (phase %s) should never expire", phase)
+			}
+		})
+	}
+}
+
+func TestCheckExpiry_FailedBuildExpires(t *testing.T) {
+	cb := newTestContainerBuildForExpiry("failed-old", phaseFailed, "1h", 2*time.Hour)
+	r := newExpiryReconciler(cb)
+
+	_, expired, err := r.checkExpiry(context.Background(), &cb)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !expired {
+		t.Fatal("failed build past TTL should expire")
+	}
+
+	got := &automotivev1alpha1.ContainerBuild{}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "failed-old", Namespace: testNamespace}, got); err != nil {
+		t.Fatalf("ContainerBuild should still exist: %v", err)
+	}
+	if got.Status.Phase != phaseExpired {
+		t.Errorf("expected phase %q, got %q", phaseExpired, got.Status.Phase)
+	}
+	if got.Status.PreviousPhase != phaseFailed {
+		t.Errorf("expected previousPhase %q, got %q", phaseFailed, got.Status.PreviousPhase)
+	}
+}
+
+func TestCheckExpiry_SetsExpiresAtInStatus(t *testing.T) {
+	cb := newTestContainerBuildForExpiry("with-status", phaseCompleted, "24h", 1*time.Hour)
+	r := newExpiryReconciler(cb)
+
+	_, expired, err := r.checkExpiry(context.Background(), &cb)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if expired {
+		t.Fatal("build should not be expired")
+	}
+
+	got := &automotivev1alpha1.ContainerBuild{}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "with-status", Namespace: testNamespace}, got); err != nil {
+		t.Fatalf("failed to get build: %v", err)
+	}
+	if got.Status.ExpiresAt == nil {
+		t.Fatal("expected ExpiresAt to be set in status")
+	}
+	expectedExpiry := cb.Status.CompletionTime.Add(24 * time.Hour)
+	diff := got.Status.ExpiresAt.Sub(expectedExpiry)
+	if diff < -time.Second || diff > time.Second {
+		t.Errorf("ExpiresAt = %v, want ~%v (diff %v)", got.Status.ExpiresAt.Time, expectedExpiry, diff)
+	}
+}
+
+func TestCheckExpiry_AlreadyExpiredSkipsCheck(t *testing.T) {
+	cb := newTestContainerBuildForExpiry("already-expired", phaseExpired, "1h", 2*time.Hour)
+	r := newExpiryReconciler(cb)
+
+	result, expired, err := r.checkExpiry(context.Background(), &cb)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if expired {
+		t.Fatal("already-expired build should not re-trigger expiry")
+	}
+	if result.RequeueAfter != 0 {
+		t.Errorf("expected no requeue for already-expired build, got %v", result.RequeueAfter)
+	}
+}
+
+func TestHandleExpiredState_DeletesBuildRun(t *testing.T) {
+	cb := newTestContainerBuildForExpiry("my-build", phaseExpired, "1h", 2*time.Hour)
+	cb.Status.BuildRunName = "my-build-br"
+
+	br := &shipwrightv1beta1.BuildRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-build-br",
+			Namespace: testNamespace,
+		},
+	}
+
+	scheme := newTestScheme()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&cb, br).
+		WithStatusSubresource(&cb).
+		Build()
+
+	r := &ContainerBuildReconciler{
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Log:      logr.Discard(),
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	result, err := r.handleExpiredState(context.Background(), &cb)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RequeueAfter != 0 {
+		t.Errorf("expected no requeue, got %v", result.RequeueAfter)
+	}
+
+	got := &shipwrightv1beta1.BuildRun{}
+	err = r.Get(context.Background(), types.NamespacedName{Name: "my-build-br", Namespace: testNamespace}, got)
+	if !errors.IsNotFound(err) {
+		t.Errorf("expected BuildRun to be deleted, got err=%v", err)
+	}
+}
+
+func TestHandleExpiredState_IdempotentWhenBuildRunAlreadyGone(t *testing.T) {
+	cb := newTestContainerBuildForExpiry("clean-build", phaseExpired, "1h", 2*time.Hour)
+	cb.Status.BuildRunName = "gone-buildrun"
+
+	r := newExpiryReconciler(cb)
+
+	result, err := r.handleExpiredState(context.Background(), &cb)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RequeueAfter != 0 {
+		t.Errorf("expected no requeue when BuildRun already gone, got %v", result.RequeueAfter)
+	}
+}
+
+func TestHandleExpiredState_PreservesContainerBuildCR(t *testing.T) {
+	cb := newTestContainerBuildForExpiry("preserved", phaseExpired, "1h", 2*time.Hour)
+	cb.Status.BuildRunName = "preserved-br"
+
+	r := newExpiryReconciler(cb)
+
+	r.handleExpiredState(context.Background(), &cb) //nolint:errcheck
+
+	got := &automotivev1alpha1.ContainerBuild{}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "preserved", Namespace: testNamespace}, got); err != nil {
+		t.Fatalf("ContainerBuild CR should still exist after cleanup: %v", err)
+	}
+}
+
+func TestResolveEffectiveTTL(t *testing.T) {
+	cases := []struct {
+		name           string
+		specTTL        string
+		configBuildTTL string
+		hasConfig      bool
+		expectedTTL    time.Duration
+	}{
+		{"spec overrides OperatorConfig", "48h", "72h", true, 48 * time.Hour},
+		{"OperatorConfig default", "", "72h", true, 72 * time.Hour},
+		{"hardcoded fallback (no config)", "", "", false, 24 * time.Hour},
+		{"spec zero disables expiry", "0", "", false, 0},
+		{"OperatorConfig zero disables expiry", "", "0", true, 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cb := newTestContainerBuildForExpiry("test-build", phaseCompleted, tc.specTTL, 1*time.Hour)
+			scheme := newTestScheme()
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+
+			if tc.hasConfig {
+				builder = builder.WithObjects(&automotivev1alpha1.OperatorConfig{
+					ObjectMeta: metav1.ObjectMeta{Name: "config", Namespace: controllerutils.OperatorNamespace()},
+					Spec: automotivev1alpha1.OperatorConfigSpec{
+						ContainerBuilds: &automotivev1alpha1.ContainerBuildsConfig{
+							DefaultBuildTTL: tc.configBuildTTL,
+						},
+					},
+				})
+			}
+
+			r := &ContainerBuildReconciler{
+				Client: builder.Build(),
+				Scheme: scheme,
+				Log:    logr.Discard(),
+			}
+
+			ttl, err := r.resolveEffectiveTTL(context.Background(), &cb)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ttl != tc.expectedTTL {
+				t.Errorf("expected %v, got %v", tc.expectedTTL, ttl)
+			}
+		})
+	}
+}
+
+func TestReconcile_ExpiredPhaseCallsCleanup(t *testing.T) {
+	cb := newTestContainerBuildForExpiry("reconcile-expired", phaseExpired, "1h", 2*time.Hour)
+	cb.Status.BuildRunName = "reconcile-expired-br"
+
+	br := &shipwrightv1beta1.BuildRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "reconcile-expired-br",
+			Namespace: testNamespace,
+		},
+	}
+
+	scheme := newTestScheme()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&cb, br).
+		WithStatusSubresource(&cb).
+		Build()
+
+	r := &ContainerBuildReconciler{
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Log:      logr.Discard(),
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "reconcile-expired", Namespace: testNamespace},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := &shipwrightv1beta1.BuildRun{}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "reconcile-expired-br", Namespace: testNamespace}, got); !errors.IsNotFound(err) {
+		t.Errorf("expected BuildRun to be cleaned up via Reconcile, got err=%v", err)
+	}
+
+	gotCB := &automotivev1alpha1.ContainerBuild{}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "reconcile-expired", Namespace: testNamespace}, gotCB); err != nil {
+		t.Fatalf("ContainerBuild should still exist: %v", err)
+	}
+}

--- a/internal/controller/controllerutils/expiry.go
+++ b/internal/controller/controllerutils/expiry.go
@@ -1,0 +1,56 @@
+package controllerutils
+
+import (
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TTLConfigProvider is implemented by OperatorConfig sections that provide
+// a default build TTL (e.g. OSBuildsConfig, ContainerBuildsConfig).
+// Implementations must be nil-safe: calling GetDefaultBuildTTL on a nil
+// receiver returns DefaultBuildTTL ("24h").
+type TTLConfigProvider interface {
+	GetDefaultBuildTTL() string
+}
+
+// ResolveBuildTTL resolves the effective TTL for a build.
+// Priority: specTTL (per-build) > configSection.GetDefaultBuildTTL() > "24h".
+// Returns 0 if expiry is disabled (TTL string is "0").
+func ResolveBuildTTL(specTTL string, configSection TTLConfigProvider) (time.Duration, error) {
+	ttlStr := specTTL
+	if ttlStr == "" {
+		ttlStr = configSection.GetDefaultBuildTTL()
+	}
+	if ttlStr == "0" {
+		return 0, nil
+	}
+	ttl, err := time.ParseDuration(ttlStr)
+	if err != nil {
+		return 0, err
+	}
+	if ttl < 0 {
+		return 0, fmt.Errorf("TTL must not be negative: %s", ttlStr)
+	}
+	return ttl, nil
+}
+
+// ComputeExpiresAt computes the desired ExpiresAt value from a raw time,
+// truncating to second precision. Reports whether the value differs from
+// current and needs a status update.
+func ComputeExpiresAt(current *metav1.Time, expiresAt *time.Time) (*metav1.Time, bool) {
+	var desired *metav1.Time
+	if expiresAt != nil {
+		truncated := expiresAt.Truncate(time.Second)
+		t := metav1.NewTime(truncated)
+		desired = &t
+	}
+	if current == nil && desired == nil {
+		return nil, false
+	}
+	if current != nil && desired != nil && current.Time.Equal(desired.Time) {
+		return desired, false
+	}
+	return desired, true
+}

--- a/internal/controller/controllerutils/expiry_test.go
+++ b/internal/controller/controllerutils/expiry_test.go
@@ -1,0 +1,122 @@
+package controllerutils
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type stubTTLConfig struct {
+	ttl string
+}
+
+func (s *stubTTLConfig) GetDefaultBuildTTL() string {
+	if s != nil && s.ttl != "" {
+		return s.ttl
+	}
+	return "24h"
+}
+
+func TestResolveBuildTTL(t *testing.T) {
+	cases := []struct {
+		name        string
+		specTTL     string
+		config      *stubTTLConfig
+		expectedTTL time.Duration
+		wantErr     bool
+	}{
+		{"spec overrides config", "48h", &stubTTLConfig{ttl: "72h"}, 48 * time.Hour, false},
+		{"config default used when spec empty", "", &stubTTLConfig{ttl: "72h"}, 72 * time.Hour, false},
+		{"nil config falls back to 24h", "", (*stubTTLConfig)(nil), 24 * time.Hour, false},
+		{"zero disables expiry", "0", nil, 0, false},
+		{"spec zero overrides config", "0", &stubTTLConfig{ttl: "72h"}, 0, false},
+		{"negative TTL is error", "-1h", nil, 0, true},
+		{"invalid TTL string is error", "bogus", nil, 0, true},
+		{"minutes work", "30m", nil, 30 * time.Minute, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var config *stubTTLConfig
+			if tc.config != nil {
+				config = tc.config
+			} else if tc.specTTL == "0" || tc.wantErr {
+				config = &stubTTLConfig{}
+			}
+
+			ttl, err := ResolveBuildTTL(tc.specTTL, config)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ttl != tc.expectedTTL {
+				t.Errorf("expected %v, got %v", tc.expectedTTL, ttl)
+			}
+		})
+	}
+}
+
+func TestResolveBuildTTL_NilConfigSection(t *testing.T) {
+	ttl, err := ResolveBuildTTL("", (*stubTTLConfig)(nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ttl != 24*time.Hour {
+		t.Errorf("expected 24h fallback, got %v", ttl)
+	}
+}
+
+func TestComputeExpiresAt(t *testing.T) {
+	now := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+	nowMeta := metav1.NewTime(now)
+	later := now.Add(24 * time.Hour)
+	laterMeta := metav1.NewTime(later)
+
+	cases := []struct {
+		name       string
+		current    *metav1.Time
+		expiresAt  *time.Time
+		wantUpdate bool
+		wantNil    bool
+	}{
+		{"both nil", nil, nil, false, true},
+		{"current nil, desired set", nil, &later, true, false},
+		{"current set, desired nil", &nowMeta, nil, true, true},
+		{"same time no update", &laterMeta, &later, false, false},
+		{"different time needs update", &nowMeta, &later, true, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			desired, needsUpdate := ComputeExpiresAt(tc.current, tc.expiresAt)
+			if needsUpdate != tc.wantUpdate {
+				t.Errorf("needsUpdate = %v, want %v", needsUpdate, tc.wantUpdate)
+			}
+			if tc.wantNil && desired != nil {
+				t.Errorf("expected nil desired, got %v", desired)
+			}
+			if !tc.wantNil && desired == nil {
+				t.Error("expected non-nil desired, got nil")
+			}
+		})
+	}
+}
+
+func TestComputeExpiresAt_TruncatesToSeconds(t *testing.T) {
+	withNanos := time.Date(2025, 6, 1, 12, 30, 45, 123456789, time.UTC)
+	expected := time.Date(2025, 6, 1, 12, 30, 45, 0, time.UTC)
+
+	desired, needsUpdate := ComputeExpiresAt(nil, &withNanos)
+	if !needsUpdate {
+		t.Fatal("expected update needed")
+	}
+	if !desired.Time.Equal(expected) {
+		t.Errorf("expected %v, got %v", expected, desired.Time)
+	}
+}

--- a/internal/controller/imagebuild/controller.go
+++ b/internal/controller/imagebuild/controller.go
@@ -570,36 +570,13 @@ func (r *ImageBuildReconciler) resolveEffectiveTTL(
 	ctx context.Context,
 	imageBuild *automotivev1alpha1.ImageBuild,
 ) (time.Duration, error) {
-	ttlStr := imageBuild.Spec.GetTTL()
-
-	if ttlStr == "" {
-		operatorConfig := &automotivev1alpha1.OperatorConfig{}
-		if err := r.Get(ctx, types.NamespacedName{
-			Name: "config", Namespace: controllerutils.OperatorNamespace(),
-		}, operatorConfig); err != nil {
-			if !errors.IsNotFound(err) {
-				return 0, fmt.Errorf("failed to load OperatorConfig: %w", err)
-			}
-			ttlStr = automotivev1alpha1.DefaultBuildTTL
-		} else if operatorConfig.Spec.OSBuilds != nil {
-			ttlStr = operatorConfig.Spec.OSBuilds.GetDefaultBuildTTL()
-		} else {
-			ttlStr = automotivev1alpha1.DefaultBuildTTL
-		}
+	operatorConfig := &automotivev1alpha1.OperatorConfig{}
+	if err := r.Get(ctx, types.NamespacedName{
+		Name: "config", Namespace: controllerutils.OperatorNamespace(),
+	}, operatorConfig); err != nil && !errors.IsNotFound(err) {
+		return 0, fmt.Errorf("failed to load OperatorConfig: %w", err)
 	}
-
-	if ttlStr == "0" {
-		return 0, nil
-	}
-
-	ttl, err := time.ParseDuration(ttlStr)
-	if err != nil {
-		return 0, err
-	}
-	if ttl < 0 {
-		return 0, fmt.Errorf("TTL must not be negative: %s", ttlStr)
-	}
-	return ttl, nil
+	return controllerutils.ResolveBuildTTL(imageBuild.Spec.GetTTL(), operatorConfig.Spec.OSBuilds)
 }
 
 // updateExpiresAt sets or clears status.ExpiresAt. Pass nil to clear.
@@ -608,21 +585,10 @@ func (r *ImageBuildReconciler) updateExpiresAt(
 	imageBuild *automotivev1alpha1.ImageBuild,
 	expiresAt *time.Time,
 ) error {
-	var desired *metav1.Time
-	if expiresAt != nil {
-		truncated := expiresAt.Truncate(time.Second)
-		t := metav1.NewTime(truncated)
-		desired = &t
-	}
-
-	if imageBuild.Status.ExpiresAt == nil && desired == nil {
+	desired, needsUpdate := controllerutils.ComputeExpiresAt(imageBuild.Status.ExpiresAt, expiresAt)
+	if !needsUpdate {
 		return nil
 	}
-	if imageBuild.Status.ExpiresAt != nil && desired != nil &&
-		imageBuild.Status.ExpiresAt.Time.Equal(desired.Time) {
-		return nil
-	}
-
 	fresh := &automotivev1alpha1.ImageBuild{}
 	if err := r.Get(ctx, types.NamespacedName{
 		Name: imageBuild.Name, Namespace: imageBuild.Namespace,


### PR DESCRIPTION
Similar to expiration on ImageBuild. This also includes a small refactor to reduce duplication

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [X] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added container build TTL support, including a new terminal **Expired** phase and **expiresAt** tracking in build status.
  * Listings now show an **Expires** column; builds transition to **Expired** when the effective TTL elapses.
  * Supports operator-configured default TTL, per-build TTL overrides, **TTL=0** to disable expiry, and a **NoExpire** annotation to clear expiry.
* **Refactor**
  * Centralized TTL resolution and expiry timestamp computation for consistency across build controllers.
* **Tests**
  * Added comprehensive coverage for TTL resolution, timing/requeue behavior, phase transitions, status updates, and cleanup of associated build runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->