### PR TITLE
fix: allow reading cluster routes

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -35,6 +35,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+- apiGroups:
   - security.openshift.io
   resources:
   - securitycontextconstraints

--- a/internal/controller/imagebuild/controller.go
+++ b/internal/controller/imagebuild/controller.go
@@ -197,6 +197,7 @@ type ImageBuildReconciler struct {
 // +kubebuilder:rbac:groups="",namespace=system,resources=pods/exec,verbs=create;get
 // +kubebuilder:rbac:groups="",namespace=system,resources=pods/log,verbs=get
 // +kubebuilder:rbac:groups="",namespace=system,resources=services,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get
 // +kubebuilder:rbac:groups=route.openshift.io,namespace=system,resources=routes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",namespace=system,resources=events,verbs=create;patch
 

--- a/test/e2e/bootc_build_test.go
+++ b/test/e2e/bootc_build_test.go
@@ -19,6 +19,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os/exec"
 	"strings"
 	"time"
 
@@ -90,6 +91,66 @@ var _ = Describe("Bootc Container Build", Label("bootc"), Ordered, func() {
 
 		By("verifying container build appears in caib list")
 		verifyCaibList(containerBuildName)
+	})
+})
+
+var _ = Describe("Internal Registry Build", Label("internal-registry"), Ordered, func() {
+
+	BeforeAll(func() {
+		ensureOperatorDeployed()
+		if !openShiftCluster {
+			Skip("internal registry tests require an OpenShift cluster")
+		}
+		ensureBuildAPIAccess()
+		ensureCaibCredentials()
+
+		By("enabling insecure registry for internal registry builds")
+		patch := `{"spec":{"osBuilds":{"insecureRegistry":true}}}`
+		cmd := exec.Command("kubectl", "patch", "operatorconfig", "config",
+			"-n", testNamespace, "--type=merge", "-p", patch)
+		_, err := utils.Run(cmd)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	})
+
+	It("should build and push to the internal registry via --internal-registry", func() {
+		buildName := "e2e-test-internal-registry"
+
+		type buildResult struct {
+			output []byte
+			err    error
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), caibBuildTimeout)
+		defer cancel()
+
+		ch := make(chan buildResult, 1)
+
+		By("launching build with --internal-registry")
+		go func() {
+			cmd := utils.NewCaibCommand(ctx, caibEnv,
+				"image", "build",
+				caibBuildManifest,
+				"--name", buildName,
+				"--arch", arch,
+				"--internal-registry",
+				"--follow")
+			out, err := utils.RunSafe(cmd)
+			ch <- buildResult{output: out, err: err}
+		}()
+
+		select {
+		case r := <-ch:
+			By("verifying internal registry build completed successfully")
+			_, _ = fmt.Fprintf(GinkgoWriter, "\n--- caib internal-registry build (%s) ---\n%s\n",
+				buildName, string(r.output))
+			ExpectWithOffset(1, r.err).NotTo(HaveOccurred(),
+				fmt.Sprintf("internal registry build failed:\n%sError: %v\n", string(r.output), r.err))
+		case <-ctx.Done():
+			Fail(fmt.Sprintf("caib build did not complete within %v", caibBuildTimeout))
+		}
+
+		By("verifying build appears in caib list")
+		verifyCaibList(buildName)
 	})
 })
 


### PR DESCRIPTION
Otherwise --internal-registry will not work

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [X] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenShift Route resource access permissions for the system controller.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->