### PR TITLE
fix: use config API for OpenShift cluster detection in e2e tests

### DIFF
--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -104,19 +104,13 @@ func RunSafe(cmd *exec.Cmd) ([]byte, error) {
 
 // IsOpenShiftCluster returns true when the target cluster is OpenShift.
 // It checks the OPENSHIFT_CLUSTER env var first (set explicitly by run-e2e-local.sh),
-// then falls back to probing the Route CRD dynamically.
-// Prefer this over HasOpenShiftRouteCRD for branching on cluster type.
+// then falls back to probing the OpenShift config API.
 func IsOpenShiftCluster() bool {
 	v := strings.TrimSpace(os.Getenv("OPENSHIFT_CLUSTER"))
 	if strings.EqualFold(v, "true") || v == "1" {
 		return true
 	}
-	return HasOpenShiftRouteCRD()
-}
-
-// HasOpenShiftRouteCRD returns true when the cluster exposes the OpenShift Route CRD.
-func HasOpenShiftRouteCRD() bool {
-	cmd := exec.Command("kubectl", "get", "crd", "routes.route.openshift.io")
+	cmd := exec.Command("kubectl", "get", "--raw", "/apis/config.openshift.io/v1")
 	_, err := Run(cmd)
 	return err == nil
 }


### PR DESCRIPTION
The previous check used `kubectl get crd routes.route.openshift.io`, which fails on OpenShift because Routes are a built-in API type, not a CRD. Probe `/apis/config.openshift.io/v1` instead — the canonical OpenShift API group that is always present on OpenShift clusters.

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced OpenShift environment detection for improved reliability and accuracy in cluster identification, while maintaining support for configuration environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->