### PR TITLE
feat: manifest validation

### DIFF
--- a/cmd/caib/README.md
+++ b/cmd/caib/README.md
@@ -682,6 +682,7 @@ Supported locations:
 | `REGISTRY_USERNAME` | Registry username for push operations |
 | `REGISTRY_PASSWORD` | Registry password for push operations |
 | `REGISTRY_AUTH_FILE` | Path to Docker/Podman auth file (auto-discovery candidate) |
+| `CAIB_SKIP_MANIFEST_VALIDATION` | Skip local manifest schema validation when set to any value |
 
 ## Timeouts and Retries
 

--- a/cmd/caib/buildcmd/build.go
+++ b/cmd/caib/buildcmd/build.go
@@ -17,6 +17,7 @@ import (
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/registryauth"
 	buildapitypes "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi"
 	buildapiclient "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi/client"
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/manifestschema"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
@@ -34,6 +35,8 @@ const (
 )
 
 var isTerminalPhase = automotivev1alpha1.IsTerminalBuildPhase
+
+var validateFromImageFn = manifestschema.ValidateFromImage
 
 // Options wires build handlers to caller-owned state and helper functions.
 type Options struct {
@@ -233,6 +236,31 @@ func (h *Handler) resolveTarget(cmd *cobra.Command, manifestTarget string) {
 	}
 
 	*h.opts.Target = "qemu"
+}
+
+func (h *Handler) validateManifestSchema(config *buildapitypes.OperatorConfigResponse, manifest []byte) bool {
+	if os.Getenv("CAIB_SKIP_MANIFEST_VALIDATION") != "" {
+		return true
+	}
+
+	imageRef := *h.opts.AutomotiveImageBuilder
+	if imageRef == automotivev1alpha1.DefaultAutomotiveImageBuilderImage && config != nil && config.AutomotiveImageBuilder != "" {
+		imageRef = config.AutomotiveImageBuilder
+	}
+	if imageRef == "" {
+		return true
+	}
+
+	result, err := validateFromImageFn(imageRef, manifest)
+	if err != nil {
+		clilog.Warnf("Skipping local manifest validation: %v\n", err)
+		return true
+	}
+	if !result.Valid {
+		h.handleError(fmt.Errorf("%s", result.Error()))
+		return false
+	}
+	return true
 }
 
 // fetchTargetDefaults fetches the operator config once and returns it.
@@ -505,6 +533,17 @@ func (h *Handler) RunBuild(cmd *cobra.Command, args []string) {
 
 	h.resolveTarget(cmd, common.ManifestTarget(manifestBytes))
 
+	validateFlash := *h.opts.FlashAfterBuild && *h.opts.ExporterSelector == ""
+	operatorConfig, cfgErr := h.fetchTargetDefaults(ctx, api, *h.opts.Target, validateFlash)
+	if cfgErr != nil {
+		h.handleError(cfgErr)
+		return
+	}
+
+	if !h.validateManifestSchema(operatorConfig, manifestBytes) {
+		return
+	}
+
 	customDefs, err := h.resolveCustomDefs()
 	if err != nil {
 		h.handleError(err)
@@ -544,12 +583,6 @@ func (h *Handler) RunBuild(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	validateFlash := *h.opts.FlashAfterBuild && *h.opts.ExporterSelector == ""
-	operatorConfig, cfgErr := h.fetchTargetDefaults(ctx, api, *h.opts.Target, validateFlash)
-	if cfgErr != nil {
-		h.handleError(cfgErr)
-		return
-	}
 	ApplyTargetDefaults(cmd, operatorConfig, &req)
 
 	if err := h.applyFlashOptions(&req, "--push-disk"); err != nil {
@@ -758,6 +791,17 @@ func (h *Handler) RunBuildDev(cmd *cobra.Command, args []string) {
 
 	h.resolveTarget(cmd, common.ManifestTarget(manifestBytes))
 
+	validateFlash := *h.opts.FlashAfterBuild && *h.opts.ExporterSelector == ""
+	operatorConfig, cfgErr := h.fetchTargetDefaults(ctx, api, *h.opts.Target, validateFlash)
+	if cfgErr != nil {
+		h.handleError(cfgErr)
+		return
+	}
+
+	if !h.validateManifestSchema(operatorConfig, manifestBytes) {
+		return
+	}
+
 	customDefs, err := h.resolveCustomDefs()
 	if err != nil {
 		h.handleError(err)
@@ -809,12 +853,6 @@ func (h *Handler) RunBuildDev(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	validateFlash := *h.opts.FlashAfterBuild && *h.opts.ExporterSelector == ""
-	operatorConfig, cfgErr := h.fetchTargetDefaults(ctx, api, *h.opts.Target, validateFlash)
-	if cfgErr != nil {
-		h.handleError(cfgErr)
-		return
-	}
 	ApplyTargetDefaults(cmd, operatorConfig, &req)
 
 	if err := h.applyFlashOptions(&req, "--push"); err != nil {

--- a/cmd/caib/buildcmd/build_validate_test.go
+++ b/cmd/caib/buildcmd/build_validate_test.go
@@ -1,0 +1,81 @@
+package buildcmd
+
+import (
+	"testing"
+
+	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
+	buildapitypes "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi"
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/manifestschema"
+)
+
+func TestValidateManifestSchemaImagePriority(t *testing.T) {
+	const (
+		flagImage     = "quay.io/custom/aib:v1"
+		configImage   = "quay.io/cluster/aib:v2"
+		defaultImage  = automotivev1alpha1.DefaultAutomotiveImageBuilderImage
+		dummyManifest = "name: test"
+	)
+
+	tests := []struct {
+		name          string
+		flagValue     string
+		configImage   string
+		wantImageUsed string
+	}{
+		{
+			name:          "explicit flag takes precedence over operator config",
+			flagValue:     flagImage,
+			configImage:   configImage,
+			wantImageUsed: flagImage,
+		},
+		{
+			name:          "operator config used when flag is default",
+			flagValue:     defaultImage,
+			configImage:   configImage,
+			wantImageUsed: configImage,
+		},
+		{
+			name:          "default used when no operator config",
+			flagValue:     defaultImage,
+			configImage:   "",
+			wantImageUsed: defaultImage,
+		},
+		{
+			name:          "explicit flag used when no operator config",
+			flagValue:     flagImage,
+			configImage:   "",
+			wantImageUsed: flagImage,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			orig := validateFromImageFn
+			defer func() { validateFromImageFn = orig }()
+
+			var capturedImageRef string
+			validateFromImageFn = func(imageRef string, _ []byte) (manifestschema.ValidationResult, error) {
+				capturedImageRef = imageRef
+				return manifestschema.ValidationResult{Valid: true}, nil
+			}
+
+			aibImage := tc.flagValue
+			opts := newTestDiskOpts()
+			opts.AutomotiveImageBuilder = &aibImage
+
+			var config *buildapitypes.OperatorConfigResponse
+			if tc.configImage != "" {
+				config = &buildapitypes.OperatorConfigResponse{
+					AutomotiveImageBuilder: tc.configImage,
+				}
+			}
+
+			h := NewHandler(opts)
+			h.validateManifestSchema(config, []byte(dummyManifest))
+
+			if capturedImageRef != tc.wantImageUsed {
+				t.Errorf("validateManifestSchema used image %q, want %q", capturedImageRef, tc.wantImageUsed)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.7
 require (
 	github.com/containers/image/v5 v5.36.2
 	github.com/containers/storage v1.59.1
+	github.com/dlclark/regexp2 v1.12.0
 	github.com/docker/cli v29.4.0+incompatible
 	github.com/fatih/color v1.18.0
 	github.com/gin-gonic/gin v1.10.1
@@ -15,6 +16,7 @@ require (
 	github.com/onsi/gomega v1.39.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/shipwright-io/build v0.18.3
 	github.com/sigstore/cosign/v3 v3.0.6
 	github.com/sigstore/sigstore v1.10.5

--- a/go.sum
+++ b/go.sum
@@ -148,6 +148,8 @@ github.com/digitorus/timestamp v0.0.0-20231217203849-220c5c2851b7 h1:lxmTCgmHE1G
 github.com/digitorus/timestamp v0.0.0-20231217203849-220c5c2851b7/go.mod h1:GvWntX9qiTlOud0WkQ6ewFm0LPy5JUR1Xo0Ngbd1w6Y=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
+github.com/dlclark/regexp2 v1.12.0 h1:0j4c5qQmnC6XOWNjP3PIXURXN2gWx76rd3KvgdPkCz8=
+github.com/dlclark/regexp2 v1.12.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/docker/cli v29.4.0+incompatible h1:+IjXULMetlvWJiuSI0Nbor36lcJ5BTcVpUmB21KBoVM=
 github.com/docker/cli v29.4.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=

--- a/internal/buildapi/progress.go
+++ b/internal/buildapi/progress.go
@@ -3,6 +3,7 @@ package buildapi
 import (
 	"context"
 	"net/http"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -109,6 +110,24 @@ func stageForPipelineTask(taskName string) string {
 	}
 }
 
+// pendingPodStage returns a human-readable stage name for a pod that is
+// still in the Pending phase, based on container waiting reasons.
+func pendingPodStage(pod *corev1.Pod) string {
+	statuses := slices.Concat(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses)
+	for _, cs := range statuses {
+		if cs.State.Waiting == nil {
+			continue
+		}
+		switch cs.State.Waiting.Reason {
+		case "ContainerCreating", "PodInitializing":
+			return "Pulling image"
+		case "ErrImagePull", "ImagePullBackOff":
+			return "Pulling image (retrying)"
+		}
+	}
+	return ""
+}
+
 // readTaskProgressFromPods reads the progress annotation from each pipeline
 // task pod, sorted by pod start time. For pods that don't have the annotation
 // yet (e.g. just started), a synthetic marker is generated when the pod is
@@ -145,7 +164,8 @@ func readTaskProgressFromPods(ctx context.Context, cs *kubernetes.Clientset, pip
 
 		// Synthesize a marker for pods that don't have the annotation
 		// yet so the progress bar advances when tasks start running.
-		if pod.Status.Phase == corev1.PodRunning || pod.Status.Phase == corev1.PodSucceeded {
+		switch pod.Status.Phase {
+		case corev1.PodRunning, corev1.PodSucceeded:
 			done := 0
 			if pod.Status.Phase == corev1.PodSucceeded {
 				done = 1
@@ -154,6 +174,15 @@ func readTaskProgressFromPods(ctx context.Context, cs *kubernetes.Clientset, pip
 				taskName: taskName,
 				marker:   BuildStep{Stage: stageForPipelineTask(taskName), Done: done, Total: 1},
 			})
+		case corev1.PodPending:
+			// Surface image-pull or container-creating status so the
+			// user knows the pod is making progress, not stuck.
+			if stage := pendingPodStage(&pod); stage != "" {
+				results = append(results, taskProgress{
+					taskName: taskName,
+					marker:   BuildStep{Stage: stage, Done: 0, Total: 1},
+				})
+			}
 		}
 	}
 

--- a/internal/buildapi/progress_test.go
+++ b/internal/buildapi/progress_test.go
@@ -1,0 +1,72 @@
+package buildapi
+
+import (
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("pendingPodStage", func() {
+	It("returns empty string for pod with no waiting containers", func() {
+		pod := &corev1.Pod{
+			Status: corev1.PodStatus{
+				Phase: corev1.PodPending,
+			},
+		}
+		Expect(pendingPodStage(pod)).To(BeEmpty())
+	})
+
+	DescribeTable("returns expected stage for waiting reason",
+		func(reason, expected string) {
+			pod := &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							State: corev1.ContainerState{
+								Waiting: &corev1.ContainerStateWaiting{Reason: reason},
+							},
+						},
+					},
+				},
+			}
+			Expect(pendingPodStage(pod)).To(Equal(expected))
+		},
+		Entry("ContainerCreating", "ContainerCreating", "Pulling image"),
+		Entry("PodInitializing", "PodInitializing", "Pulling image"),
+		Entry("ErrImagePull", "ErrImagePull", "Pulling image (retrying)"),
+		Entry("ImagePullBackOff", "ImagePullBackOff", "Pulling image (retrying)"),
+	)
+
+	It("detects waiting init containers", func() {
+		pod := &corev1.Pod{
+			Status: corev1.PodStatus{
+				Phase: corev1.PodPending,
+				InitContainerStatuses: []corev1.ContainerStatus{
+					{
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{Reason: "ContainerCreating"},
+						},
+					},
+				},
+			},
+		}
+		Expect(pendingPodStage(pod)).To(Equal("Pulling image"))
+	})
+
+	It("returns empty for unrecognized waiting reason", func() {
+		pod := &corev1.Pod{
+			Status: corev1.PodStatus{
+				Phase: corev1.PodPending,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{Reason: "Unschedulable"},
+						},
+					},
+				},
+			},
+		}
+		Expect(pendingPodStage(pod)).To(BeEmpty())
+	})
+})

--- a/internal/buildapi/server.go
+++ b/internal/buildapi/server.go
@@ -42,6 +42,7 @@ import (
 	"github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi/catalog"
 	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/bundleverify"
 	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/labels"
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/manifestschema"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
@@ -1093,6 +1094,35 @@ func verifyWorkspaceImage(ctx context.Context, k8sClient client.Client, namespac
 	return 0, nil
 }
 
+func (a *APIServer) validateManifestSchema(c *gin.Context, span trace.Span, req *BuildRequest) bool {
+	result, err := manifestschema.ValidateFromImage(req.AutomotiveImageBuilder, []byte(req.Manifest))
+	if err != nil {
+		a.log.Info("Skipping manifest schema validation", "error", err, "reqID", c.GetString("reqID"))
+		return true
+	}
+	if !result.Valid {
+		spanError(span, fmt.Errorf("%s", result.Error()))
+		c.JSON(http.StatusBadRequest, gin.H{"error": result.Error()})
+		return false
+	}
+	return true
+}
+
+func (a *APIServer) applyExtraRepos(ctx context.Context, c *gin.Context, span trace.Span, k8sClient client.Client, req *BuildRequest) bool {
+	restCfg, err := getRESTConfigFromRequest(c)
+	if err != nil {
+		spanError(span, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get kubernetes config"})
+		return false
+	}
+	if err := a.resolveExtraRepos(ctx, k8sClient, restCfg, req); err != nil {
+		spanError(span, err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return false
+	}
+	return true
+}
+
 func (a *APIServer) createBuild(c *gin.Context) {
 	ctx, span := apiTracer.Start(c.Request.Context(), "createBuild")
 	defer span.End()
@@ -1119,6 +1149,10 @@ func (a *APIServer) createBuild(c *gin.Context) {
 		return
 	}
 
+	if !a.validateManifestSchema(c, span, &req) {
+		return
+	}
+
 	k8sClient, err := getK8sClientOrFail(c)
 	if err != nil {
 		spanError(span, err)
@@ -1134,17 +1168,8 @@ func (a *APIServer) createBuild(c *gin.Context) {
 		return
 	}
 
-	// Resolve --extra-repo workspace:path pairs into extra_repos custom defines
 	if len(req.ExtraRepos) > 0 {
-		restCfgForRepos, err := getRESTConfigFromRequest(c)
-		if err != nil {
-			spanError(span, err)
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get kubernetes config"})
-			return
-		}
-		if err := a.resolveExtraRepos(ctx, k8sClient, restCfgForRepos, &req); err != nil {
-			spanError(span, err)
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		if !a.applyExtraRepos(ctx, c, span, k8sClient, &req) {
 			return
 		}
 	}
@@ -1590,8 +1615,10 @@ func (a *APIServer) handleGetOperatorConfig(c *gin.Context) {
 	operatorConfig, err := loadOperatorConfigFn(ctx, k8sClient, namespace)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			a.log.Info("OperatorConfig not found; returning empty operator config response", "reqID", reqID, "namespace", namespace)
-			c.JSON(http.StatusOK, OperatorConfigResponse{})
+			a.log.Info("OperatorConfig not found; returning defaults", "reqID", reqID, "namespace", namespace)
+			c.JSON(http.StatusOK, OperatorConfigResponse{
+				AutomotiveImageBuilder: automotivev1alpha1.DefaultAutomotiveImageBuilderImage,
+			})
 			return
 		}
 		a.log.Error(err, "failed to get OperatorConfig", "reqID", reqID, "namespace", namespace)
@@ -1600,7 +1627,9 @@ func (a *APIServer) handleGetOperatorConfig(c *gin.Context) {
 	}
 
 	// Build the response with Jumpstarter target mappings (flash-specific, from CRD)
-	response := OperatorConfigResponse{}
+	response := OperatorConfigResponse{
+		AutomotiveImageBuilder: operatorConfig.Spec.GetImages().GetAutomotiveImageBuilderImage(),
+	}
 
 	if operatorConfig.Spec.Jumpstarter != nil && len(operatorConfig.Spec.Jumpstarter.TargetMappings) > 0 {
 		response.JumpstarterTargets = make(map[string]JumpstarterTarget)

--- a/internal/buildapi/server_test.go
+++ b/internal/buildapi/server_test.go
@@ -539,7 +539,7 @@ var _ = Describe("APIServer", func() {
 			}
 		})
 
-		It("should return empty operator config when config resource is not found", func() {
+		It("should return default AIB image when config resource is not found", func() {
 			getClientFromRequestFn = func(_ *gin.Context) (ctrlclient.Client, error) {
 				return nil, nil
 			}
@@ -565,6 +565,7 @@ var _ = Describe("APIServer", func() {
 			Expect(w.Code).To(Equal(http.StatusOK))
 			var response OperatorConfigResponse
 			Expect(json.Unmarshal(w.Body.Bytes(), &response)).To(Succeed())
+			Expect(response.AutomotiveImageBuilder).To(Equal(automotivev1alpha1.DefaultAutomotiveImageBuilderImage))
 			Expect(response.JumpstarterTargets).To(BeNil())
 			Expect(response.TargetDefaults).To(BeNil())
 		})

--- a/internal/buildapi/types.go
+++ b/internal/buildapi/types.go
@@ -355,6 +355,8 @@ type OperatorConfigResponse struct {
 	JumpstarterTargets map[string]JumpstarterTarget `json:"jumpstarterTargets,omitempty"`
 	// TargetDefaults contains build defaults per target (from ConfigMap)
 	TargetDefaults map[string]TargetDefaults `json:"targetDefaults,omitempty"`
+	// AutomotiveImageBuilder is the resolved AIB container image (from OperatorConfig or default)
+	AutomotiveImageBuilder string `json:"automotiveImageBuilder,omitempty"`
 }
 
 type (

--- a/internal/common/manifestschema/cache.go
+++ b/internal/common/manifestschema/cache.go
@@ -1,0 +1,104 @@
+package manifestschema
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const cacheSubdir = "caib/schemas"
+
+var schemaCacheDir = defaultCacheDir
+
+func defaultCacheDir() (string, error) {
+	base, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, cacheSubdir), nil
+}
+
+func cacheKeyFor(digest string) string {
+	h := sha256.Sum256([]byte(digest))
+	return hex.EncodeToString(h[:])
+}
+
+func loadCachedSchema(digest string) []byte {
+	dir, err := schemaCacheDir()
+	if err != nil {
+		return nil
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, cacheKeyFor(digest)+".yml"))
+	if err != nil {
+		return nil
+	}
+	return data
+}
+
+var digestCacheTTL = 5 * time.Minute
+
+func loadCachedDigest(imageRef string) string {
+	dir, err := schemaCacheDir()
+	if err != nil {
+		return ""
+	}
+	path := filepath.Join(dir, "digest-"+cacheKeyFor(imageRef)+".txt")
+	info, err := os.Stat(path)
+	if err != nil {
+		return ""
+	}
+	if time.Since(info.ModTime()) > digestCacheTTL {
+		return ""
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	d := strings.TrimSpace(string(data))
+	algo, hexPart, ok := strings.Cut(d, ":")
+	if !ok || algo == "" || hexPart == "" {
+		return ""
+	}
+	return d
+}
+
+func atomicWriteFile(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmp.Name())
+		return err
+	}
+	return os.Rename(tmp.Name(), path)
+}
+
+func saveCachedDigest(imageRef, digest string) {
+	dir, err := schemaCacheDir()
+	if err != nil {
+		return
+	}
+	_ = atomicWriteFile(filepath.Join(dir, "digest-"+cacheKeyFor(imageRef)+".txt"), []byte(digest))
+}
+
+func saveCachedSchema(digest string, data []byte) error {
+	dir, err := schemaCacheDir()
+	if err != nil {
+		return err
+	}
+	return atomicWriteFile(filepath.Join(dir, cacheKeyFor(digest)+".yml"), data)
+}

--- a/internal/common/manifestschema/cache_test.go
+++ b/internal/common/manifestschema/cache_test.go
@@ -1,0 +1,148 @@
+package manifestschema
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func withTempCacheDir(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	original := schemaCacheDir
+	schemaCacheDir = func() (string, error) { return dir, nil }
+	t.Cleanup(func() { schemaCacheDir = original })
+}
+
+func TestCacheKeyDeterminism(t *testing.T) {
+	a := cacheKeyFor("sha256:abc123")
+	b := cacheKeyFor("sha256:abc123")
+	if a != b {
+		t.Errorf("same input produced different keys: %s vs %s", a, b)
+	}
+	c := cacheKeyFor("sha256:def456")
+	if a == c {
+		t.Error("different inputs produced same key")
+	}
+}
+
+const (
+	testDigest   = "sha256:abc123"
+	testImageRef = "quay.io/org/repo:latest"
+)
+
+func TestCacheHit(t *testing.T) {
+	withTempCacheDir(t)
+	data := []byte("type: object\n")
+	digest := testDigest
+
+	if err := saveCachedSchema(digest, data); err != nil {
+		t.Fatalf("save failed: %v", err)
+	}
+
+	got := loadCachedSchema(digest)
+	if got == nil {
+		t.Fatal("expected cache hit")
+	}
+	if string(got) != string(data) {
+		t.Errorf("got %q, want %q", got, data)
+	}
+}
+
+func TestCacheMissNonexistent(t *testing.T) {
+	withTempCacheDir(t)
+	got := loadCachedSchema("sha256:doesnotexist")
+	if got != nil {
+		t.Error("expected nil for nonexistent key")
+	}
+}
+
+func TestSaveCreatesCacheDir(t *testing.T) {
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "deep", "nested")
+	schemaCacheDir = func() (string, error) { return nested, nil }
+	t.Cleanup(func() { schemaCacheDir = defaultCacheDir })
+
+	err := saveCachedSchema("sha256:abc123", []byte("data"))
+	if err != nil {
+		t.Fatalf("save failed: %v", err)
+	}
+
+	if _, err := os.Stat(nested); os.IsNotExist(err) {
+		t.Error("expected cache directory to be created")
+	}
+}
+
+func TestCacheImmutable(t *testing.T) {
+	withTempCacheDir(t)
+	digest := testDigest
+	data := []byte("type: object\n")
+
+	if err := saveCachedSchema(digest, data); err != nil {
+		t.Fatalf("save failed: %v", err)
+	}
+
+	got := loadCachedSchema(digest)
+	if got == nil {
+		t.Fatal("expected cache hit — digest entries never expire")
+	}
+}
+
+func TestDigestCacheHit(t *testing.T) {
+	withTempCacheDir(t)
+	saveCachedDigest(testImageRef, testDigest)
+
+	got := loadCachedDigest(testImageRef)
+	if got != testDigest {
+		t.Errorf("got %q, want %q", got, testDigest)
+	}
+}
+
+func TestDigestCacheMiss(t *testing.T) {
+	withTempCacheDir(t)
+	got := loadCachedDigest("quay.io/org/repo:nonexistent")
+	if got != "" {
+		t.Errorf("expected empty string for miss, got %q", got)
+	}
+}
+
+func TestDigestCacheExpired(t *testing.T) {
+	withTempCacheDir(t)
+	saveCachedDigest(testImageRef, testDigest)
+
+	// Backdate the file to make it expired.
+	dir, _ := schemaCacheDir()
+	path := filepath.Join(dir, "digest-"+cacheKeyFor(testImageRef)+".txt")
+	old := time.Now().Add(-10 * time.Minute)
+	_ = os.Chtimes(path, old, old)
+
+	got := loadCachedDigest(testImageRef)
+	if got != "" {
+		t.Errorf("expected empty string for expired entry, got %q", got)
+	}
+}
+
+func TestDigestCacheMalformed(t *testing.T) {
+	withTempCacheDir(t)
+	dir, _ := schemaCacheDir()
+	_ = os.MkdirAll(dir, 0755)
+	target := filepath.Join(dir, "digest-"+cacheKeyFor(testImageRef)+".txt")
+	_ = os.WriteFile(target, []byte("garbage"), 0644)
+
+	got := loadCachedDigest(testImageRef)
+	if got != "" {
+		t.Errorf("expected empty string for malformed digest, got %q", got)
+	}
+}
+
+func TestDigestCacheOverwrite(t *testing.T) {
+	withTempCacheDir(t)
+	saveCachedDigest(testImageRef, "sha256:old")
+	saveCachedDigest(testImageRef, "sha256:new")
+
+	got := loadCachedDigest(testImageRef)
+	if got != "sha256:new" {
+		t.Errorf("got %q, want %q", got, "sha256:new")
+	}
+}

--- a/internal/common/manifestschema/extract.go
+++ b/internal/common/manifestschema/extract.go
@@ -1,0 +1,90 @@
+package manifestschema
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+// FetchImageFn is the function used to pull a container image.
+// Replaceable for testing.
+var FetchImageFn = func(ref name.Reference) (v1.Image, error) {
+	return remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+}
+
+// ResolveDigestFn resolves an image reference to its digest string.
+// Replaceable for testing.
+var ResolveDigestFn = func(ref name.Reference) (string, error) {
+	desc, err := remote.Head(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil {
+		return "", err
+	}
+	return desc.Digest.String(), nil
+}
+
+// ExtractSchemaFromImage extracts manifest_schema.yml from an AIB container
+// image by pulling its layers from the registry.
+func ExtractSchemaFromImage(imageRef string) ([]byte, error) {
+	ref, err := name.ParseReference(imageRef)
+	if err != nil {
+		return nil, fmt.Errorf("parsing image reference %q: %w", imageRef, err)
+	}
+
+	img, err := FetchImageFn(ref)
+	if err != nil {
+		return nil, fmt.Errorf("pulling image %q: %w", imageRef, err)
+	}
+
+	layers, err := img.Layers()
+	if err != nil {
+		return nil, fmt.Errorf("getting image layers: %w", err)
+	}
+
+	for i := len(layers) - 1; i >= 0; i-- {
+		data, err := findFileInLayer(layers[i], SchemaPathInContainer)
+		if err != nil {
+			continue
+		}
+		if data != nil {
+			return data, nil
+		}
+	}
+
+	return nil, fmt.Errorf("manifest_schema.yml not found in image %s", imageRef)
+}
+
+func findFileInLayer(layer v1.Layer, targetPath string) ([]byte, error) {
+	rc, err := layer.Uncompressed()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rc.Close() }()
+
+	tr := tar.NewReader(rc)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		cleanName := strings.TrimPrefix(hdr.Name, "./")
+		cleanName = strings.TrimPrefix(cleanName, "/")
+		if cleanName == targetPath {
+			const maxSchemaSize = 10 << 20 // 10 MB
+			data, err := io.ReadAll(io.LimitReader(tr, maxSchemaSize))
+			if err != nil {
+				return nil, fmt.Errorf("reading %s: %w", targetPath, err)
+			}
+			return data, nil
+		}
+	}
+}

--- a/internal/common/manifestschema/extract_test.go
+++ b/internal/common/manifestschema/extract_test.go
@@ -1,0 +1,131 @@
+package manifestschema
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+type testLayer struct {
+	buf []byte
+}
+
+func newTestLayer(files map[string][]byte) *testLayer {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for n, content := range files {
+		_ = tw.WriteHeader(&tar.Header{Name: n, Size: int64(len(content)), Mode: 0644})
+		_, _ = tw.Write(content)
+	}
+	_ = tw.Close()
+	_ = gz.Close()
+	return &testLayer{buf: buf.Bytes()}
+}
+
+func (l *testLayer) Digest() (v1.Hash, error)            { return v1.Hash{}, nil }
+func (l *testLayer) DiffID() (v1.Hash, error)            { return v1.Hash{}, nil }
+func (l *testLayer) Size() (int64, error)                { return int64(len(l.buf)), nil }
+func (l *testLayer) MediaType() (types.MediaType, error) { return types.OCILayer, nil }
+func (l *testLayer) Compressed() (io.ReadCloser, error) {
+	return io.NopCloser(bytes.NewReader(l.buf)), nil
+}
+func (l *testLayer) Uncompressed() (io.ReadCloser, error) {
+	gz, err := gzip.NewReader(bytes.NewReader(l.buf))
+	if err != nil {
+		return nil, err
+	}
+	return gz, nil
+}
+
+type testImage struct{ layers []v1.Layer }
+
+func (i *testImage) Layers() ([]v1.Layer, error)             { return i.layers, nil }
+func (i *testImage) MediaType() (types.MediaType, error)     { return types.DockerManifestSchema2, nil }
+func (i *testImage) Size() (int64, error)                    { return 0, nil }
+func (i *testImage) ConfigName() (v1.Hash, error)            { return v1.Hash{}, nil }
+func (i *testImage) ConfigFile() (*v1.ConfigFile, error)     { return &v1.ConfigFile{}, nil }
+func (i *testImage) RawConfigFile() ([]byte, error)          { return []byte("{}"), nil }
+func (i *testImage) Digest() (v1.Hash, error)                { return v1.Hash{}, nil }
+func (i *testImage) Manifest() (*v1.Manifest, error)         { return &v1.Manifest{}, nil }
+func (i *testImage) RawManifest() ([]byte, error)            { return []byte("{}"), nil }
+func (i *testImage) LayerByDigest(v1.Hash) (v1.Layer, error) { return nil, fmt.Errorf("unimplemented") }
+func (i *testImage) LayerByDiffID(v1.Hash) (v1.Layer, error) { return nil, fmt.Errorf("unimplemented") }
+
+func TestExtractSchemaFromImage(t *testing.T) {
+	orig := FetchImageFn
+	defer func() { FetchImageFn = orig }()
+
+	t.Run("extracts from layer", func(t *testing.T) {
+		FetchImageFn = func(_ name.Reference) (v1.Image, error) {
+			return &testImage{layers: []v1.Layer{
+				newTestLayer(map[string][]byte{SchemaPathInContainer: minimalSchema}),
+			}}, nil
+		}
+		data, err := ExtractSchemaFromImage("fake:latest")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !bytes.Contains(data, []byte("$schema")) {
+			t.Error("expected schema content")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		FetchImageFn = func(_ name.Reference) (v1.Image, error) {
+			return &testImage{layers: []v1.Layer{
+				newTestLayer(map[string][]byte{"other/file": []byte("x")}),
+			}}, nil
+		}
+		_, err := ExtractSchemaFromImage("empty:latest")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("top layer wins", func(t *testing.T) {
+		old := []byte("type: object\n")
+		FetchImageFn = func(_ name.Reference) (v1.Image, error) {
+			return &testImage{layers: []v1.Layer{
+				newTestLayer(map[string][]byte{SchemaPathInContainer: old}),
+				newTestLayer(map[string][]byte{SchemaPathInContainer: minimalSchema}),
+			}}, nil
+		}
+		data, err := ExtractSchemaFromImage("layered:latest")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !bytes.Contains(data, []byte("additionalProperties")) {
+			t.Error("expected top layer schema")
+		}
+	})
+
+	t.Run("invalid ref", func(t *testing.T) {
+		_, err := ExtractSchemaFromImage("!!!invalid!!!")
+		if err == nil {
+			t.Fatal("expected error for invalid ref")
+		}
+	})
+
+	t.Run("handles ./ prefix in tar", func(t *testing.T) {
+		FetchImageFn = func(_ name.Reference) (v1.Image, error) {
+			return &testImage{layers: []v1.Layer{
+				newTestLayer(map[string][]byte{"./" + SchemaPathInContainer: []byte("found")}),
+			}}, nil
+		}
+		data, err := ExtractSchemaFromImage("prefixed:latest")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if string(data) != "found" {
+			t.Errorf("got %q, want %q", data, "found")
+		}
+	})
+}

--- a/internal/common/manifestschema/validate.go
+++ b/internal/common/manifestschema/validate.go
@@ -1,0 +1,198 @@
+// Package manifestschema provides AIB manifest validation against the JSON Schema
+// extracted from the automotive-image-builder container image.
+// This package has no gin, k8s, or server dependencies and can be used by both
+// the build API server and the caib CLI.
+package manifestschema
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/dlclark/regexp2"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	printer       = message.NewPrinter(language.English)
+	compiledCache sync.Map // digest → *jsonschema.Schema
+)
+
+// SchemaPathInContainer is where the AIB RPM installs the manifest schema.
+const SchemaPathInContainer = "usr/lib/automotive-image-builder/files/manifest_schema.yml"
+
+// ValidationResult holds the outcome of a manifest validation.
+type ValidationResult struct {
+	Valid  bool
+	Errors []string
+}
+
+func (r ValidationResult) Error() string {
+	return fmt.Sprintf("manifest validation errors:\n  - %s", strings.Join(r.Errors, "\n  - "))
+}
+
+// ValidateFromImage extracts a schema from the given AIB container image and
+// validates the manifest against it. Resolves the image tag to a digest first,
+// then checks a content-addressed cache before pulling layers.
+func ValidateFromImage(imageRef string, manifest []byte) (ValidationResult, error) {
+	if os.Getenv("CAIB_SKIP_MANIFEST_VALIDATION") != "" {
+		return ValidationResult{Valid: true}, nil
+	}
+
+	ref, err := name.ParseReference(imageRef)
+	if err != nil {
+		return ValidationResult{}, fmt.Errorf("parsing image reference %q: %w", imageRef, err)
+	}
+
+	var digest string
+	if cached := loadCachedDigest(imageRef); cached != "" {
+		digest = cached
+	} else {
+		digest, err = ResolveDigestFn(ref)
+		if err != nil {
+			return ValidationResult{}, fmt.Errorf("resolving digest for %q: %w", imageRef, err)
+		}
+		saveCachedDigest(imageRef, digest)
+	}
+
+	schemaYAML := loadCachedSchema(digest)
+	if schemaYAML == nil {
+		schemaYAML, err = ExtractSchemaFromImage(imageRef)
+		if err != nil {
+			return ValidationResult{}, err
+		}
+		_ = saveCachedSchema(digest, schemaYAML)
+	}
+
+	var schema *jsonschema.Schema
+	if cached, ok := compiledCache.Load(digest); ok {
+		schema = cached.(*jsonschema.Schema)
+	} else {
+		compiled, err := CompileSchema(schemaYAML)
+		if err != nil {
+			return ValidationResult{}, err
+		}
+		compiledCache.Store(digest, compiled)
+		schema = compiled
+	}
+
+	return ValidateManifest(schema, manifest), nil
+}
+
+// ValidateManifest validates a YAML manifest against a pre-compiled schema.
+func ValidateManifest(schema *jsonschema.Schema, manifest []byte) ValidationResult {
+	var data any
+	if err := yaml.Unmarshal(manifest, &data); err != nil {
+		return ValidationResult{
+			Valid:  false,
+			Errors: []string{fmt.Sprintf("invalid YAML: %v", err)},
+		}
+	}
+
+	data = ConvertYAMLToJSONCompatible(data)
+
+	err := schema.Validate(data)
+	if err == nil {
+		return ValidationResult{Valid: true}
+	}
+
+	var errors []string
+	if ve, ok := err.(*jsonschema.ValidationError); ok {
+		collectLeafErrors(ve, &errors)
+		if len(errors) == 0 {
+			errors = []string{ve.Error()}
+		}
+	} else {
+		errors = []string{err.Error()}
+	}
+
+	return ValidationResult{Valid: false, Errors: errors}
+}
+
+func collectLeafErrors(ve *jsonschema.ValidationError, out *[]string) {
+	if len(ve.Causes) == 0 {
+		loc := "/" + strings.Join(ve.InstanceLocation, "/")
+		*out = append(*out, fmt.Sprintf("%s: %s", loc, ve.ErrorKind.LocalizedString(printer)))
+		return
+	}
+	for _, cause := range ve.Causes {
+		collectLeafErrors(cause, out)
+	}
+}
+
+// CompileSchema parses a YAML schema and compiles it for validation.
+// Uses an ECMA-262 compatible regexp engine to support patterns with
+// negative lookaheads used in the AIB schema.
+func CompileSchema(schemaYAML []byte) (*jsonschema.Schema, error) {
+	var schemaObj any
+	if err := yaml.Unmarshal(schemaYAML, &schemaObj); err != nil {
+		return nil, fmt.Errorf("parsing schema YAML: %w", err)
+	}
+	schemaObj = ConvertYAMLToJSONCompatible(schemaObj)
+
+	compiler := jsonschema.NewCompiler()
+	compiler.UseRegexpEngine(ecmaRegexpEngine)
+	if err := compiler.AddResource("manifest_schema.json", schemaObj); err != nil {
+		return nil, fmt.Errorf("adding schema resource: %w", err)
+	}
+
+	return compiler.Compile("manifest_schema.json")
+}
+
+// ecmaRegexp adapts regexp2 to the jsonschema.Regexp interface.
+type ecmaRegexp struct {
+	re  *regexp2.Regexp
+	src string
+}
+
+func (r *ecmaRegexp) MatchString(s string) bool {
+	m, err := r.re.MatchString(s)
+	if err != nil {
+		slog.Warn("regexp2 match failed, skipping pattern check", "pattern", r.src, "error", err)
+		return true
+	}
+	return m
+}
+
+func (r *ecmaRegexp) String() string { return r.src }
+
+func ecmaRegexpEngine(s string) (jsonschema.Regexp, error) {
+	re, err := regexp2.Compile(s, regexp2.ECMAScript)
+	if err != nil {
+		return nil, err
+	}
+	return &ecmaRegexp{re: re, src: s}, nil
+}
+
+// ConvertYAMLToJSONCompatible converts YAML-decoded data to JSON-compatible types.
+// YAML can decode maps as map[any]any; JSON Schema validation expects map[string]any.
+func ConvertYAMLToJSONCompatible(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		result := make(map[string]any, len(val))
+		for k, v := range val {
+			result[k] = ConvertYAMLToJSONCompatible(v)
+		}
+		return result
+	case map[any]any:
+		result := make(map[string]any, len(val))
+		for k, v := range val {
+			result[fmt.Sprintf("%v", k)] = ConvertYAMLToJSONCompatible(v)
+		}
+		return result
+	case []any:
+		result := make([]any, len(val))
+		for i, v := range val {
+			result[i] = ConvertYAMLToJSONCompatible(v)
+		}
+		return result
+	default:
+		return v
+	}
+}

--- a/internal/common/manifestschema/validate_test.go
+++ b/internal/common/manifestschema/validate_test.go
@@ -1,0 +1,206 @@
+package manifestschema
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+var minimalSchema = []byte(`
+$schema: https://json-schema.org/draft-07/schema
+type: object
+additionalProperties: false
+required:
+  - name
+properties:
+  name:
+    type: string
+  content:
+    type: object
+    additionalProperties: false
+    properties:
+      rpms:
+        type: array
+        items:
+          type: string
+`)
+
+func TestCompileSchema(t *testing.T) {
+	t.Run("valid schema", func(t *testing.T) {
+		schema, err := CompileSchema(minimalSchema)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if schema == nil {
+			t.Fatal("expected non-nil schema")
+		}
+	})
+
+	t.Run("invalid YAML", func(t *testing.T) {
+		_, err := CompileSchema([]byte("{{not yaml"))
+		if err == nil {
+			t.Fatal("expected error for invalid YAML")
+		}
+	})
+
+	t.Run("invalid JSON Schema", func(t *testing.T) {
+		_, err := CompileSchema([]byte(`type: not-a-real-type`))
+		if err == nil {
+			t.Fatal("expected error for invalid JSON Schema type")
+		}
+	})
+}
+
+func TestConvertYAMLToJSONCompatible(t *testing.T) {
+	t.Run("map[any]any to map[string]any", func(t *testing.T) {
+		input := map[any]any{"key": "value", 42: "number-key"}
+		result := ConvertYAMLToJSONCompatible(input)
+		m, ok := result.(map[string]any)
+		if !ok {
+			t.Fatalf("expected map[string]any, got %T", result)
+		}
+		if m["key"] != "value" || m["42"] != "number-key" {
+			t.Errorf("unexpected result: %v", m)
+		}
+	})
+
+	t.Run("nested maps", func(t *testing.T) {
+		input := map[string]any{"outer": map[any]any{"inner": "value"}}
+		result := ConvertYAMLToJSONCompatible(input)
+		inner := result.(map[string]any)["outer"].(map[string]any)
+		if inner["inner"] != "value" {
+			t.Errorf("unexpected nested value: %v", inner)
+		}
+	})
+
+	t.Run("scalars unchanged", func(t *testing.T) {
+		if ConvertYAMLToJSONCompatible("hello") != "hello" {
+			t.Error("string changed")
+		}
+		if ConvertYAMLToJSONCompatible(42) != 42 {
+			t.Error("int changed")
+		}
+		if ConvertYAMLToJSONCompatible(nil) != nil {
+			t.Error("nil changed")
+		}
+	})
+}
+
+func TestValidateManifest(t *testing.T) {
+	schema, err := CompileSchema(minimalSchema)
+	if err != nil {
+		t.Fatalf("failed to compile schema: %v", err)
+	}
+
+	t.Run("valid manifest", func(t *testing.T) {
+		r := ValidateManifest(schema, []byte("name: my-build\n"))
+		if !r.Valid {
+			t.Errorf("expected valid, got errors: %v", r.Errors)
+		}
+	})
+
+	t.Run("valid with content", func(t *testing.T) {
+		r := ValidateManifest(schema, []byte("name: my-build\ncontent:\n  rpms:\n    - vim\n"))
+		if !r.Valid {
+			t.Errorf("expected valid, got errors: %v", r.Errors)
+		}
+	})
+
+	t.Run("missing required name", func(t *testing.T) {
+		r := ValidateManifest(schema, []byte("content:\n  rpms: [vim]\n"))
+		if r.Valid {
+			t.Error("expected invalid for missing name")
+		}
+	})
+
+	t.Run("unknown field", func(t *testing.T) {
+		r := ValidateManifest(schema, []byte("name: test\nunknown_field: nope\n"))
+		if r.Valid {
+			t.Error("expected invalid for unknown field")
+		}
+		found := false
+		for _, e := range r.Errors {
+			if strings.Contains(e, "unknown_field") {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected error to mention 'unknown_field', got: %v", r.Errors)
+		}
+	})
+
+	t.Run("invalid YAML", func(t *testing.T) {
+		r := ValidateManifest(schema, []byte("{{broken"))
+		if r.Valid {
+			t.Error("expected invalid for broken YAML")
+		}
+		if len(r.Errors) == 0 || r.Errors[0] == "" {
+			t.Error("expected error message")
+		}
+	})
+}
+
+func TestValidateWithRealSchema(t *testing.T) {
+	schemaPath := os.Getenv("AIB_SCHEMA_PATH")
+	if schemaPath == "" {
+		candidates := []string{
+			"../../../../automotive-image-builder/files/manifest_schema.yml",
+			os.ExpandEnv("$HOME/dev/automotive/automotive-image-builder/files/manifest_schema.yml"),
+		}
+		for _, p := range candidates {
+			if _, err := os.Stat(p); err == nil {
+				schemaPath = p
+				break
+			}
+		}
+	}
+	if schemaPath == "" {
+		t.Skip("AIB schema not available locally (set AIB_SCHEMA_PATH)")
+	}
+
+	data, err := os.ReadFile(schemaPath)
+	if err != nil {
+		t.Skipf("cannot read schema: %v", err)
+	}
+
+	schema, err := CompileSchema(data)
+	if err != nil {
+		t.Fatalf("CompileSchema failed: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		manifest string
+		valid    bool
+	}{
+		{"valid minimal", "name: test\n", true},
+		{"valid with rpms", "name: test\ncontent:\n  rpms:\n    - vim\n    - curl\n", true},
+		{"valid image_size", "name: test\nimage:\n  image_size: \"8 GiB\"\n", true},
+		{"valid network static", "name: test\nnetwork:\n  static:\n    ip: \"192.168.1.1\"\n    ip_prefixlen: 24\n    gateway: \"192.168.1.1\"\n    dns: \"8.8.8.8\"\n", true},
+		{"valid auth users", "name: test\nauth:\n  users:\n    testuser:\n      uid: 1001\n      groups: [wheel]\n", true},
+		{"valid qm", "name: test\nqm:\n  content:\n    rpms: [podman]\n  memory_limit:\n    max: \"512M\"\n", true},
+		{"valid kernel", "name: test\nkernel:\n  cmdline: [quiet]\n  loglevel: 3\n", true},
+		{"invalid missing name", "content:\n  rpms: [vim]\n", false},
+		{"invalid unknown field", "name: test\nbogus: nope\n", false},
+		{"invalid image_size format", "name: test\nimage:\n  image_size: \"lots\"\n", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var manifestData any
+			if err := yaml.Unmarshal([]byte(tt.manifest), &manifestData); err != nil {
+				t.Fatalf("bad test YAML: %v", err)
+			}
+			manifestData = ConvertYAMLToJSONCompatible(manifestData)
+			err := schema.Validate(manifestData)
+			if tt.valid && err != nil {
+				t.Errorf("expected valid, got: %v", err)
+			}
+			if !tt.valid && err == nil {
+				t.Error("expected invalid, got valid")
+			}
+		})
+	}
+}

--- a/test/config/invalid-manifest.aib.yml
+++ b/test/config/invalid-manifest.aib.yml
@@ -1,0 +1,5 @@
+name: invalid-test
+content:
+  rpmso:
+    - vim
+  bogus_field: nope

--- a/test/e2e/manifest_validation_test.go
+++ b/test/e2e/manifest_validation_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // Dot import is standard for Ginkgo
+	. "github.com/onsi/gomega"    //nolint:revive // Dot import is standard for Gomega
+
+	utils "github.com/centos-automotive-suite/automotive-dev-operator/test/utils"
+)
+
+const (
+	invalidManifest   = "test/config/invalid-manifest.aib.yml"
+	validationTimeout = 2 * time.Minute
+)
+
+var _ = Describe("Manifest Validation", Label("manifest-validation"), Ordered, func() {
+
+	BeforeAll(func() {
+		ensureOperatorDeployed()
+		ensureBuildAPIAccess()
+		ensureCaibCredentials()
+	})
+
+	It("should reject a manifest with unknown fields", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), validationTimeout)
+		defer cancel()
+
+		cmd := utils.NewCaibCommand(ctx, caibEnv,
+			"image", "build",
+			invalidManifest,
+			"--name", "e2e-invalid-manifest",
+			"--arch", arch,
+			"--push", "localhost:5000/test/invalid:latest")
+		output, err := utils.RunSafe(cmd)
+
+		_, _ = fmt.Fprintf(GinkgoWriter, "\n--- caib manifest validation ---\n%s\n", string(output))
+
+		Expect(err).To(HaveOccurred(), "expected caib to fail on invalid manifest")
+		Expect(string(output)).To(ContainSubstring("manifest validation error"),
+			"expected manifest validation error in output")
+	})
+})

--- a/vendor/github.com/dlclark/regexp2/.gitignore
+++ b/vendor/github.com/dlclark/regexp2/.gitignore
@@ -1,0 +1,27 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+*.out
+
+.DS_Store

--- a/vendor/github.com/dlclark/regexp2/.travis.yml
+++ b/vendor/github.com/dlclark/regexp2/.travis.yml
@@ -1,0 +1,7 @@
+language: go
+arch:
+  - AMD64
+  - ppc64le
+go:
+  - 1.9
+  - tip

--- a/vendor/github.com/dlclark/regexp2/ATTRIB
+++ b/vendor/github.com/dlclark/regexp2/ATTRIB
@@ -1,0 +1,133 @@
+============
+These pieces of code were ported from dotnet/corefx:
+
+syntax/charclass.go (from RegexCharClass.cs): ported to use the built-in Go unicode classes.  Canonicalize is 
+    a direct port, but most of the other code required large changes because the C# implementation 
+    used a string to represent the CharSet data structure and I cleaned that up in my implementation.
+
+syntax/code.go (from RegexCode.cs): ported literally with various cleanups and layout to make it more Go-ish.
+
+syntax/escape.go (from RegexParser.cs): ported Escape method and added some optimizations.  Unescape is inspired by 
+    the C# implementation but couldn't be directly ported because of the lack of do-while syntax in Go.
+
+syntax/parser.go (from RegexpParser.cs and RegexOptions.cs): ported parser struct and associated methods as 
+    literally as possible. Several language differences required changes.  E.g. lack pre/post-fix increments as 
+    expressions, lack of do-while loops, lack of overloads, etc.
+
+syntax/prefix.go (from RegexFCD.cs and RegexBoyerMoore.cs): ported as literally as possible and added support
+    for unicode chars that are longer than the 16-bit char in C# for the 32-bit rune in Go.
+
+syntax/replacerdata.go (from RegexReplacement.cs): conceptually ported and re-organized to handle differences 
+    in charclass implementation, and fix odd code layout between RegexParser.cs, Regex.cs, and RegexReplacement.cs.
+
+syntax/tree.go (from RegexTree.cs and RegexNode.cs): ported literally as possible.
+
+syntax/writer.go (from RegexWriter.cs): ported literally with minor changes to make it more Go-ish.
+
+match.go (from RegexMatch.cs): ported, simplified, and changed to handle Go's lack of inheritence.
+
+regexp.go (from Regex.cs and RegexOptions.cs): conceptually serves the same "starting point", but is simplified 
+    and changed to handle differences in C# strings and Go strings/runes.  
+
+replace.go (from RegexReplacement.cs): ported closely and then cleaned up to combine the MatchEvaluator and 
+    simple string replace implementations.
+
+runner.go (from RegexRunner.cs): ported literally as possible.
+
+regexp_test.go (from CaptureTests.cs and GroupNamesAndNumbers.cs): conceptually ported, but the code was 
+    manually structured like Go tests.
+
+replace_test.go (from RegexReplaceStringTest0.cs): conceptually ported
+
+rtl_test.go (from RightToLeft.cs): conceptually ported
+---
+dotnet/corefx was released under this license:
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+============
+These pieces of code are copied from the Go framework:
+
+- The overall directory structure of regexp2 was inspired by the Go runtime regexp package.
+- The optimization in the escape method of syntax/escape.go is from the Go runtime QuoteMeta() func in regexp/regexp.go
+- The method signatures in regexp.go are designed to match the Go framework regexp methods closely
+- func regexp2.MustCompile and func quote are almost identifical to the regexp package versions
+- BenchmarkMatch* and TestProgramTooLong* funcs in regexp_performance_test.go were copied from the framework 
+    regexp/exec_test.go
+---
+The Go framework was released under this license:
+
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+============
+Some test data were gathered from the Mono project.
+
+regexp_mono_test.go: ported from https://github.com/mono/mono/blob/master/mcs/class/System/Test/System.Text.RegularExpressions/PerlTrials.cs
+---
+Mono tests released under this license:
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/vendor/github.com/dlclark/regexp2/LICENSE
+++ b/vendor/github.com/dlclark/regexp2/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Doug Clark
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/dlclark/regexp2/README.md
+++ b/vendor/github.com/dlclark/regexp2/README.md
@@ -1,0 +1,174 @@
+# regexp2 - full featured regular expressions for Go
+Regexp2 is a feature-rich RegExp engine for Go.  It doesn't have constant time guarantees like the built-in `regexp` package, but it allows backtracking and is compatible with Perl5 and .NET.  You'll likely be better off with the RE2 engine from the `regexp` package and should only use this if you need to write very complex patterns or require compatibility with .NET.
+
+## Basis of the engine
+The engine is ported from the .NET framework's System.Text.RegularExpressions.Regex engine.  That engine was open sourced in 2015 under the MIT license.  There are some fundamental differences between .NET strings and Go strings that required a bit of borrowing from the Go framework regex engine as well.  I cleaned up a couple of the dirtier bits during the port (regexcharclass.cs was terrible), but the parse tree, code emmitted, and therefore patterns matched should be identical.
+
+## New Code Generation
+For extra performance use `regexp2` with [`regexp2cg`](https://github.com/dlclark/regexp2cg). It is a code generation utility for `regexp2` and you can likely improve your regexp runtime performance by 3-10x in hot code paths. As always you should benchmark your specifics to confirm the results. Give it a try!
+
+## Installing
+This is a go-gettable library, so install is easy:
+
+    go get github.com/dlclark/regexp2
+
+To use the new Code Generation (while it's in beta) you'll need to use the `code_gen` branch:
+
+    go get github.com/dlclark/regexp2@code_gen
+
+## Usage
+Usage is similar to the Go `regexp` package.  Just like in `regexp`, you start by converting a regex into a state machine via the `Compile` or `MustCompile` methods.  They ultimately do the same thing, but `MustCompile` will panic if the regex is invalid.  You can then use the provided `Regexp` struct to find matches repeatedly.  A `Regexp` struct is safe to use across goroutines.
+
+```go
+re := regexp2.MustCompile(`Your pattern`, 0)
+if isMatch, _ := re.MatchString(`Something to match`); isMatch {
+    //do something
+}
+```
+
+The only error that the `*Match*` methods *should* return is a Timeout if you set the `re.MatchTimeout` field.  Any other error is a bug in the `regexp2` package.  If you need more details about capture groups in a match then use the `FindStringMatch` method, like so:
+
+```go
+if m, _ := re.FindStringMatch(`Something to match`); m != nil {
+    // the whole match is always group 0
+    fmt.Printf("Group 0: %v\n", m.String())
+
+    // you can get all the groups too
+    gps := m.Groups()
+
+    // a group can be captured multiple times, so each cap is separately addressable
+    fmt.Printf("Group 1, first capture", gps[1].Captures[0].String())
+    fmt.Printf("Group 1, second capture", gps[1].Captures[1].String())
+}
+```
+
+Group 0 is embedded in the Match.  Group 0 is an automatically-assigned group that encompasses the whole pattern.  This means that `m.String()` is the same as `m.Group.String()` and `m.Groups()[0].String()`
+
+The __last__ capture is embedded in each group, so `g.String()` will return the same thing as `g.Capture.String()` and  `g.Captures[len(g.Captures)-1].String()`.
+
+If you want to find multiple matches from a single input string you should use the `FindNextMatch` method.  For example, to implement a function similar to `regexp.FindAllString`:
+
+```go
+func regexp2FindAllString(re *regexp2.Regexp, s string) []string {
+	var matches []string
+	m, _ := re.FindStringMatch(s)
+	for m != nil {
+		matches = append(matches, m.String())
+		m, _ = re.FindNextMatch(m)
+	}
+	return matches
+}
+```
+
+`FindNextMatch` is optmized so that it re-uses the underlying string/rune slice.
+
+The internals of `regexp2` always operate on `[]rune` so `Index` and `Length` data in a `Match` always reference a position in `rune`s rather than `byte`s (even if the input was given as a string). This is a dramatic difference between `regexp` and `regexp2`.  It's advisable to use the provided `String()` methods to avoid having to work with indices.
+
+## Compare `regexp` and `regexp2`
+| Category | regexp | regexp2 |
+| --- | --- | --- |
+| Catastrophic backtracking possible | no, constant execution time guarantees | yes, if your pattern is at risk you can use the `re.MatchTimeout` field |
+| Python-style capture groups `(?P<name>re)` | yes | no (yes in RE2 compat mode) |
+| .NET-style capture groups `(?<name>re)` or `(?'name're)` | yes | yes |
+| comments `(?#comment)` | no | yes |
+| branch numbering reset `(?\|a\|b)` | no | no |
+| possessive match `(?>re)` | no | yes |
+| positive lookahead `(?=re)` | no | yes |
+| negative lookahead `(?!re)` | no | yes |
+| positive lookbehind `(?<=re)` | no | yes |
+| negative lookbehind `(?<!re)` | no | yes |
+| back reference `\1` | no | yes |
+| named back reference `\k'name'` | no | yes |
+| named ascii character class `[[:foo:]]`| yes | no (yes in RE2 compat mode) |
+| conditionals `(?(expr)yes\|no)` | no | yes |
+
+## RE2 compatibility mode
+The default behavior of `regexp2` is to match the .NET regexp engine, however the `RE2` option is provided to change the parsing to increase compatibility with RE2.  Using the `RE2` option when compiling a regexp will not take away any features, but will change the following behaviors:
+* add support for named ascii character classes (e.g. `[[:foo:]]`)
+* add support for python-style capture groups (e.g. `(P<name>re)`)
+* change singleline behavior for `$` to only match end of string (like RE2) (see [#24](https://github.com/dlclark/regexp2/issues/24))
+* change the character classes `\d` `\s` and `\w` to match the same characters as RE2. NOTE: if you also use the `ECMAScript` option then this will change the `\s` character class to match ECMAScript instead of RE2.  ECMAScript allows more whitespace characters in `\s` than RE2 (but still fewer than the the default behavior).
+* allow character escape sequences to have defaults. For example, by default `\_` isn't a known character escape and will fail to compile, but in RE2 mode it will match the literal character `_`
+ 
+```go
+re := regexp2.MustCompile(`Your RE2-compatible pattern`, regexp2.RE2)
+if isMatch, _ := re.MatchString(`Something to match`); isMatch {
+    //do something
+}
+```
+
+This feature is a work in progress and I'm open to ideas for more things to put here (maybe more relaxed character escaping rules?).
+
+## Catastrophic Backtracking and Timeouts
+
+`regexp2` supports features that can lead to catastrophic backtracking.
+`Regexp.MatchTimeout` can be set to to limit the impact of such behavior; the
+match will fail with an error after approximately MatchTimeout. No timeout
+checks are done by default.
+
+Timeout checking is not free. The current timeout checking implementation starts
+a background worker that updates a clock value approximately once every 100
+milliseconds. The matching code compares this value against the precomputed
+deadline for the match. The performance impact is as follows.
+
+1.  A match with a timeout runs almost as fast as a match without a timeout.
+2.  If any live matches have a timeout, there will be a background CPU load
+    (`~0.15%` currently on a modern machine). This load will remain constant
+    regardless of the number of matches done including matches done in parallel.
+3.  If no live matches are using a timeout, the background load will remain
+    until the longest deadline (match timeout + the time when the match started)
+    is reached. E.g., if you set a timeout of one minute the load will persist
+    for approximately a minute even if the match finishes quickly.
+
+See [PR #58](https://github.com/dlclark/regexp2/pull/58) for more details and 
+alternatives considered.
+
+## Goroutine leak error
+If you're using a library during unit tests (e.g. https://github.com/uber-go/goleak) that validates all goroutines are exited then you'll likely get an error if you or any of your dependencies use regex's with a MatchTimeout. 
+To remedy the problem you'll need to tell the unit test to wait until the backgroup timeout goroutine is exited.
+
+```go
+func TestSomething(t *testing.T) {
+    defer goleak.VerifyNone(t)
+    defer regexp2.StopTimeoutClock()
+
+    // ... test
+}
+
+//or
+
+func TestMain(m *testing.M) {
+    // setup
+    // ...
+
+    // run 
+    m.Run()
+
+    //tear down
+    regexp2.StopTimeoutClock()
+    goleak.VerifyNone(t)
+}
+```
+
+This will add ~100ms runtime to each test (or TestMain). If that's too much time you can set the clock cycle rate of the timeout goroutine in an init function in a test file. `regexp2.SetTimeoutCheckPeriod` isn't threadsafe so it must be setup before starting any regex's with Timeouts.
+
+```go
+func init() {
+	//speed up testing by making the timeout clock 1ms
+	regexp2.SetTimeoutCheckPeriod(time.Millisecond)
+}
+```
+
+## ECMAScript compatibility mode
+In this mode the engine provides compatibility with the [regex engine](https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp-regular-expression-objects) described in the ECMAScript specification.
+
+Additionally a Unicode mode is provided which allows parsing of `\u{CodePoint}` syntax that is only when both are provided.
+
+## Library features that I'm still working on
+- Regex split
+
+## Potential bugs
+I've run a battery of tests against regexp2 from various sources and found the debug output matches the .NET engine, but .NET and Go handle strings very differently.  I've attempted to handle these differences, but most of my testing deals with basic ASCII with a little bit of multi-byte Unicode.  There's a chance that there are bugs in the string handling related to character sets with supplementary Unicode chars.  Right-to-Left support is coded, but not well tested either.
+
+## Find a bug?
+I'm open to new issues and pull requests with tests if you find something odd!

--- a/vendor/github.com/dlclark/regexp2/fastclock.go
+++ b/vendor/github.com/dlclark/regexp2/fastclock.go
@@ -1,0 +1,141 @@
+package regexp2
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// fasttime holds a time value (ticks since clock initialization)
+type fasttime int64
+
+// fastclock provides a fast clock implementation.
+//
+// A background goroutine periodically stores the current time
+// into an atomic variable.
+//
+// A deadline can be quickly checked for expiration by comparing
+// its value to the clock stored in the atomic variable.
+//
+// The goroutine automatically stops once clockEnd is reached.
+// (clockEnd covers the largest deadline seen so far + some
+// extra time). This ensures that if regexp2 with timeouts
+// stops being used we will stop background work.
+type fastclock struct {
+	// instances of atomicTime must be at the start of the struct (or at least 64-bit aligned)
+	// otherwise 32-bit architectures will panic
+
+	current  atomicTime // Current time (approximate)
+	clockEnd atomicTime // When clock updater is supposed to stop (>= any existing deadline)
+
+	// current and clockEnd can be read via atomic loads.
+	// Reads and writes of other fields require mu to be held.
+	mu      sync.Mutex
+	start   time.Time // Time corresponding to fasttime(0)
+	running bool      // Is a clock updater running?
+}
+
+var fast fastclock
+
+// reached returns true if current time is at or past t.
+func (t fasttime) reached() bool {
+	return fast.current.read() >= t
+}
+
+// makeDeadline returns a time that is approximately time.Now().Add(d)
+func makeDeadline(d time.Duration) fasttime {
+	// Increase the deadline since the clock we are reading may be
+	// just about to tick forwards.
+	end := fast.current.read() + durationToTicks(d+clockPeriod)
+
+	// Start or extend clock if necessary.
+	if end > fast.clockEnd.read() {
+		// If time.Since(last use) > timeout, there's a chance that
+		// fast.current will no longer be updated, which can lead to
+		// incorrect 'end' calculations that can trigger a false timeout
+		fast.mu.Lock()
+		if !fast.running && !fast.start.IsZero() {
+			// update fast.current
+			fast.current.write(durationToTicks(time.Since(fast.start)))
+			// recalculate our end value
+			end = fast.current.read() + durationToTicks(d+clockPeriod)
+		}
+		fast.mu.Unlock()
+		extendClock(end)
+	}
+
+	return end
+}
+
+// extendClock ensures that clock is live and will run until at least end.
+func extendClock(end fasttime) {
+	fast.mu.Lock()
+	defer fast.mu.Unlock()
+
+	if fast.start.IsZero() {
+		fast.start = time.Now()
+	}
+
+	// Extend the running time to cover end as well as a bit of slop.
+	if shutdown := end + durationToTicks(time.Second); shutdown > fast.clockEnd.read() {
+		fast.clockEnd.write(shutdown)
+	}
+
+	// Start clock if necessary
+	if !fast.running {
+		fast.running = true
+		go runClock()
+	}
+}
+
+// stop the timeout clock in the background
+// should only used for unit tests to abandon the background goroutine
+func stopClock() {
+	fast.mu.Lock()
+	if fast.running {
+		fast.clockEnd.write(fasttime(0))
+	}
+	fast.mu.Unlock()
+
+	// pause until not running
+	// get and release the lock
+	isRunning := true
+	for isRunning {
+		time.Sleep(clockPeriod / 2)
+		fast.mu.Lock()
+		isRunning = fast.running
+		fast.mu.Unlock()
+	}
+}
+
+func durationToTicks(d time.Duration) fasttime {
+	// Downscale nanoseconds to approximately a millisecond so that we can avoid
+	// overflow even if the caller passes in math.MaxInt64.
+	return fasttime(d) >> 20
+}
+
+const DefaultClockPeriod = 100 * time.Millisecond
+
+// clockPeriod is the approximate interval between updates of approximateClock.
+var clockPeriod = DefaultClockPeriod
+
+func runClock() {
+	fast.mu.Lock()
+	defer fast.mu.Unlock()
+
+	for fast.current.read() <= fast.clockEnd.read() {
+		// Unlock while sleeping.
+		fast.mu.Unlock()
+		time.Sleep(clockPeriod)
+		fast.mu.Lock()
+
+		newTime := durationToTicks(time.Since(fast.start))
+		fast.current.write(newTime)
+	}
+	fast.running = false
+}
+
+type atomicTime struct{ v int64 } // Should change to atomic.Int64 when we can use go 1.19
+
+func (t *atomicTime) read() fasttime   { return fasttime(atomic.LoadInt64(&t.v)) }
+func (t *atomicTime) write(v fasttime) { atomic.StoreInt64(&t.v, int64(v)) }

--- a/vendor/github.com/dlclark/regexp2/match.go
+++ b/vendor/github.com/dlclark/regexp2/match.go
@@ -1,0 +1,349 @@
+package regexp2
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// Match is a single regex result match that contains groups and repeated captures
+//
+//		-Groups
+//	   -Capture
+type Match struct {
+	Group //embeded group 0
+
+	regex       *Regexp
+	otherGroups []Group
+
+	// input to the match
+	textpos   int
+	textstart int
+
+	capcount   int
+	caps       []int
+	sparseCaps map[int]int
+
+	// output from the match
+	matches    [][]int
+	matchcount []int
+
+	// whether we've done any balancing with this match.  If we
+	// have done balancing, we'll need to do extra work in Tidy().
+	balancing bool
+}
+
+// Group is an explicit or implit (group 0) matched group within the pattern
+type Group struct {
+	Capture // the last capture of this group is embeded for ease of use
+
+	Name     string    // group name
+	Captures []Capture // captures of this group
+}
+
+// Capture is a single capture of text within the larger original string
+type Capture struct {
+	// the original string
+	text []rune
+	// Index is the position in the underlying rune slice where the first character of
+	// captured substring was found. Even if you pass in a string this will be in Runes.
+	Index int
+	// Length is the number of runes in the captured substring.
+	Length int
+}
+
+// String returns the captured text as a String
+func (c *Capture) String() string {
+	return string(c.text[c.Index : c.Index+c.Length])
+}
+
+// Runes returns the captured text as a rune slice
+func (c *Capture) Runes() []rune {
+	return c.text[c.Index : c.Index+c.Length]
+}
+
+func newMatch(regex *Regexp, capcount int, text []rune, startpos int) *Match {
+	m := Match{
+		regex:      regex,
+		matchcount: make([]int, capcount),
+		matches:    make([][]int, capcount),
+		textstart:  startpos,
+		balancing:  false,
+	}
+	m.Name = "0"
+	m.text = text
+	m.matches[0] = make([]int, 2)
+	return &m
+}
+
+func newMatchSparse(regex *Regexp, caps map[int]int, capcount int, text []rune, startpos int) *Match {
+	m := newMatch(regex, capcount, text, startpos)
+	m.sparseCaps = caps
+	return m
+}
+
+func (m *Match) reset(text []rune, textstart int) {
+	m.text = text
+	m.textstart = textstart
+	for i := 0; i < len(m.matchcount); i++ {
+		m.matchcount[i] = 0
+	}
+	m.balancing = false
+}
+
+func (m *Match) tidy(textpos int) {
+
+	interval := m.matches[0]
+	m.Index = interval[0]
+	m.Length = interval[1]
+	m.textpos = textpos
+	m.capcount = m.matchcount[0]
+	//copy our root capture to the list
+	m.Group.Captures = []Capture{m.Group.Capture}
+
+	if m.balancing {
+		// The idea here is that we want to compact all of our unbalanced captures.  To do that we
+		// use j basically as a count of how many unbalanced captures we have at any given time
+		// (really j is an index, but j/2 is the count).  First we skip past all of the real captures
+		// until we find a balance captures.  Then we check each subsequent entry.  If it's a balance
+		// capture (it's negative), we decrement j.  If it's a real capture, we increment j and copy
+		// it down to the last free position.
+		for cap := 0; cap < len(m.matchcount); cap++ {
+			limit := m.matchcount[cap] * 2
+			matcharray := m.matches[cap]
+
+			var i, j int
+
+			for i = 0; i < limit; i++ {
+				if matcharray[i] < 0 {
+					break
+				}
+			}
+
+			for j = i; i < limit; i++ {
+				if matcharray[i] < 0 {
+					// skip negative values
+					j--
+				} else {
+					// but if we find something positive (an actual capture), copy it back to the last
+					// unbalanced position.
+					if i != j {
+						matcharray[j] = matcharray[i]
+					}
+					j++
+				}
+			}
+
+			m.matchcount[cap] = j / 2
+		}
+
+		m.balancing = false
+	}
+}
+
+// isMatched tells if a group was matched by capnum
+func (m *Match) isMatched(cap int) bool {
+	return cap < len(m.matchcount) && m.matchcount[cap] > 0 && m.matches[cap][m.matchcount[cap]*2-1] != (-3+1)
+}
+
+// matchIndex returns the index of the last specified matched group by capnum
+func (m *Match) matchIndex(cap int) int {
+	i := m.matches[cap][m.matchcount[cap]*2-2]
+	if i >= 0 {
+		return i
+	}
+
+	return m.matches[cap][-3-i]
+}
+
+// matchLength returns the length of the last specified matched group by capnum
+func (m *Match) matchLength(cap int) int {
+	i := m.matches[cap][m.matchcount[cap]*2-1]
+	if i >= 0 {
+		return i
+	}
+
+	return m.matches[cap][-3-i]
+}
+
+// Nonpublic builder: add a capture to the group specified by "c"
+func (m *Match) addMatch(c, start, l int) {
+
+	if m.matches[c] == nil {
+		m.matches[c] = make([]int, 2)
+	}
+
+	capcount := m.matchcount[c]
+
+	if capcount*2+2 > len(m.matches[c]) {
+		oldmatches := m.matches[c]
+		newmatches := make([]int, capcount*8)
+		copy(newmatches, oldmatches[:capcount*2])
+		m.matches[c] = newmatches
+	}
+
+	m.matches[c][capcount*2] = start
+	m.matches[c][capcount*2+1] = l
+	m.matchcount[c] = capcount + 1
+	//log.Printf("addMatch: c=%v, i=%v, l=%v ... matches: %v", c, start, l, m.matches)
+}
+
+// Nonpublic builder: Add a capture to balance the specified group.  This is used by the
+//
+//	balanced match construct. (?<foo-foo2>...)
+//
+// If there were no such thing as backtracking, this would be as simple as calling RemoveMatch(c).
+// However, since we have backtracking, we need to keep track of everything.
+func (m *Match) balanceMatch(c int) {
+	m.balancing = true
+
+	// we'll look at the last capture first
+	capcount := m.matchcount[c]
+	target := capcount*2 - 2
+
+	// first see if it is negative, and therefore is a reference to the next available
+	// capture group for balancing.  If it is, we'll reset target to point to that capture.
+	if m.matches[c][target] < 0 {
+		target = -3 - m.matches[c][target]
+	}
+
+	// move back to the previous capture
+	target -= 2
+
+	// if the previous capture is a reference, just copy that reference to the end.  Otherwise, point to it.
+	if target >= 0 && m.matches[c][target] < 0 {
+		m.addMatch(c, m.matches[c][target], m.matches[c][target+1])
+	} else {
+		m.addMatch(c, -3-target, -4-target /* == -3 - (target + 1) */)
+	}
+}
+
+// Nonpublic builder: removes a group match by capnum
+func (m *Match) removeMatch(c int) {
+	m.matchcount[c]--
+}
+
+// GroupCount returns the number of groups this match has matched
+func (m *Match) GroupCount() int {
+	return len(m.matchcount)
+}
+
+// GroupByName returns a group based on the name of the group, or nil if the group name does not exist
+func (m *Match) GroupByName(name string) *Group {
+	num := m.regex.GroupNumberFromName(name)
+	if num < 0 {
+		return nil
+	}
+	return m.GroupByNumber(num)
+}
+
+// GroupByNumber returns a group based on the number of the group, or nil if the group number does not exist
+func (m *Match) GroupByNumber(num int) *Group {
+	// check our sparse map
+	if m.sparseCaps != nil {
+		if newNum, ok := m.sparseCaps[num]; ok {
+			num = newNum
+		}
+	}
+	if num >= len(m.matchcount) || num < 0 {
+		return nil
+	}
+
+	if num == 0 {
+		return &m.Group
+	}
+
+	m.populateOtherGroups()
+
+	return &m.otherGroups[num-1]
+}
+
+// Groups returns all the capture groups, starting with group 0 (the full match)
+func (m *Match) Groups() []Group {
+	m.populateOtherGroups()
+	g := make([]Group, len(m.otherGroups)+1)
+	g[0] = m.Group
+	copy(g[1:], m.otherGroups)
+	return g
+}
+
+func (m *Match) populateOtherGroups() {
+	// Construct all the Group objects first time called
+	if m.otherGroups == nil {
+		m.otherGroups = make([]Group, len(m.matchcount)-1)
+		for i := 0; i < len(m.otherGroups); i++ {
+			m.otherGroups[i] = newGroup(m.regex.GroupNameFromNumber(i+1), m.text, m.matches[i+1], m.matchcount[i+1])
+		}
+	}
+}
+
+func (m *Match) groupValueAppendToBuf(groupnum int, buf *bytes.Buffer) {
+	c := m.matchcount[groupnum]
+	if c == 0 {
+		return
+	}
+
+	matches := m.matches[groupnum]
+
+	index := matches[(c-1)*2]
+	last := index + matches[(c*2)-1]
+
+	for ; index < last; index++ {
+		buf.WriteRune(m.text[index])
+	}
+}
+
+func newGroup(name string, text []rune, caps []int, capcount int) Group {
+	g := Group{}
+	g.text = text
+	if capcount > 0 {
+		g.Index = caps[(capcount-1)*2]
+		g.Length = caps[(capcount*2)-1]
+	}
+	g.Name = name
+	g.Captures = make([]Capture, capcount)
+	for i := 0; i < capcount; i++ {
+		g.Captures[i] = Capture{
+			text:   text,
+			Index:  caps[i*2],
+			Length: caps[i*2+1],
+		}
+	}
+	//log.Printf("newGroup! capcount %v, %+v", capcount, g)
+
+	return g
+}
+
+func (m *Match) dump() string {
+	buf := &bytes.Buffer{}
+	buf.WriteRune('\n')
+	if len(m.sparseCaps) > 0 {
+		for k, v := range m.sparseCaps {
+			fmt.Fprintf(buf, "Slot %v -> %v\n", k, v)
+		}
+	}
+
+	for i, g := range m.Groups() {
+		fmt.Fprintf(buf, "Group %v (%v), %v caps:\n", i, g.Name, len(g.Captures))
+
+		for _, c := range g.Captures {
+			fmt.Fprintf(buf, "  (%v, %v) %v\n", c.Index, c.Length, c.String())
+		}
+	}
+	/*
+		for i := 0; i < len(m.matchcount); i++ {
+			fmt.Fprintf(buf, "\nGroup %v (%v):\n", i, m.regex.GroupNameFromNumber(i))
+
+			for j := 0; j < m.matchcount[i]; j++ {
+				text := ""
+
+				if m.matches[i][j*2] >= 0 {
+					start := m.matches[i][j*2]
+					text = m.text[start : start+m.matches[i][j*2+1]]
+				}
+
+				fmt.Fprintf(buf, "  (%v, %v) %v\n", m.matches[i][j*2], m.matches[i][j*2+1], text)
+			}
+		}
+	*/
+	return buf.String()
+}

--- a/vendor/github.com/dlclark/regexp2/regexp.go
+++ b/vendor/github.com/dlclark/regexp2/regexp.go
@@ -1,0 +1,395 @@
+/*
+Package regexp2 is a regexp package that has an interface similar to Go's framework regexp engine but uses a
+more feature full regex engine behind the scenes.
+
+It doesn't have constant time guarantees, but it allows backtracking and is compatible with Perl5 and .NET.
+You'll likely be better off with the RE2 engine from the regexp package and should only use this if you
+need to write very complex patterns or require compatibility with .NET.
+*/
+package regexp2
+
+import (
+	"errors"
+	"math"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/dlclark/regexp2/syntax"
+)
+
+var (
+	// DefaultMatchTimeout used when running regexp matches -- "forever"
+	DefaultMatchTimeout = time.Duration(math.MaxInt64)
+	// DefaultUnmarshalOptions used when unmarshaling a regex from text
+	DefaultUnmarshalOptions = None
+)
+
+// Regexp is the representation of a compiled regular expression.
+// A Regexp is safe for concurrent use by multiple goroutines.
+type Regexp struct {
+	// A match will time out if it takes (approximately) more than
+	// MatchTimeout. This is a safety check in case the match
+	// encounters catastrophic backtracking.  The default value
+	// (DefaultMatchTimeout) causes all time out checking to be
+	// suppressed.
+	MatchTimeout time.Duration
+
+	// read-only after Compile
+	pattern string       // as passed to Compile
+	options RegexOptions // options
+
+	caps     map[int]int    // capnum->index
+	capnames map[string]int //capture group name -> index
+	capslist []string       //sorted list of capture group names
+	capsize  int            // size of the capture array
+
+	code *syntax.Code // compiled program
+
+	// cache of machines for running regexp
+	muRun  *sync.Mutex
+	runner []*runner
+}
+
+// Compile parses a regular expression and returns, if successful,
+// a Regexp object that can be used to match against text.
+func Compile(expr string, opt RegexOptions) (*Regexp, error) {
+	// parse it
+	tree, err := syntax.Parse(expr, syntax.RegexOptions(opt))
+	if err != nil {
+		return nil, err
+	}
+
+	// translate it to code
+	code, err := syntax.Write(tree)
+	if err != nil {
+		return nil, err
+	}
+
+	// return it
+	return &Regexp{
+		pattern:      expr,
+		options:      opt,
+		caps:         code.Caps,
+		capnames:     tree.Capnames,
+		capslist:     tree.Caplist,
+		capsize:      code.Capsize,
+		code:         code,
+		MatchTimeout: DefaultMatchTimeout,
+		muRun:        &sync.Mutex{},
+	}, nil
+}
+
+// MustCompile is like Compile but panics if the expression cannot be parsed.
+// It simplifies safe initialization of global variables holding compiled regular
+// expressions.
+func MustCompile(str string, opt RegexOptions) *Regexp {
+	regexp, error := Compile(str, opt)
+	if error != nil {
+		panic(`regexp2: Compile(` + quote(str) + `): ` + error.Error())
+	}
+	return regexp
+}
+
+// Escape adds backslashes to any special characters in the input string
+func Escape(input string) string {
+	return syntax.Escape(input)
+}
+
+// Unescape removes any backslashes from previously-escaped special characters in the input string
+func Unescape(input string) (string, error) {
+	return syntax.Unescape(input)
+}
+
+// SetTimeoutPeriod is a debug function that sets the frequency of the timeout goroutine's sleep cycle.
+// Defaults to 100ms. The only benefit of setting this lower is that the 1 background goroutine that manages
+// timeouts may exit slightly sooner after all the timeouts have expired. See Github issue #63
+func SetTimeoutCheckPeriod(d time.Duration) {
+	clockPeriod = d
+}
+
+// StopTimeoutClock should only be used in unit tests to prevent the timeout clock goroutine
+// from appearing like a leaking goroutine
+func StopTimeoutClock() {
+	stopClock()
+}
+
+// String returns the source text used to compile the regular expression.
+func (re *Regexp) String() string {
+	return re.pattern
+}
+
+func quote(s string) string {
+	if strconv.CanBackquote(s) {
+		return "`" + s + "`"
+	}
+	return strconv.Quote(s)
+}
+
+// RegexOptions impact the runtime and parsing behavior
+// for each specific regex.  They are setable in code as well
+// as in the regex pattern itself.
+type RegexOptions int32
+
+const (
+	None                    RegexOptions = 0x0
+	IgnoreCase                           = 0x0001 // "i"
+	Multiline                            = 0x0002 // "m"
+	ExplicitCapture                      = 0x0004 // "n"
+	Compiled                             = 0x0008 // "c"
+	Singleline                           = 0x0010 // "s"
+	IgnorePatternWhitespace              = 0x0020 // "x"
+	RightToLeft                          = 0x0040 // "r"
+	Debug                                = 0x0080 // "d"
+	ECMAScript                           = 0x0100 // "e"
+	RE2                                  = 0x0200 // RE2 (regexp package) compatibility mode
+	Unicode                              = 0x0400 // "u"
+)
+
+func (re *Regexp) RightToLeft() bool {
+	return re.options&RightToLeft != 0
+}
+
+func (re *Regexp) Debug() bool {
+	return re.options&Debug != 0
+}
+
+// Replace searches the input string and replaces each match found with the replacement text.
+// Count will limit the number of matches attempted and startAt will allow
+// us to skip past possible matches at the start of the input (left or right depending on RightToLeft option).
+// Set startAt and count to -1 to go through the whole string
+func (re *Regexp) Replace(input, replacement string, startAt, count int) (string, error) {
+	data, err := syntax.NewReplacerData(replacement, re.caps, re.capsize, re.capnames, syntax.RegexOptions(re.options))
+	if err != nil {
+		return "", err
+	}
+	//TODO: cache ReplacerData
+
+	return replace(re, data, nil, input, startAt, count)
+}
+
+// ReplaceFunc searches the input string and replaces each match found using the string from the evaluator
+// Count will limit the number of matches attempted and startAt will allow
+// us to skip past possible matches at the start of the input (left or right depending on RightToLeft option).
+// Set startAt and count to -1 to go through the whole string.
+func (re *Regexp) ReplaceFunc(input string, evaluator MatchEvaluator, startAt, count int) (string, error) {
+	return replace(re, nil, evaluator, input, startAt, count)
+}
+
+// FindStringMatch searches the input string for a Regexp match
+func (re *Regexp) FindStringMatch(s string) (*Match, error) {
+	// convert string to runes
+	return re.run(false, -1, getRunes(s))
+}
+
+// FindRunesMatch searches the input rune slice for a Regexp match
+func (re *Regexp) FindRunesMatch(r []rune) (*Match, error) {
+	return re.run(false, -1, r)
+}
+
+// FindStringMatchStartingAt searches the input string for a Regexp match starting at the startAt index
+func (re *Regexp) FindStringMatchStartingAt(s string, startAt int) (*Match, error) {
+	if startAt > len(s) {
+		return nil, errors.New("startAt must be less than the length of the input string")
+	}
+	r, startAt := re.getRunesAndStart(s, startAt)
+	if startAt == -1 {
+		// we didn't find our start index in the string -- that's a problem
+		return nil, errors.New("startAt must align to the start of a valid rune in the input string")
+	}
+
+	return re.run(false, startAt, r)
+}
+
+// FindRunesMatchStartingAt searches the input rune slice for a Regexp match starting at the startAt index
+func (re *Regexp) FindRunesMatchStartingAt(r []rune, startAt int) (*Match, error) {
+	return re.run(false, startAt, r)
+}
+
+// FindNextMatch returns the next match in the same input string as the match parameter.
+// Will return nil if there is no next match or if given a nil match.
+func (re *Regexp) FindNextMatch(m *Match) (*Match, error) {
+	if m == nil {
+		return nil, nil
+	}
+
+	// If previous match was empty, advance by one before matching to prevent
+	// infinite loop
+	startAt := m.textpos
+	if m.Length == 0 {
+		if m.textpos == len(m.text) {
+			return nil, nil
+		}
+
+		if re.RightToLeft() {
+			startAt--
+		} else {
+			startAt++
+		}
+	}
+	return re.run(false, startAt, m.text)
+}
+
+// MatchString return true if the string matches the regex
+// error will be set if a timeout occurs
+func (re *Regexp) MatchString(s string) (bool, error) {
+	m, err := re.run(true, -1, getRunes(s))
+	if err != nil {
+		return false, err
+	}
+	return m != nil, nil
+}
+
+func (re *Regexp) getRunesAndStart(s string, startAt int) ([]rune, int) {
+	if startAt < 0 {
+		if re.RightToLeft() {
+			r := getRunes(s)
+			return r, len(r)
+		}
+		return getRunes(s), 0
+	}
+	ret := make([]rune, len(s))
+	i := 0
+	runeIdx := -1
+	for strIdx, r := range s {
+		if strIdx == startAt {
+			runeIdx = i
+		}
+		ret[i] = r
+		i++
+	}
+	if startAt == len(s) {
+		runeIdx = i
+	}
+	return ret[:i], runeIdx
+}
+
+func getRunes(s string) []rune {
+	return []rune(s)
+}
+
+// MatchRunes return true if the runes matches the regex
+// error will be set if a timeout occurs
+func (re *Regexp) MatchRunes(r []rune) (bool, error) {
+	m, err := re.run(true, -1, r)
+	if err != nil {
+		return false, err
+	}
+	return m != nil, nil
+}
+
+// GetGroupNames Returns the set of strings used to name capturing groups in the expression.
+func (re *Regexp) GetGroupNames() []string {
+	var result []string
+
+	if re.capslist == nil {
+		result = make([]string, re.capsize)
+
+		for i := 0; i < len(result); i++ {
+			result[i] = strconv.Itoa(i)
+		}
+	} else {
+		result = make([]string, len(re.capslist))
+		copy(result, re.capslist)
+	}
+
+	return result
+}
+
+// GetGroupNumbers returns the integer group numbers corresponding to a group name.
+func (re *Regexp) GetGroupNumbers() []int {
+	var result []int
+
+	if re.caps == nil {
+		result = make([]int, re.capsize)
+
+		for i := 0; i < len(result); i++ {
+			result[i] = i
+		}
+	} else {
+		result = make([]int, len(re.caps))
+
+		for k, v := range re.caps {
+			result[v] = k
+		}
+	}
+
+	return result
+}
+
+// GroupNameFromNumber retrieves a group name that corresponds to a group number.
+// It will return "" for and unknown group number.  Unnamed groups automatically
+// receive a name that is the decimal string equivalent of its number.
+func (re *Regexp) GroupNameFromNumber(i int) string {
+	if re.capslist == nil {
+		if i >= 0 && i < re.capsize {
+			return strconv.Itoa(i)
+		}
+
+		return ""
+	}
+
+	if re.caps != nil {
+		var ok bool
+		if i, ok = re.caps[i]; !ok {
+			return ""
+		}
+	}
+
+	if i >= 0 && i < len(re.capslist) {
+		return re.capslist[i]
+	}
+
+	return ""
+}
+
+// GroupNumberFromName returns a group number that corresponds to a group name.
+// Returns -1 if the name is not a recognized group name.  Numbered groups
+// automatically get a group name that is the decimal string equivalent of its number.
+func (re *Regexp) GroupNumberFromName(name string) int {
+	// look up name if we have a hashtable of names
+	if re.capnames != nil {
+		if k, ok := re.capnames[name]; ok {
+			return k
+		}
+
+		return -1
+	}
+
+	// convert to an int if it looks like a number
+	result := 0
+	for i := 0; i < len(name); i++ {
+		ch := name[i]
+
+		if ch > '9' || ch < '0' {
+			return -1
+		}
+
+		result *= 10
+		result += int(ch - '0')
+	}
+
+	// return int if it's in range
+	if result >= 0 && result < re.capsize {
+		return result
+	}
+
+	return -1
+}
+
+// MarshalText implements [encoding.TextMarshaler]. The output
+// matches that of calling the [Regexp.String] method.
+func (re *Regexp) MarshalText() ([]byte, error) {
+	return []byte(re.String()), nil
+}
+
+// UnmarshalText implements [encoding.TextUnmarshaler] by calling
+// [Compile] on the encoded value.
+func (re *Regexp) UnmarshalText(text []byte) error {
+	newRE, err := Compile(string(text), DefaultUnmarshalOptions)
+	if err != nil {
+		return err
+	}
+	*re = *newRE
+	return nil
+}

--- a/vendor/github.com/dlclark/regexp2/replace.go
+++ b/vendor/github.com/dlclark/regexp2/replace.go
@@ -1,0 +1,177 @@
+package regexp2
+
+import (
+	"bytes"
+	"errors"
+
+	"github.com/dlclark/regexp2/syntax"
+)
+
+const (
+	replaceSpecials     = 4
+	replaceLeftPortion  = -1
+	replaceRightPortion = -2
+	replaceLastGroup    = -3
+	replaceWholeString  = -4
+)
+
+// MatchEvaluator is a function that takes a match and returns a replacement string to be used
+type MatchEvaluator func(Match) string
+
+// Three very similar algorithms appear below: replace (pattern),
+// replace (evaluator), and split.
+
+// Replace Replaces all occurrences of the regex in the string with the
+// replacement pattern.
+//
+// Note that the special case of no matches is handled on its own:
+// with no matches, the input string is returned unchanged.
+// The right-to-left case is split out because StringBuilder
+// doesn't handle right-to-left string building directly very well.
+func replace(regex *Regexp, data *syntax.ReplacerData, evaluator MatchEvaluator, input string, startAt, count int) (string, error) {
+	if count < -1 {
+		return "", errors.New("Count too small")
+	}
+	if count == 0 {
+		return "", nil
+	}
+
+	m, err := regex.FindStringMatchStartingAt(input, startAt)
+
+	if err != nil {
+		return "", err
+	}
+	if m == nil {
+		return input, nil
+	}
+
+	buf := &bytes.Buffer{}
+	text := m.text
+
+	if !regex.RightToLeft() {
+		prevat := 0
+		for m != nil {
+			if m.Index != prevat {
+				buf.WriteString(string(text[prevat:m.Index]))
+			}
+			prevat = m.Index + m.Length
+			if evaluator == nil {
+				replacementImpl(data, buf, m)
+			} else {
+				buf.WriteString(evaluator(*m))
+			}
+
+			count--
+			if count == 0 {
+				break
+			}
+			m, err = regex.FindNextMatch(m)
+			if err != nil {
+				return "", nil
+			}
+		}
+
+		if prevat < len(text) {
+			buf.WriteString(string(text[prevat:]))
+		}
+	} else {
+		prevat := len(text)
+		var al []string
+
+		for m != nil {
+			if m.Index+m.Length != prevat {
+				al = append(al, string(text[m.Index+m.Length:prevat]))
+			}
+			prevat = m.Index
+			if evaluator == nil {
+				replacementImplRTL(data, &al, m)
+			} else {
+				al = append(al, evaluator(*m))
+			}
+
+			count--
+			if count == 0 {
+				break
+			}
+			m, err = regex.FindNextMatch(m)
+			if err != nil {
+				return "", nil
+			}
+		}
+
+		if prevat > 0 {
+			buf.WriteString(string(text[:prevat]))
+		}
+
+		for i := len(al) - 1; i >= 0; i-- {
+			buf.WriteString(al[i])
+		}
+	}
+
+	return buf.String(), nil
+}
+
+// Given a Match, emits into the StringBuilder the evaluated
+// substitution pattern.
+func replacementImpl(data *syntax.ReplacerData, buf *bytes.Buffer, m *Match) {
+	for _, r := range data.Rules {
+
+		if r >= 0 { // string lookup
+			buf.WriteString(data.Strings[r])
+		} else if r < -replaceSpecials { // group lookup
+			m.groupValueAppendToBuf(-replaceSpecials-1-r, buf)
+		} else {
+			switch -replaceSpecials - 1 - r { // special insertion patterns
+			case replaceLeftPortion:
+				for i := 0; i < m.Index; i++ {
+					buf.WriteRune(m.text[i])
+				}
+			case replaceRightPortion:
+				for i := m.Index + m.Length; i < len(m.text); i++ {
+					buf.WriteRune(m.text[i])
+				}
+			case replaceLastGroup:
+				m.groupValueAppendToBuf(m.GroupCount()-1, buf)
+			case replaceWholeString:
+				for i := 0; i < len(m.text); i++ {
+					buf.WriteRune(m.text[i])
+				}
+			}
+		}
+	}
+}
+
+func replacementImplRTL(data *syntax.ReplacerData, al *[]string, m *Match) {
+	l := *al
+	buf := &bytes.Buffer{}
+
+	for _, r := range data.Rules {
+		buf.Reset()
+		if r >= 0 { // string lookup
+			l = append(l, data.Strings[r])
+		} else if r < -replaceSpecials { // group lookup
+			m.groupValueAppendToBuf(-replaceSpecials-1-r, buf)
+			l = append(l, buf.String())
+		} else {
+			switch -replaceSpecials - 1 - r { // special insertion patterns
+			case replaceLeftPortion:
+				for i := 0; i < m.Index; i++ {
+					buf.WriteRune(m.text[i])
+				}
+			case replaceRightPortion:
+				for i := m.Index + m.Length; i < len(m.text); i++ {
+					buf.WriteRune(m.text[i])
+				}
+			case replaceLastGroup:
+				m.groupValueAppendToBuf(m.GroupCount()-1, buf)
+			case replaceWholeString:
+				for i := 0; i < len(m.text); i++ {
+					buf.WriteRune(m.text[i])
+				}
+			}
+			l = append(l, buf.String())
+		}
+	}
+
+	*al = l
+}

--- a/vendor/github.com/dlclark/regexp2/runner.go
+++ b/vendor/github.com/dlclark/regexp2/runner.go
@@ -1,0 +1,1614 @@
+package regexp2
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/dlclark/regexp2/syntax"
+)
+
+type runner struct {
+	re   *Regexp
+	code *syntax.Code
+
+	runtextstart int // starting point for search
+
+	runtext    []rune // text to search
+	runtextpos int    // current position in text
+	runtextend int
+
+	// The backtracking stack.  Opcodes use this to store data regarding
+	// what they have matched and where to backtrack to.  Each "frame" on
+	// the stack takes the form of [CodePosition Data1 Data2...], where
+	// CodePosition is the position of the current opcode and
+	// the data values are all optional.  The CodePosition can be negative, and
+	// these values (also called "back2") are used by the BranchMark family of opcodes
+	// to indicate whether they are backtracking after a successful or failed
+	// match.
+	// When we backtrack, we pop the CodePosition off the stack, set the current
+	// instruction pointer to that code position, and mark the opcode
+	// with a backtracking flag ("Back").  Each opcode then knows how to
+	// handle its own data.
+	runtrack    []int
+	runtrackpos int
+
+	// This stack is used to track text positions across different opcodes.
+	// For example, in /(a*b)+/, the parentheses result in a SetMark/CaptureMark
+	// pair. SetMark records the text position before we match a*b.  Then
+	// CaptureMark uses that position to figure out where the capture starts.
+	// Opcodes which push onto this stack are always paired with other opcodes
+	// which will pop the value from it later.  A successful match should mean
+	// that this stack is empty.
+	runstack    []int
+	runstackpos int
+
+	// The crawl stack is used to keep track of captures.  Every time a group
+	// has a capture, we push its group number onto the runcrawl stack.  In
+	// the case of a balanced match, we push BOTH groups onto the stack.
+	runcrawl    []int
+	runcrawlpos int
+
+	runtrackcount int // count of states that may do backtracking
+
+	runmatch *Match // result object
+
+	ignoreTimeout bool
+	timeout       time.Duration // timeout in milliseconds (needed for actual)
+	deadline      fasttime
+
+	operator        syntax.InstOp
+	codepos         int
+	rightToLeft     bool
+	caseInsensitive bool
+}
+
+// run searches for matches and can continue from the previous match
+//
+// quick is usually false, but can be true to not return matches, just put it in caches
+// textstart is -1 to start at the "beginning" (depending on Right-To-Left), otherwise an index in input
+// input is the string to search for our regex pattern
+func (re *Regexp) run(quick bool, textstart int, input []rune) (*Match, error) {
+
+	// get a cached runner
+	runner := re.getRunner()
+	defer re.putRunner(runner)
+
+	if textstart < 0 {
+		if re.RightToLeft() {
+			textstart = len(input)
+		} else {
+			textstart = 0
+		}
+	}
+
+	return runner.scan(input, textstart, quick, re.MatchTimeout)
+}
+
+// Scans the string to find the first match. Uses the Match object
+// both to feed text in and as a place to store matches that come out.
+//
+// All the action is in the Go() method. Our
+// responsibility is to load up the class members before
+// calling Go.
+//
+// The optimizer can compute a set of candidate starting characters,
+// and we could use a separate method Skip() that will quickly scan past
+// any characters that we know can't match.
+func (r *runner) scan(rt []rune, textstart int, quick bool, timeout time.Duration) (*Match, error) {
+	r.timeout = timeout
+	r.ignoreTimeout = (time.Duration(math.MaxInt64) == timeout)
+	r.runtextstart = textstart
+	r.runtext = rt
+	r.runtextend = len(rt)
+
+	stoppos := r.runtextend
+	bump := 1
+
+	if r.re.RightToLeft() {
+		bump = -1
+		stoppos = 0
+	}
+
+	r.runtextpos = textstart
+	initted := false
+
+	r.startTimeoutWatch()
+	for {
+		if r.re.Debug() {
+			//fmt.Printf("\nSearch content: %v\n", string(r.runtext))
+			fmt.Printf("\nSearch range: from 0 to %v\n", r.runtextend)
+			fmt.Printf("Firstchar search starting at %v stopping at %v\n", r.runtextpos, stoppos)
+		}
+
+		if r.findFirstChar() {
+			if err := r.checkTimeout(); err != nil {
+				return nil, err
+			}
+
+			if !initted {
+				r.initMatch()
+				initted = true
+			}
+
+			if r.re.Debug() {
+				fmt.Printf("Executing engine starting at %v\n\n", r.runtextpos)
+			}
+
+			if err := r.execute(); err != nil {
+				return nil, err
+			}
+
+			if r.runmatch.matchcount[0] > 0 {
+				// We'll return a match even if it touches a previous empty match
+				return r.tidyMatch(quick), nil
+			}
+
+			// reset state for another go
+			r.runtrackpos = len(r.runtrack)
+			r.runstackpos = len(r.runstack)
+			r.runcrawlpos = len(r.runcrawl)
+		}
+
+		// failure!
+
+		if r.runtextpos == stoppos {
+			r.tidyMatch(true)
+			return nil, nil
+		}
+
+		// Recognize leading []* and various anchors, and bump on failure accordingly
+
+		// r.bump by one and start again
+
+		r.runtextpos += bump
+	}
+	// We never get here
+}
+
+func (r *runner) execute() error {
+
+	r.goTo(0)
+
+	for {
+
+		if r.re.Debug() {
+			r.dumpState()
+		}
+
+		if err := r.checkTimeout(); err != nil {
+			return err
+		}
+
+		switch r.operator {
+		case syntax.Stop:
+			return nil
+
+		case syntax.Nothing:
+			break
+
+		case syntax.Goto:
+			r.goTo(r.operand(0))
+			continue
+
+		case syntax.Testref:
+			if !r.runmatch.isMatched(r.operand(0)) {
+				break
+			}
+			r.advance(1)
+			continue
+
+		case syntax.Lazybranch:
+			r.trackPush1(r.textPos())
+			r.advance(1)
+			continue
+
+		case syntax.Lazybranch | syntax.Back:
+			r.trackPop()
+			r.textto(r.trackPeek())
+			r.goTo(r.operand(0))
+			continue
+
+		case syntax.Setmark:
+			r.stackPush(r.textPos())
+			r.trackPush()
+			r.advance(0)
+			continue
+
+		case syntax.Nullmark:
+			r.stackPush(-1)
+			r.trackPush()
+			r.advance(0)
+			continue
+
+		case syntax.Setmark | syntax.Back, syntax.Nullmark | syntax.Back:
+			r.stackPop()
+			break
+
+		case syntax.Getmark:
+			r.stackPop()
+			r.trackPush1(r.stackPeek())
+			r.textto(r.stackPeek())
+			r.advance(0)
+			continue
+
+		case syntax.Getmark | syntax.Back:
+			r.trackPop()
+			r.stackPush(r.trackPeek())
+			break
+
+		case syntax.Capturemark:
+			if r.operand(1) != -1 && !r.runmatch.isMatched(r.operand(1)) {
+				break
+			}
+			r.stackPop()
+			if r.operand(1) != -1 {
+				r.transferCapture(r.operand(0), r.operand(1), r.stackPeek(), r.textPos())
+			} else {
+				r.capture(r.operand(0), r.stackPeek(), r.textPos())
+			}
+			r.trackPush1(r.stackPeek())
+
+			r.advance(2)
+
+			continue
+
+		case syntax.Capturemark | syntax.Back:
+			r.trackPop()
+			r.stackPush(r.trackPeek())
+			r.uncapture()
+			if r.operand(0) != -1 && r.operand(1) != -1 {
+				r.uncapture()
+			}
+
+			break
+
+		case syntax.Branchmark:
+			r.stackPop()
+
+			matched := r.textPos() - r.stackPeek()
+
+			if matched != 0 { // Nonempty match -> loop now
+				r.trackPush2(r.stackPeek(), r.textPos()) // Save old mark, textpos
+				r.stackPush(r.textPos())                 // Make new mark
+				r.goTo(r.operand(0))                     // Loop
+			} else { // Empty match -> straight now
+				r.trackPushNeg1(r.stackPeek()) // Save old mark
+				r.advance(1)                   // Straight
+			}
+			continue
+
+		case syntax.Branchmark | syntax.Back:
+			r.trackPopN(2)
+			r.stackPop()
+			r.textto(r.trackPeekN(1))      // Recall position
+			r.trackPushNeg1(r.trackPeek()) // Save old mark
+			r.advance(1)                   // Straight
+			continue
+
+		case syntax.Branchmark | syntax.Back2:
+			r.trackPop()
+			r.stackPush(r.trackPeek()) // Recall old mark
+			break                      // Backtrack
+
+		case syntax.Lazybranchmark:
+			{
+				// We hit this the first time through a lazy loop and after each
+				// successful match of the inner expression.  It simply continues
+				// on and doesn't loop.
+				r.stackPop()
+
+				oldMarkPos := r.stackPeek()
+
+				if r.textPos() != oldMarkPos { // Nonempty match -> try to loop again by going to 'back' state
+					if oldMarkPos != -1 {
+						r.trackPush2(oldMarkPos, r.textPos()) // Save old mark, textpos
+					} else {
+						r.trackPush2(r.textPos(), r.textPos())
+					}
+				} else {
+					// The inner expression found an empty match, so we'll go directly to 'back2' if we
+					// backtrack. Don't touch the grouping stack here; instead, record the old mark and
+					// a flag indicating that backtracking doesn't need to pop a grouping stack frame.
+					r.trackPushNeg2(oldMarkPos, 0)
+				}
+				r.advance(1)
+				continue
+			}
+
+		case syntax.Lazybranchmark | syntax.Back:
+
+			// After the first time, Lazybranchmark | syntax.Back occurs
+			// with each iteration of the loop, and therefore with every attempted
+			// match of the inner expression.  We'll try to match the inner expression,
+			// then go back to Lazybranchmark if successful.  If the inner expression
+			// fails, we go to Lazybranchmark | syntax.Back2
+
+			r.trackPopN(2)
+			pos := r.trackPeekN(1)
+			r.trackPushNeg2(r.trackPeek(), 1) // Save old mark, note that we pushed a new mark
+			r.stackPush(pos)                  // Make new mark
+			r.textto(pos)                     // Recall position
+			r.goTo(r.operand(0))              // Loop
+			continue
+
+		case syntax.Lazybranchmark | syntax.Back2:
+			// The lazy loop has failed.  We'll do a true backtrack and
+			// start over before the lazy loop.
+			r.trackPopN(2)
+			oldMark := r.trackPeek()
+			needsPop := r.trackPeekN(1)
+			if needsPop != 0 {
+				r.stackPop()
+			}
+			r.stackPush(oldMark) // Recall old mark
+			break
+
+		case syntax.Setcount:
+			r.stackPush2(r.textPos(), r.operand(0))
+			r.trackPush()
+			r.advance(1)
+			continue
+
+		case syntax.Nullcount:
+			r.stackPush2(-1, r.operand(0))
+			r.trackPush()
+			r.advance(1)
+			continue
+
+		case syntax.Setcount | syntax.Back:
+			r.stackPopN(2)
+			break
+
+		case syntax.Nullcount | syntax.Back:
+			r.stackPopN(2)
+			break
+
+		case syntax.Branchcount:
+			// r.stackPush:
+			//  0: Mark
+			//  1: Count
+
+			r.stackPopN(2)
+			mark := r.stackPeek()
+			count := r.stackPeekN(1)
+			matched := r.textPos() - mark
+
+			if count >= r.operand(1) || (matched == 0 && count >= 0) { // Max loops or empty match -> straight now
+				r.trackPushNeg2(mark, count) // Save old mark, count
+				r.advance(2)                 // Straight
+			} else { // Nonempty match -> count+loop now
+				r.trackPush1(mark)                 // remember mark
+				r.stackPush2(r.textPos(), count+1) // Make new mark, incr count
+				r.goTo(r.operand(0))               // Loop
+			}
+			continue
+
+		case syntax.Branchcount | syntax.Back:
+			// r.trackPush:
+			//  0: Previous mark
+			// r.stackPush:
+			//  0: Mark (= current pos, discarded)
+			//  1: Count
+			r.trackPop()
+			r.stackPopN(2)
+			if r.stackPeekN(1) > 0 { // Positive -> can go straight
+				r.textto(r.stackPeek())                           // Zap to mark
+				r.trackPushNeg2(r.trackPeek(), r.stackPeekN(1)-1) // Save old mark, old count
+				r.advance(2)                                      // Straight
+				continue
+			}
+			r.stackPush2(r.trackPeek(), r.stackPeekN(1)-1) // recall old mark, old count
+			break
+
+		case syntax.Branchcount | syntax.Back2:
+			// r.trackPush:
+			//  0: Previous mark
+			//  1: Previous count
+			r.trackPopN(2)
+			r.stackPush2(r.trackPeek(), r.trackPeekN(1)) // Recall old mark, old count
+			break                                        // Backtrack
+
+		case syntax.Lazybranchcount:
+			// r.stackPush:
+			//  0: Mark
+			//  1: Count
+
+			r.stackPopN(2)
+			mark := r.stackPeek()
+			count := r.stackPeekN(1)
+
+			if count < 0 { // Negative count -> loop now
+				r.trackPushNeg1(mark)              // Save old mark
+				r.stackPush2(r.textPos(), count+1) // Make new mark, incr count
+				r.goTo(r.operand(0))               // Loop
+			} else { // Nonneg count -> straight now
+				r.trackPush3(mark, count, r.textPos()) // Save mark, count, position
+				r.advance(2)                           // Straight
+			}
+			continue
+
+		case syntax.Lazybranchcount | syntax.Back:
+			// r.trackPush:
+			//  0: Mark
+			//  1: Count
+			//  2: r.textPos
+
+			r.trackPopN(3)
+			mark := r.trackPeek()
+			textpos := r.trackPeekN(2)
+
+			if r.trackPeekN(1) < r.operand(1) && textpos != mark { // Under limit and not empty match -> loop
+				r.textto(textpos)                        // Recall position
+				r.stackPush2(textpos, r.trackPeekN(1)+1) // Make new mark, incr count
+				r.trackPushNeg1(mark)                    // Save old mark
+				r.goTo(r.operand(0))                     // Loop
+				continue
+			} else { // Max loops or empty match -> backtrack
+				r.stackPush2(r.trackPeek(), r.trackPeekN(1)) // Recall old mark, count
+				break                                        // backtrack
+			}
+
+		case syntax.Lazybranchcount | syntax.Back2:
+			// r.trackPush:
+			//  0: Previous mark
+			// r.stackPush:
+			//  0: Mark (== current pos, discarded)
+			//  1: Count
+			r.trackPop()
+			r.stackPopN(2)
+			r.stackPush2(r.trackPeek(), r.stackPeekN(1)-1) // Recall old mark, count
+			break                                          // Backtrack
+
+		case syntax.Setjump:
+			r.stackPush2(r.trackpos(), r.crawlpos())
+			r.trackPush()
+			r.advance(0)
+			continue
+
+		case syntax.Setjump | syntax.Back:
+			r.stackPopN(2)
+			break
+
+		case syntax.Backjump:
+			// r.stackPush:
+			//  0: Saved trackpos
+			//  1: r.crawlpos
+			r.stackPopN(2)
+			r.trackto(r.stackPeek())
+
+			for r.crawlpos() != r.stackPeekN(1) {
+				r.uncapture()
+			}
+
+			break
+
+		case syntax.Forejump:
+			// r.stackPush:
+			//  0: Saved trackpos
+			//  1: r.crawlpos
+			r.stackPopN(2)
+			r.trackto(r.stackPeek())
+			r.trackPush1(r.stackPeekN(1))
+			r.advance(0)
+			continue
+
+		case syntax.Forejump | syntax.Back:
+			// r.trackPush:
+			//  0: r.crawlpos
+			r.trackPop()
+
+			for r.crawlpos() != r.trackPeek() {
+				r.uncapture()
+			}
+
+			break
+
+		case syntax.Bol:
+			if r.leftchars() > 0 && r.charAt(r.textPos()-1) != '\n' {
+				break
+			}
+			r.advance(0)
+			continue
+
+		case syntax.Eol:
+			if r.rightchars() > 0 && r.charAt(r.textPos()) != '\n' {
+				break
+			}
+			r.advance(0)
+			continue
+
+		case syntax.Boundary:
+			if !r.isBoundary(r.textPos(), 0, r.runtextend) {
+				break
+			}
+			r.advance(0)
+			continue
+
+		case syntax.Nonboundary:
+			if r.isBoundary(r.textPos(), 0, r.runtextend) {
+				break
+			}
+			r.advance(0)
+			continue
+
+		case syntax.ECMABoundary:
+			if !r.isECMABoundary(r.textPos(), 0, r.runtextend) {
+				break
+			}
+			r.advance(0)
+			continue
+
+		case syntax.NonECMABoundary:
+			if r.isECMABoundary(r.textPos(), 0, r.runtextend) {
+				break
+			}
+			r.advance(0)
+			continue
+
+		case syntax.Beginning:
+			if r.leftchars() > 0 {
+				break
+			}
+			r.advance(0)
+			continue
+
+		case syntax.Start:
+			if r.textPos() != r.textstart() {
+				break
+			}
+			r.advance(0)
+			continue
+
+		case syntax.EndZ:
+			rchars := r.rightchars()
+			if rchars > 1 {
+				break
+			}
+			// RE2 and EcmaScript define $ as "asserts position at the end of the string"
+			// PCRE/.NET adds "or before the line terminator right at the end of the string (if any)"
+			if (r.re.options & (RE2 | ECMAScript)) != 0 {
+				// RE2/Ecmascript mode
+				if rchars > 0 {
+					break
+				}
+			} else if rchars == 1 && r.charAt(r.textPos()) != '\n' {
+				// "regular" mode
+				break
+			}
+
+			r.advance(0)
+			continue
+
+		case syntax.End:
+			if r.rightchars() > 0 {
+				break
+			}
+			r.advance(0)
+			continue
+
+		case syntax.One:
+			if r.forwardchars() < 1 || r.forwardcharnext() != rune(r.operand(0)) {
+				break
+			}
+
+			r.advance(1)
+			continue
+
+		case syntax.Notone:
+			if r.forwardchars() < 1 || r.forwardcharnext() == rune(r.operand(0)) {
+				break
+			}
+
+			r.advance(1)
+			continue
+
+		case syntax.Set:
+
+			if r.forwardchars() < 1 || !r.code.Sets[r.operand(0)].CharIn(r.forwardcharnext()) {
+				break
+			}
+
+			r.advance(1)
+			continue
+
+		case syntax.Multi:
+			if !r.runematch(r.code.Strings[r.operand(0)]) {
+				break
+			}
+
+			r.advance(1)
+			continue
+
+		case syntax.Ref:
+
+			capnum := r.operand(0)
+
+			if r.runmatch.isMatched(capnum) {
+				if !r.refmatch(r.runmatch.matchIndex(capnum), r.runmatch.matchLength(capnum)) {
+					break
+				}
+			} else {
+				if (r.re.options & ECMAScript) == 0 {
+					break
+				}
+			}
+
+			r.advance(1)
+			continue
+
+		case syntax.Onerep:
+
+			c := r.operand(1)
+
+			if r.forwardchars() < c {
+				break
+			}
+
+			ch := rune(r.operand(0))
+
+			for c > 0 {
+				if r.forwardcharnext() != ch {
+					goto BreakBackward
+				}
+				c--
+			}
+
+			r.advance(2)
+			continue
+
+		case syntax.Notonerep:
+
+			c := r.operand(1)
+
+			if r.forwardchars() < c {
+				break
+			}
+			ch := rune(r.operand(0))
+
+			for c > 0 {
+				if r.forwardcharnext() == ch {
+					goto BreakBackward
+				}
+				c--
+			}
+
+			r.advance(2)
+			continue
+
+		case syntax.Setrep:
+
+			c := r.operand(1)
+
+			if r.forwardchars() < c {
+				break
+			}
+
+			set := r.code.Sets[r.operand(0)]
+
+			for c > 0 {
+				if !set.CharIn(r.forwardcharnext()) {
+					goto BreakBackward
+				}
+				c--
+			}
+
+			r.advance(2)
+			continue
+
+		case syntax.Oneloop:
+
+			c := r.operand(1)
+
+			if c > r.forwardchars() {
+				c = r.forwardchars()
+			}
+
+			ch := rune(r.operand(0))
+			i := c
+
+			for ; i > 0; i-- {
+				if r.forwardcharnext() != ch {
+					r.backwardnext()
+					break
+				}
+			}
+
+			if c > i {
+				r.trackPush2(c-i-1, r.textPos()-r.bump())
+			}
+
+			r.advance(2)
+			continue
+
+		case syntax.Notoneloop:
+
+			c := r.operand(1)
+
+			if c > r.forwardchars() {
+				c = r.forwardchars()
+			}
+
+			ch := rune(r.operand(0))
+			i := c
+
+			for ; i > 0; i-- {
+				if r.forwardcharnext() == ch {
+					r.backwardnext()
+					break
+				}
+			}
+
+			if c > i {
+				r.trackPush2(c-i-1, r.textPos()-r.bump())
+			}
+
+			r.advance(2)
+			continue
+
+		case syntax.Setloop:
+
+			c := r.operand(1)
+
+			if c > r.forwardchars() {
+				c = r.forwardchars()
+			}
+
+			set := r.code.Sets[r.operand(0)]
+			i := c
+
+			for ; i > 0; i-- {
+				if !set.CharIn(r.forwardcharnext()) {
+					r.backwardnext()
+					break
+				}
+			}
+
+			if c > i {
+				r.trackPush2(c-i-1, r.textPos()-r.bump())
+			}
+
+			r.advance(2)
+			continue
+
+		case syntax.Oneloop | syntax.Back, syntax.Notoneloop | syntax.Back:
+
+			r.trackPopN(2)
+			i := r.trackPeek()
+			pos := r.trackPeekN(1)
+
+			r.textto(pos)
+
+			if i > 0 {
+				r.trackPush2(i-1, pos-r.bump())
+			}
+
+			r.advance(2)
+			continue
+
+		case syntax.Setloop | syntax.Back:
+
+			r.trackPopN(2)
+			i := r.trackPeek()
+			pos := r.trackPeekN(1)
+
+			r.textto(pos)
+
+			if i > 0 {
+				r.trackPush2(i-1, pos-r.bump())
+			}
+
+			r.advance(2)
+			continue
+
+		case syntax.Onelazy, syntax.Notonelazy:
+
+			c := r.operand(1)
+
+			if c > r.forwardchars() {
+				c = r.forwardchars()
+			}
+
+			if c > 0 {
+				r.trackPush2(c-1, r.textPos())
+			}
+
+			r.advance(2)
+			continue
+
+		case syntax.Setlazy:
+
+			c := r.operand(1)
+
+			if c > r.forwardchars() {
+				c = r.forwardchars()
+			}
+
+			if c > 0 {
+				r.trackPush2(c-1, r.textPos())
+			}
+
+			r.advance(2)
+			continue
+
+		case syntax.Onelazy | syntax.Back:
+
+			r.trackPopN(2)
+			pos := r.trackPeekN(1)
+			r.textto(pos)
+
+			if r.forwardcharnext() != rune(r.operand(0)) {
+				break
+			}
+
+			i := r.trackPeek()
+
+			if i > 0 {
+				r.trackPush2(i-1, pos+r.bump())
+			}
+
+			r.advance(2)
+			continue
+
+		case syntax.Notonelazy | syntax.Back:
+
+			r.trackPopN(2)
+			pos := r.trackPeekN(1)
+			r.textto(pos)
+
+			if r.forwardcharnext() == rune(r.operand(0)) {
+				break
+			}
+
+			i := r.trackPeek()
+
+			if i > 0 {
+				r.trackPush2(i-1, pos+r.bump())
+			}
+
+			r.advance(2)
+			continue
+
+		case syntax.Setlazy | syntax.Back:
+
+			r.trackPopN(2)
+			pos := r.trackPeekN(1)
+			r.textto(pos)
+
+			if !r.code.Sets[r.operand(0)].CharIn(r.forwardcharnext()) {
+				break
+			}
+
+			i := r.trackPeek()
+
+			if i > 0 {
+				r.trackPush2(i-1, pos+r.bump())
+			}
+
+			r.advance(2)
+			continue
+
+		default:
+			return errors.New("unknown state in regex runner")
+		}
+
+	BreakBackward:
+		;
+
+		// "break Backward" comes here:
+		r.backtrack()
+	}
+}
+
+// increase the size of stack and track storage
+func (r *runner) ensureStorage() {
+	if r.runstackpos < r.runtrackcount*4 {
+		doubleIntSlice(&r.runstack, &r.runstackpos)
+	}
+	if r.runtrackpos < r.runtrackcount*4 {
+		doubleIntSlice(&r.runtrack, &r.runtrackpos)
+	}
+}
+
+func doubleIntSlice(s *[]int, pos *int) {
+	oldLen := len(*s)
+	newS := make([]int, oldLen*2)
+
+	copy(newS[oldLen:], *s)
+	*pos += oldLen
+	*s = newS
+}
+
+// Save a number on the longjump unrolling stack
+func (r *runner) crawl(i int) {
+	if r.runcrawlpos == 0 {
+		doubleIntSlice(&r.runcrawl, &r.runcrawlpos)
+	}
+	r.runcrawlpos--
+	r.runcrawl[r.runcrawlpos] = i
+}
+
+// Remove a number from the longjump unrolling stack
+func (r *runner) popcrawl() int {
+	val := r.runcrawl[r.runcrawlpos]
+	r.runcrawlpos++
+	return val
+}
+
+// Get the height of the stack
+func (r *runner) crawlpos() int {
+	return len(r.runcrawl) - r.runcrawlpos
+}
+
+func (r *runner) advance(i int) {
+	r.codepos += (i + 1)
+	r.setOperator(r.code.Codes[r.codepos])
+}
+
+func (r *runner) goTo(newpos int) {
+	// when branching backward or in place, ensure storage
+	if newpos <= r.codepos {
+		r.ensureStorage()
+	}
+
+	r.setOperator(r.code.Codes[newpos])
+	r.codepos = newpos
+}
+
+func (r *runner) textto(newpos int) {
+	r.runtextpos = newpos
+}
+
+func (r *runner) trackto(newpos int) {
+	r.runtrackpos = len(r.runtrack) - newpos
+}
+
+func (r *runner) textstart() int {
+	return r.runtextstart
+}
+
+func (r *runner) textPos() int {
+	return r.runtextpos
+}
+
+// push onto the backtracking stack
+func (r *runner) trackpos() int {
+	return len(r.runtrack) - r.runtrackpos
+}
+
+func (r *runner) trackPush() {
+	r.runtrackpos--
+	r.runtrack[r.runtrackpos] = r.codepos
+}
+
+func (r *runner) trackPush1(I1 int) {
+	r.runtrackpos--
+	r.runtrack[r.runtrackpos] = I1
+	r.runtrackpos--
+	r.runtrack[r.runtrackpos] = r.codepos
+}
+
+func (r *runner) trackPush2(I1, I2 int) {
+	r.runtrackpos--
+	r.runtrack[r.runtrackpos] = I1
+	r.runtrackpos--
+	r.runtrack[r.runtrackpos] = I2
+	r.runtrackpos--
+	r.runtrack[r.runtrackpos] = r.codepos
+}
+
+func (r *runner) trackPush3(I1, I2, I3 int) {
+	r.runtrackpos--
+	r.runtrack[r.runtrackpos] = I1
+	r.runtrackpos--
+	r.runtrack[r.runtrackpos] = I2
+	r.runtrackpos--
+	r.runtrack[r.runtrackpos] = I3
+	r.runtrackpos--
+	r.runtrack[r.runtrackpos] = r.codepos
+}
+
+func (r *runner) trackPushNeg1(I1 int) {
+	r.runtrackpos--
+	r.runtrack[r.runtrackpos] = I1
+	r.runtrackpos--
+	r.runtrack[r.runtrackpos] = -r.codepos
+}
+
+func (r *runner) trackPushNeg2(I1, I2 int) {
+	r.runtrackpos--
+	r.runtrack[r.runtrackpos] = I1
+	r.runtrackpos--
+	r.runtrack[r.runtrackpos] = I2
+	r.runtrackpos--
+	r.runtrack[r.runtrackpos] = -r.codepos
+}
+
+func (r *runner) backtrack() {
+	newpos := r.runtrack[r.runtrackpos]
+	r.runtrackpos++
+
+	if r.re.Debug() {
+		if newpos < 0 {
+			fmt.Printf("       Backtracking (back2) to code position %v\n", -newpos)
+		} else {
+			fmt.Printf("       Backtracking to code position %v\n", newpos)
+		}
+	}
+
+	if newpos < 0 {
+		newpos = -newpos
+		r.setOperator(r.code.Codes[newpos] | syntax.Back2)
+	} else {
+		r.setOperator(r.code.Codes[newpos] | syntax.Back)
+	}
+
+	// When branching backward, ensure storage
+	if newpos < r.codepos {
+		r.ensureStorage()
+	}
+
+	r.codepos = newpos
+}
+
+func (r *runner) setOperator(op int) {
+	r.caseInsensitive = (0 != (op & syntax.Ci))
+	r.rightToLeft = (0 != (op & syntax.Rtl))
+	r.operator = syntax.InstOp(op & ^(syntax.Rtl | syntax.Ci))
+}
+
+func (r *runner) trackPop() {
+	r.runtrackpos++
+}
+
+// pop framesize items from the backtracking stack
+func (r *runner) trackPopN(framesize int) {
+	r.runtrackpos += framesize
+}
+
+// Technically we are actually peeking at items already popped.  So if you want to
+// get and pop the top item from the stack, you do
+// r.trackPop();
+// r.trackPeek();
+func (r *runner) trackPeek() int {
+	return r.runtrack[r.runtrackpos-1]
+}
+
+// get the ith element down on the backtracking stack
+func (r *runner) trackPeekN(i int) int {
+	return r.runtrack[r.runtrackpos-i-1]
+}
+
+// Push onto the grouping stack
+func (r *runner) stackPush(I1 int) {
+	r.runstackpos--
+	r.runstack[r.runstackpos] = I1
+}
+
+func (r *runner) stackPush2(I1, I2 int) {
+	r.runstackpos--
+	r.runstack[r.runstackpos] = I1
+	r.runstackpos--
+	r.runstack[r.runstackpos] = I2
+}
+
+func (r *runner) stackPop() {
+	r.runstackpos++
+}
+
+// pop framesize items from the grouping stack
+func (r *runner) stackPopN(framesize int) {
+	r.runstackpos += framesize
+}
+
+// Technically we are actually peeking at items already popped.  So if you want to
+// get and pop the top item from the stack, you do
+// r.stackPop();
+// r.stackPeek();
+func (r *runner) stackPeek() int {
+	return r.runstack[r.runstackpos-1]
+}
+
+// get the ith element down on the grouping stack
+func (r *runner) stackPeekN(i int) int {
+	return r.runstack[r.runstackpos-i-1]
+}
+
+func (r *runner) operand(i int) int {
+	return r.code.Codes[r.codepos+i+1]
+}
+
+func (r *runner) leftchars() int {
+	return r.runtextpos
+}
+
+func (r *runner) rightchars() int {
+	return r.runtextend - r.runtextpos
+}
+
+func (r *runner) bump() int {
+	if r.rightToLeft {
+		return -1
+	}
+	return 1
+}
+
+func (r *runner) forwardchars() int {
+	if r.rightToLeft {
+		return r.runtextpos
+	}
+	return r.runtextend - r.runtextpos
+}
+
+func (r *runner) forwardcharnext() rune {
+	var ch rune
+	if r.rightToLeft {
+		r.runtextpos--
+		ch = r.runtext[r.runtextpos]
+	} else {
+		ch = r.runtext[r.runtextpos]
+		r.runtextpos++
+	}
+
+	if r.caseInsensitive {
+		return unicode.ToLower(ch)
+	}
+	return ch
+}
+
+func (r *runner) runematch(str []rune) bool {
+	var pos int
+
+	c := len(str)
+	if !r.rightToLeft {
+		if r.runtextend-r.runtextpos < c {
+			return false
+		}
+
+		pos = r.runtextpos + c
+	} else {
+		if r.runtextpos-0 < c {
+			return false
+		}
+
+		pos = r.runtextpos
+	}
+
+	if !r.caseInsensitive {
+		for c != 0 {
+			c--
+			pos--
+			if str[c] != r.runtext[pos] {
+				return false
+			}
+		}
+	} else {
+		for c != 0 {
+			c--
+			pos--
+			if str[c] != unicode.ToLower(r.runtext[pos]) {
+				return false
+			}
+		}
+	}
+
+	if !r.rightToLeft {
+		pos += len(str)
+	}
+
+	r.runtextpos = pos
+
+	return true
+}
+
+func (r *runner) refmatch(index, len int) bool {
+	var c, pos, cmpos int
+
+	if !r.rightToLeft {
+		if r.runtextend-r.runtextpos < len {
+			return false
+		}
+
+		pos = r.runtextpos + len
+	} else {
+		if r.runtextpos-0 < len {
+			return false
+		}
+
+		pos = r.runtextpos
+	}
+	cmpos = index + len
+
+	c = len
+
+	if !r.caseInsensitive {
+		for c != 0 {
+			c--
+			cmpos--
+			pos--
+			if r.runtext[cmpos] != r.runtext[pos] {
+				return false
+			}
+
+		}
+	} else {
+		for c != 0 {
+			c--
+			cmpos--
+			pos--
+
+			if unicode.ToLower(r.runtext[cmpos]) != unicode.ToLower(r.runtext[pos]) {
+				return false
+			}
+		}
+	}
+
+	if !r.rightToLeft {
+		pos += len
+	}
+
+	r.runtextpos = pos
+
+	return true
+}
+
+func (r *runner) backwardnext() {
+	if r.rightToLeft {
+		r.runtextpos++
+	} else {
+		r.runtextpos--
+	}
+}
+
+func (r *runner) charAt(j int) rune {
+	return r.runtext[j]
+}
+
+func (r *runner) findFirstChar() bool {
+
+	if 0 != (r.code.Anchors & (syntax.AnchorBeginning | syntax.AnchorStart | syntax.AnchorEndZ | syntax.AnchorEnd)) {
+		if !r.code.RightToLeft {
+			if (0 != (r.code.Anchors&syntax.AnchorBeginning) && r.runtextpos > 0) ||
+				(0 != (r.code.Anchors&syntax.AnchorStart) && r.runtextpos > r.runtextstart) {
+				r.runtextpos = r.runtextend
+				return false
+			}
+			if 0 != (r.code.Anchors&syntax.AnchorEndZ) && r.runtextpos < r.runtextend-1 {
+				r.runtextpos = r.runtextend - 1
+			} else if 0 != (r.code.Anchors&syntax.AnchorEnd) && r.runtextpos < r.runtextend {
+				r.runtextpos = r.runtextend
+			}
+		} else {
+			if (0 != (r.code.Anchors&syntax.AnchorEnd) && r.runtextpos < r.runtextend) ||
+				(0 != (r.code.Anchors&syntax.AnchorEndZ) && (r.runtextpos < r.runtextend-1 ||
+					(r.runtextpos == r.runtextend-1 && r.charAt(r.runtextpos) != '\n'))) ||
+				(0 != (r.code.Anchors&syntax.AnchorStart) && r.runtextpos < r.runtextstart) {
+				r.runtextpos = 0
+				return false
+			}
+			if 0 != (r.code.Anchors&syntax.AnchorBeginning) && r.runtextpos > 0 {
+				r.runtextpos = 0
+			}
+		}
+
+		if r.code.BmPrefix != nil {
+			return r.code.BmPrefix.IsMatch(r.runtext, r.runtextpos, 0, r.runtextend)
+		}
+
+		return true // found a valid start or end anchor
+	} else if r.code.BmPrefix != nil {
+		r.runtextpos = r.code.BmPrefix.Scan(r.runtext, r.runtextpos, 0, r.runtextend)
+
+		if r.runtextpos == -1 {
+			if r.code.RightToLeft {
+				r.runtextpos = 0
+			} else {
+				r.runtextpos = r.runtextend
+			}
+			return false
+		}
+
+		return true
+	} else if r.code.FcPrefix == nil {
+		return true
+	}
+
+	r.rightToLeft = r.code.RightToLeft
+	r.caseInsensitive = r.code.FcPrefix.CaseInsensitive
+
+	set := r.code.FcPrefix.PrefixSet
+	if set.IsSingleton() {
+		ch := set.SingletonChar()
+		for i := r.forwardchars(); i > 0; i-- {
+			if ch == r.forwardcharnext() {
+				r.backwardnext()
+				return true
+			}
+		}
+	} else {
+		for i := r.forwardchars(); i > 0; i-- {
+			n := r.forwardcharnext()
+			//fmt.Printf("%v in %v: %v\n", string(n), set.String(), set.CharIn(n))
+			if set.CharIn(n) {
+				r.backwardnext()
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func (r *runner) initMatch() {
+	// Use a hashtable'ed Match object if the capture numbers are sparse
+
+	if r.runmatch == nil {
+		if r.re.caps != nil {
+			r.runmatch = newMatchSparse(r.re, r.re.caps, r.re.capsize, r.runtext, r.runtextstart)
+		} else {
+			r.runmatch = newMatch(r.re, r.re.capsize, r.runtext, r.runtextstart)
+		}
+	} else {
+		r.runmatch.reset(r.runtext, r.runtextstart)
+	}
+
+	// note we test runcrawl, because it is the last one to be allocated
+	// If there is an alloc failure in the middle of the three allocations,
+	// we may still return to reuse this instance, and we want to behave
+	// as if the allocations didn't occur. (we used to test _trackcount != 0)
+
+	if r.runcrawl != nil {
+		r.runtrackpos = len(r.runtrack)
+		r.runstackpos = len(r.runstack)
+		r.runcrawlpos = len(r.runcrawl)
+		return
+	}
+
+	r.initTrackCount()
+
+	tracksize := r.runtrackcount * 8
+	stacksize := r.runtrackcount * 8
+
+	if tracksize < 32 {
+		tracksize = 32
+	}
+	if stacksize < 16 {
+		stacksize = 16
+	}
+
+	r.runtrack = make([]int, tracksize)
+	r.runtrackpos = tracksize
+
+	r.runstack = make([]int, stacksize)
+	r.runstackpos = stacksize
+
+	r.runcrawl = make([]int, 32)
+	r.runcrawlpos = 32
+}
+
+func (r *runner) tidyMatch(quick bool) *Match {
+	if !quick {
+		match := r.runmatch
+
+		r.runmatch = nil
+
+		match.tidy(r.runtextpos)
+		return match
+	} else {
+		// send back our match -- it's not leaving the package, so it's safe to not clean it up
+		// this reduces allocs for frequent calls to the "IsMatch" bool-only functions
+		return r.runmatch
+	}
+}
+
+// capture captures a subexpression. Note that the
+// capnum used here has already been mapped to a non-sparse
+// index (by the code generator RegexWriter).
+func (r *runner) capture(capnum, start, end int) {
+	if end < start {
+		T := end
+		end = start
+		start = T
+	}
+
+	r.crawl(capnum)
+	r.runmatch.addMatch(capnum, start, end-start)
+}
+
+// transferCapture captures a subexpression. Note that the
+// capnum used here has already been mapped to a non-sparse
+// index (by the code generator RegexWriter).
+func (r *runner) transferCapture(capnum, uncapnum, start, end int) {
+	var start2, end2 int
+
+	// these are the two intervals that are cancelling each other
+
+	if end < start {
+		T := end
+		end = start
+		start = T
+	}
+
+	start2 = r.runmatch.matchIndex(uncapnum)
+	end2 = start2 + r.runmatch.matchLength(uncapnum)
+
+	// The new capture gets the innermost defined interval
+
+	if start >= end2 {
+		end = start
+		start = end2
+	} else if end <= start2 {
+		start = start2
+	} else {
+		if end > end2 {
+			end = end2
+		}
+		if start2 > start {
+			start = start2
+		}
+	}
+
+	r.crawl(uncapnum)
+	r.runmatch.balanceMatch(uncapnum)
+
+	if capnum != -1 {
+		r.crawl(capnum)
+		r.runmatch.addMatch(capnum, start, end-start)
+	}
+}
+
+// revert the last capture
+func (r *runner) uncapture() {
+	capnum := r.popcrawl()
+	r.runmatch.removeMatch(capnum)
+}
+
+//debug
+
+func (r *runner) dumpState() {
+	back := ""
+	if r.operator&syntax.Back != 0 {
+		back = " Back"
+	}
+	if r.operator&syntax.Back2 != 0 {
+		back += " Back2"
+	}
+	fmt.Printf("Text:  %v\nTrack: %v\nStack: %v\n       %s%s\n\n",
+		r.textposDescription(),
+		r.stackDescription(r.runtrack, r.runtrackpos),
+		r.stackDescription(r.runstack, r.runstackpos),
+		r.code.OpcodeDescription(r.codepos),
+		back)
+}
+
+func (r *runner) stackDescription(a []int, index int) string {
+	buf := &bytes.Buffer{}
+
+	fmt.Fprintf(buf, "%v/%v", len(a)-index, len(a))
+	if buf.Len() < 8 {
+		buf.WriteString(strings.Repeat(" ", 8-buf.Len()))
+	}
+
+	buf.WriteRune('(')
+	for i := index; i < len(a); i++ {
+		if i > index {
+			buf.WriteRune(' ')
+		}
+
+		buf.WriteString(strconv.Itoa(a[i]))
+	}
+
+	buf.WriteRune(')')
+
+	return buf.String()
+}
+
+func (r *runner) textposDescription() string {
+	buf := &bytes.Buffer{}
+
+	buf.WriteString(strconv.Itoa(r.runtextpos))
+
+	if buf.Len() < 8 {
+		buf.WriteString(strings.Repeat(" ", 8-buf.Len()))
+	}
+
+	if r.runtextpos > 0 {
+		buf.WriteString(syntax.CharDescription(r.runtext[r.runtextpos-1]))
+	} else {
+		buf.WriteRune('^')
+	}
+
+	buf.WriteRune('>')
+
+	for i := r.runtextpos; i < r.runtextend; i++ {
+		buf.WriteString(syntax.CharDescription(r.runtext[i]))
+	}
+	if buf.Len() >= 64 {
+		buf.Truncate(61)
+		buf.WriteString("...")
+	} else {
+		buf.WriteRune('$')
+	}
+
+	return buf.String()
+}
+
+// decide whether the pos
+// at the specified index is a boundary or not. It's just not worth
+// emitting inline code for this logic.
+func (r *runner) isBoundary(index, startpos, endpos int) bool {
+	return (index > startpos && syntax.IsWordChar(r.runtext[index-1])) !=
+		(index < endpos && syntax.IsWordChar(r.runtext[index]))
+}
+
+func (r *runner) isECMABoundary(index, startpos, endpos int) bool {
+	return (index > startpos && syntax.IsECMAWordChar(r.runtext[index-1])) !=
+		(index < endpos && syntax.IsECMAWordChar(r.runtext[index]))
+}
+
+func (r *runner) startTimeoutWatch() {
+	if r.ignoreTimeout {
+		return
+	}
+	r.deadline = makeDeadline(r.timeout)
+}
+
+func (r *runner) checkTimeout() error {
+	if r.ignoreTimeout || !r.deadline.reached() {
+		return nil
+	}
+
+	if r.re.Debug() {
+		//Debug.WriteLine("")
+		//Debug.WriteLine("RegEx match timeout occurred!")
+		//Debug.WriteLine("Specified timeout:       " + TimeSpan.FromMilliseconds(_timeout).ToString())
+		//Debug.WriteLine("Timeout check frequency: " + TimeoutCheckFrequency)
+		//Debug.WriteLine("Search pattern:          " + _runregex._pattern)
+		//Debug.WriteLine("Input:                   " + r.runtext)
+		//Debug.WriteLine("About to throw RegexMatchTimeoutException.")
+	}
+
+	return fmt.Errorf("match timeout after %v on input `%v`", r.timeout, string(r.runtext))
+}
+
+func (r *runner) initTrackCount() {
+	r.runtrackcount = r.code.TrackCount
+}
+
+// getRunner returns a run to use for matching re.
+// It uses the re's runner cache if possible, to avoid
+// unnecessary allocation.
+func (re *Regexp) getRunner() *runner {
+	re.muRun.Lock()
+	if n := len(re.runner); n > 0 {
+		z := re.runner[n-1]
+		re.runner = re.runner[:n-1]
+		re.muRun.Unlock()
+		return z
+	}
+	re.muRun.Unlock()
+	z := &runner{
+		re:   re,
+		code: re.code,
+	}
+	return z
+}
+
+// putRunner returns a runner to the re's cache.
+// There is no attempt to limit the size of the cache, so it will
+// grow to the maximum number of simultaneous matches
+// run using re.  (The cache empties when re gets garbage collected.)
+func (re *Regexp) putRunner(r *runner) {
+	re.muRun.Lock()
+	r.runtext = nil
+	if r.runmatch != nil {
+		r.runmatch.text = nil
+	}
+	re.runner = append(re.runner, r)
+	re.muRun.Unlock()
+}

--- a/vendor/github.com/dlclark/regexp2/syntax/charclass.go
+++ b/vendor/github.com/dlclark/regexp2/syntax/charclass.go
@@ -1,0 +1,865 @@
+package syntax
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"sort"
+	"unicode"
+	"unicode/utf8"
+)
+
+// CharSet combines start-end rune ranges and unicode categories representing a set of characters
+type CharSet struct {
+	ranges     []singleRange
+	categories []category
+	sub        *CharSet //optional subtractor
+	negate     bool
+	anything   bool
+}
+
+type category struct {
+	negate bool
+	cat    string
+}
+
+type singleRange struct {
+	first rune
+	last  rune
+}
+
+const (
+	spaceCategoryText = " "
+	wordCategoryText  = "W"
+)
+
+var (
+	ecmaSpace = []rune{0x0009, 0x000e, 0x0020, 0x0021, 0x00a0, 0x00a1, 0x1680, 0x1681, 0x2000, 0x200b, 0x2028, 0x202a, 0x202f, 0x2030, 0x205f, 0x2060, 0x3000, 0x3001, 0xfeff, 0xff00}
+	ecmaWord  = []rune{0x0030, 0x003a, 0x0041, 0x005b, 0x005f, 0x0060, 0x0061, 0x007b}
+	ecmaDigit = []rune{0x0030, 0x003a}
+
+	re2Space = []rune{0x0009, 0x000b, 0x000c, 0x000e, 0x0020, 0x0021}
+)
+
+var (
+	AnyClass          = getCharSetFromOldString([]rune{0}, false)
+	ECMAAnyClass      = getCharSetFromOldString([]rune{0, 0x000a, 0x000b, 0x000d, 0x000e}, false)
+	NoneClass         = getCharSetFromOldString(nil, false)
+	ECMAWordClass     = getCharSetFromOldString(ecmaWord, false)
+	NotECMAWordClass  = getCharSetFromOldString(ecmaWord, true)
+	ECMASpaceClass    = getCharSetFromOldString(ecmaSpace, false)
+	NotECMASpaceClass = getCharSetFromOldString(ecmaSpace, true)
+	ECMADigitClass    = getCharSetFromOldString(ecmaDigit, false)
+	NotECMADigitClass = getCharSetFromOldString(ecmaDigit, true)
+
+	WordClass     = getCharSetFromCategoryString(false, false, wordCategoryText)
+	NotWordClass  = getCharSetFromCategoryString(true, false, wordCategoryText)
+	SpaceClass    = getCharSetFromCategoryString(false, false, spaceCategoryText)
+	NotSpaceClass = getCharSetFromCategoryString(true, false, spaceCategoryText)
+	DigitClass    = getCharSetFromCategoryString(false, false, "Nd")
+	NotDigitClass = getCharSetFromCategoryString(false, true, "Nd")
+
+	RE2SpaceClass    = getCharSetFromOldString(re2Space, false)
+	NotRE2SpaceClass = getCharSetFromOldString(re2Space, true)
+)
+
+var unicodeCategories = func() map[string]*unicode.RangeTable {
+	retVal := make(map[string]*unicode.RangeTable)
+	for k, v := range unicode.Scripts {
+		retVal[k] = v
+	}
+	for k, v := range unicode.Categories {
+		retVal[k] = v
+	}
+	for k, v := range unicode.Properties {
+		retVal[k] = v
+	}
+	return retVal
+}()
+
+func getCharSetFromCategoryString(negateSet bool, negateCat bool, cats ...string) func() *CharSet {
+	if negateCat && negateSet {
+		panic("BUG!  You should only negate the set OR the category in a constant setup, but not both")
+	}
+
+	c := CharSet{negate: negateSet}
+
+	c.categories = make([]category, len(cats))
+	for i, cat := range cats {
+		c.categories[i] = category{cat: cat, negate: negateCat}
+	}
+	return func() *CharSet {
+		//make a copy each time
+		local := c
+		//return that address
+		return &local
+	}
+}
+
+func getCharSetFromOldString(setText []rune, negate bool) func() *CharSet {
+	c := CharSet{}
+	if len(setText) > 0 {
+		fillFirst := false
+		l := len(setText)
+		if negate {
+			if setText[0] == 0 {
+				setText = setText[1:]
+			} else {
+				l++
+				fillFirst = true
+			}
+		}
+
+		if l%2 == 0 {
+			c.ranges = make([]singleRange, l/2)
+		} else {
+			c.ranges = make([]singleRange, l/2+1)
+		}
+
+		first := true
+		if fillFirst {
+			c.ranges[0] = singleRange{first: 0}
+			first = false
+		}
+
+		i := 0
+		for _, r := range setText {
+			if first {
+				// lower bound in a new range
+				c.ranges[i] = singleRange{first: r}
+				first = false
+			} else {
+				c.ranges[i].last = r - 1
+				i++
+				first = true
+			}
+		}
+		if !first {
+			c.ranges[i].last = utf8.MaxRune
+		}
+	}
+
+	return func() *CharSet {
+		local := c
+		return &local
+	}
+}
+
+// Copy makes a deep copy to prevent accidental mutation of a set
+func (c CharSet) Copy() CharSet {
+	ret := CharSet{
+		anything: c.anything,
+		negate:   c.negate,
+	}
+
+	ret.ranges = append(ret.ranges, c.ranges...)
+	ret.categories = append(ret.categories, c.categories...)
+
+	if c.sub != nil {
+		sub := c.sub.Copy()
+		ret.sub = &sub
+	}
+
+	return ret
+}
+
+// gets a human-readable description for a set string
+func (c CharSet) String() string {
+	buf := &bytes.Buffer{}
+	buf.WriteRune('[')
+
+	if c.IsNegated() {
+		buf.WriteRune('^')
+	}
+
+	for _, r := range c.ranges {
+
+		buf.WriteString(CharDescription(r.first))
+		if r.first != r.last {
+			if r.last-r.first != 1 {
+				//groups that are 1 char apart skip the dash
+				buf.WriteRune('-')
+			}
+			buf.WriteString(CharDescription(r.last))
+		}
+	}
+
+	for _, c := range c.categories {
+		buf.WriteString(c.String())
+	}
+
+	if c.sub != nil {
+		buf.WriteRune('-')
+		buf.WriteString(c.sub.String())
+	}
+
+	buf.WriteRune(']')
+
+	return buf.String()
+}
+
+// mapHashFill converts a charset into a buffer for use in maps
+func (c CharSet) mapHashFill(buf *bytes.Buffer) {
+	if c.negate {
+		buf.WriteByte(0)
+	} else {
+		buf.WriteByte(1)
+	}
+
+	binary.Write(buf, binary.LittleEndian, len(c.ranges))
+	binary.Write(buf, binary.LittleEndian, len(c.categories))
+	for _, r := range c.ranges {
+		buf.WriteRune(r.first)
+		buf.WriteRune(r.last)
+	}
+	for _, ct := range c.categories {
+		buf.WriteString(ct.cat)
+		if ct.negate {
+			buf.WriteByte(1)
+		} else {
+			buf.WriteByte(0)
+		}
+	}
+
+	if c.sub != nil {
+		c.sub.mapHashFill(buf)
+	}
+}
+
+// CharIn returns true if the rune is in our character set (either ranges or categories).
+// It handles negations and subtracted sub-charsets.
+func (c CharSet) CharIn(ch rune) bool {
+	val := false
+	// in s && !s.subtracted
+
+	//check ranges
+	for _, r := range c.ranges {
+		if ch < r.first {
+			continue
+		}
+		if ch <= r.last {
+			val = true
+			break
+		}
+	}
+
+	//check categories if we haven't already found a range
+	if !val && len(c.categories) > 0 {
+		for _, ct := range c.categories {
+			// special categories...then unicode
+			if ct.cat == spaceCategoryText {
+				if unicode.IsSpace(ch) {
+					// we found a space so we're done
+					// negate means this is a "bad" thing
+					val = !ct.negate
+					break
+				} else if ct.negate {
+					val = true
+					break
+				}
+			} else if ct.cat == wordCategoryText {
+				if IsWordChar(ch) {
+					val = !ct.negate
+					break
+				} else if ct.negate {
+					val = true
+					break
+				}
+			} else if unicode.Is(unicodeCategories[ct.cat], ch) {
+				// if we're in this unicode category then we're done
+				// if negate=true on this category then we "failed" our test
+				// otherwise we're good that we found it
+				val = !ct.negate
+				break
+			} else if ct.negate {
+				val = true
+				break
+			}
+		}
+	}
+
+	// negate the whole char set
+	if c.negate {
+		val = !val
+	}
+
+	// get subtracted recurse
+	if val && c.sub != nil {
+		val = !c.sub.CharIn(ch)
+	}
+
+	//log.Printf("Char '%v' in %v == %v", string(ch), c.String(), val)
+	return val
+}
+
+func (c category) String() string {
+	switch c.cat {
+	case spaceCategoryText:
+		if c.negate {
+			return "\\S"
+		}
+		return "\\s"
+	case wordCategoryText:
+		if c.negate {
+			return "\\W"
+		}
+		return "\\w"
+	}
+	if _, ok := unicodeCategories[c.cat]; ok {
+
+		if c.negate {
+			return "\\P{" + c.cat + "}"
+		}
+		return "\\p{" + c.cat + "}"
+	}
+	return "Unknown category: " + c.cat
+}
+
+// CharDescription Produces a human-readable description for a single character.
+func CharDescription(ch rune) string {
+	/*if ch == '\\' {
+		return "\\\\"
+	}
+
+	if ch > ' ' && ch <= '~' {
+		return string(ch)
+	} else if ch == '\n' {
+		return "\\n"
+	} else if ch == ' ' {
+		return "\\ "
+	}*/
+
+	b := &bytes.Buffer{}
+	escape(b, ch, false) //fmt.Sprintf("%U", ch)
+	return b.String()
+}
+
+// According to UTS#18 Unicode Regular Expressions (http://www.unicode.org/reports/tr18/)
+// RL 1.4 Simple Word Boundaries  The class of <word_character> includes all Alphabetic
+// values from the Unicode character database, from UnicodeData.txt [UData], plus the U+200C
+// ZERO WIDTH NON-JOINER and U+200D ZERO WIDTH JOINER.
+func IsWordChar(r rune) bool {
+	//"L", "Mn", "Nd", "Pc"
+	return unicode.In(r,
+		unicode.Categories["L"], unicode.Categories["Mn"],
+		unicode.Categories["Nd"], unicode.Categories["Pc"]) || r == '\u200D' || r == '\u200C'
+	//return 'A' <= r && r <= 'Z' || 'a' <= r && r <= 'z' || '0' <= r && r <= '9' || r == '_'
+}
+
+func IsECMAWordChar(r rune) bool {
+	return unicode.In(r,
+		unicode.Categories["L"], unicode.Categories["Mn"],
+		unicode.Categories["Nd"], unicode.Categories["Pc"])
+
+	//return 'A' <= r && r <= 'Z' || 'a' <= r && r <= 'z' || '0' <= r && r <= '9' || r == '_'
+}
+
+// SingletonChar will return the char from the first range without validation.
+// It assumes you have checked for IsSingleton or IsSingletonInverse and will panic given bad input
+func (c CharSet) SingletonChar() rune {
+	return c.ranges[0].first
+}
+
+func (c CharSet) IsSingleton() bool {
+	return !c.negate && //negated is multiple chars
+		len(c.categories) == 0 && len(c.ranges) == 1 && // multiple ranges and unicode classes represent multiple chars
+		c.sub == nil && // subtraction means we've got multiple chars
+		c.ranges[0].first == c.ranges[0].last // first and last equal means we're just 1 char
+}
+
+func (c CharSet) IsSingletonInverse() bool {
+	return c.negate && //same as above, but requires negated
+		len(c.categories) == 0 && len(c.ranges) == 1 && // multiple ranges and unicode classes represent multiple chars
+		c.sub == nil && // subtraction means we've got multiple chars
+		c.ranges[0].first == c.ranges[0].last // first and last equal means we're just 1 char
+}
+
+func (c CharSet) IsMergeable() bool {
+	return !c.IsNegated() && !c.HasSubtraction()
+}
+
+func (c CharSet) IsNegated() bool {
+	return c.negate
+}
+
+func (c CharSet) HasSubtraction() bool {
+	return c.sub != nil
+}
+
+func (c CharSet) IsEmpty() bool {
+	return len(c.ranges) == 0 && len(c.categories) == 0 && c.sub == nil
+}
+
+func (c *CharSet) addDigit(ecma, negate bool, pattern string) {
+	if ecma {
+		if negate {
+			c.addRanges(NotECMADigitClass().ranges)
+		} else {
+			c.addRanges(ECMADigitClass().ranges)
+		}
+	} else {
+		c.addCategories(category{cat: "Nd", negate: negate})
+	}
+}
+
+func (c *CharSet) addChar(ch rune) {
+	c.addRange(ch, ch)
+}
+
+func (c *CharSet) addSpace(ecma, re2, negate bool) {
+	if ecma {
+		if negate {
+			c.addRanges(NotECMASpaceClass().ranges)
+		} else {
+			c.addRanges(ECMASpaceClass().ranges)
+		}
+	} else if re2 {
+		if negate {
+			c.addRanges(NotRE2SpaceClass().ranges)
+		} else {
+			c.addRanges(RE2SpaceClass().ranges)
+		}
+	} else {
+		c.addCategories(category{cat: spaceCategoryText, negate: negate})
+	}
+}
+
+func (c *CharSet) addWord(ecma, negate bool) {
+	if ecma {
+		if negate {
+			c.addRanges(NotECMAWordClass().ranges)
+		} else {
+			c.addRanges(ECMAWordClass().ranges)
+		}
+	} else {
+		c.addCategories(category{cat: wordCategoryText, negate: negate})
+	}
+}
+
+// Add set ranges and categories into ours -- no deduping or anything
+func (c *CharSet) addSet(set CharSet) {
+	if c.anything {
+		return
+	}
+	if set.anything {
+		c.makeAnything()
+		return
+	}
+	// just append here to prevent double-canon
+	c.ranges = append(c.ranges, set.ranges...)
+	c.addCategories(set.categories...)
+	c.canonicalize()
+}
+
+func (c *CharSet) makeAnything() {
+	c.anything = true
+	c.categories = []category{}
+	c.ranges = AnyClass().ranges
+}
+
+func (c *CharSet) addCategories(cats ...category) {
+	// don't add dupes and remove positive+negative
+	if c.anything {
+		// if we've had a previous positive+negative group then
+		// just return, we're as broad as we can get
+		return
+	}
+
+	for _, ct := range cats {
+		found := false
+		for _, ct2 := range c.categories {
+			if ct.cat == ct2.cat {
+				if ct.negate != ct2.negate {
+					// oposite negations...this mean we just
+					// take us as anything and move on
+					c.makeAnything()
+					return
+				}
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			c.categories = append(c.categories, ct)
+		}
+	}
+}
+
+// Merges new ranges to our own
+func (c *CharSet) addRanges(ranges []singleRange) {
+	if c.anything {
+		return
+	}
+	c.ranges = append(c.ranges, ranges...)
+	c.canonicalize()
+}
+
+// Merges everything but the new ranges into our own
+func (c *CharSet) addNegativeRanges(ranges []singleRange) {
+	if c.anything {
+		return
+	}
+
+	var hi rune
+
+	// convert incoming ranges into opposites, assume they are in order
+	for _, r := range ranges {
+		if hi < r.first {
+			c.ranges = append(c.ranges, singleRange{hi, r.first - 1})
+		}
+		hi = r.last + 1
+	}
+
+	if hi < utf8.MaxRune {
+		c.ranges = append(c.ranges, singleRange{hi, utf8.MaxRune})
+	}
+
+	c.canonicalize()
+}
+
+func isValidUnicodeCat(catName string) bool {
+	_, ok := unicodeCategories[catName]
+	return ok
+}
+
+func (c *CharSet) addCategory(categoryName string, negate, caseInsensitive bool, pattern string) {
+	if !isValidUnicodeCat(categoryName) {
+		// unknown unicode category, script, or property "blah"
+		panic(fmt.Errorf("Unknown unicode category, script, or property '%v'", categoryName))
+
+	}
+
+	if caseInsensitive && (categoryName == "Ll" || categoryName == "Lu" || categoryName == "Lt") {
+		// when RegexOptions.IgnoreCase is specified then {Ll} {Lu} and {Lt} cases should all match
+		c.addCategories(
+			category{cat: "Ll", negate: negate},
+			category{cat: "Lu", negate: negate},
+			category{cat: "Lt", negate: negate})
+	}
+	c.addCategories(category{cat: categoryName, negate: negate})
+}
+
+func (c *CharSet) addSubtraction(sub *CharSet) {
+	c.sub = sub
+}
+
+func (c *CharSet) addRange(chMin, chMax rune) {
+	c.ranges = append(c.ranges, singleRange{first: chMin, last: chMax})
+	c.canonicalize()
+}
+
+func (c *CharSet) addNamedASCII(name string, negate bool) bool {
+	var rs []singleRange
+
+	switch name {
+	case "alnum":
+		rs = []singleRange{singleRange{'0', '9'}, singleRange{'A', 'Z'}, singleRange{'a', 'z'}}
+	case "alpha":
+		rs = []singleRange{singleRange{'A', 'Z'}, singleRange{'a', 'z'}}
+	case "ascii":
+		rs = []singleRange{singleRange{0, 0x7f}}
+	case "blank":
+		rs = []singleRange{singleRange{'\t', '\t'}, singleRange{' ', ' '}}
+	case "cntrl":
+		rs = []singleRange{singleRange{0, 0x1f}, singleRange{0x7f, 0x7f}}
+	case "digit":
+		c.addDigit(false, negate, "")
+	case "graph":
+		rs = []singleRange{singleRange{'!', '~'}}
+	case "lower":
+		rs = []singleRange{singleRange{'a', 'z'}}
+	case "print":
+		rs = []singleRange{singleRange{' ', '~'}}
+	case "punct": //[!-/:-@[-`{-~]
+		rs = []singleRange{singleRange{'!', '/'}, singleRange{':', '@'}, singleRange{'[', '`'}, singleRange{'{', '~'}}
+	case "space":
+		c.addSpace(true, false, negate)
+	case "upper":
+		rs = []singleRange{singleRange{'A', 'Z'}}
+	case "word":
+		c.addWord(true, negate)
+	case "xdigit":
+		rs = []singleRange{singleRange{'0', '9'}, singleRange{'A', 'F'}, singleRange{'a', 'f'}}
+	default:
+		return false
+	}
+
+	if len(rs) > 0 {
+		if negate {
+			c.addNegativeRanges(rs)
+		} else {
+			c.addRanges(rs)
+		}
+	}
+
+	return true
+}
+
+type singleRangeSorter []singleRange
+
+func (p singleRangeSorter) Len() int           { return len(p) }
+func (p singleRangeSorter) Less(i, j int) bool { return p[i].first < p[j].first }
+func (p singleRangeSorter) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+// Logic to reduce a character class to a unique, sorted form.
+func (c *CharSet) canonicalize() {
+	var i, j int
+	var last rune
+
+	//
+	// Find and eliminate overlapping or abutting ranges
+	//
+
+	if len(c.ranges) > 1 {
+		sort.Sort(singleRangeSorter(c.ranges))
+
+		done := false
+
+		for i, j = 1, 0; ; i++ {
+			for last = c.ranges[j].last; ; i++ {
+				if i == len(c.ranges) || last == utf8.MaxRune {
+					done = true
+					break
+				}
+
+				CurrentRange := c.ranges[i]
+				if CurrentRange.first > last+1 {
+					break
+				}
+
+				if last < CurrentRange.last {
+					last = CurrentRange.last
+				}
+			}
+
+			c.ranges[j] = singleRange{first: c.ranges[j].first, last: last}
+
+			j++
+
+			if done {
+				break
+			}
+
+			if j < i {
+				c.ranges[j] = c.ranges[i]
+			}
+		}
+
+		c.ranges = append(c.ranges[:j], c.ranges[len(c.ranges):]...)
+	}
+}
+
+// Adds to the class any lowercase versions of characters already
+// in the class. Used for case-insensitivity.
+func (c *CharSet) addLowercase() {
+	if c.anything {
+		return
+	}
+	toAdd := []singleRange{}
+	for i := 0; i < len(c.ranges); i++ {
+		r := c.ranges[i]
+		if r.first == r.last {
+			lower := unicode.ToLower(r.first)
+			c.ranges[i] = singleRange{first: lower, last: lower}
+		} else {
+			toAdd = append(toAdd, r)
+		}
+	}
+
+	for _, r := range toAdd {
+		c.addLowercaseRange(r.first, r.last)
+	}
+	c.canonicalize()
+}
+
+/**************************************************************************
+    Let U be the set of Unicode character values and let L be the lowercase
+    function, mapping from U to U. To perform case insensitive matching of
+    character sets, we need to be able to map an interval I in U, say
+
+        I = [chMin, chMax] = { ch : chMin <= ch <= chMax }
+
+    to a set A such that A contains L(I) and A is contained in the union of
+    I and L(I).
+
+    The table below partitions U into intervals on which L is non-decreasing.
+    Thus, for any interval J = [a, b] contained in one of these intervals,
+    L(J) is contained in [L(a), L(b)].
+
+    It is also true that for any such J, [L(a), L(b)] is contained in the
+    union of J and L(J). This does not follow from L being non-decreasing on
+    these intervals. It follows from the nature of the L on each interval.
+    On each interval, L has one of the following forms:
+
+        (1) L(ch) = constant            (LowercaseSet)
+        (2) L(ch) = ch + offset         (LowercaseAdd)
+        (3) L(ch) = ch | 1              (LowercaseBor)
+        (4) L(ch) = ch + (ch & 1)       (LowercaseBad)
+
+    It is easy to verify that for any of these forms [L(a), L(b)] is
+    contained in the union of [a, b] and L([a, b]).
+***************************************************************************/
+
+const (
+	LowercaseSet = 0 // Set to arg.
+	LowercaseAdd = 1 // Add arg.
+	LowercaseBor = 2 // Bitwise or with 1.
+	LowercaseBad = 3 // Bitwise and with 1 and add original.
+)
+
+type lcMap struct {
+	chMin, chMax rune
+	op, data     int32
+}
+
+var lcTable = []lcMap{
+	lcMap{'\u0041', '\u005A', LowercaseAdd, 32},
+	lcMap{'\u00C0', '\u00DE', LowercaseAdd, 32},
+	lcMap{'\u0100', '\u012E', LowercaseBor, 0},
+	lcMap{'\u0130', '\u0130', LowercaseSet, 0x0069},
+	lcMap{'\u0132', '\u0136', LowercaseBor, 0},
+	lcMap{'\u0139', '\u0147', LowercaseBad, 0},
+	lcMap{'\u014A', '\u0176', LowercaseBor, 0},
+	lcMap{'\u0178', '\u0178', LowercaseSet, 0x00FF},
+	lcMap{'\u0179', '\u017D', LowercaseBad, 0},
+	lcMap{'\u0181', '\u0181', LowercaseSet, 0x0253},
+	lcMap{'\u0182', '\u0184', LowercaseBor, 0},
+	lcMap{'\u0186', '\u0186', LowercaseSet, 0x0254},
+	lcMap{'\u0187', '\u0187', LowercaseSet, 0x0188},
+	lcMap{'\u0189', '\u018A', LowercaseAdd, 205},
+	lcMap{'\u018B', '\u018B', LowercaseSet, 0x018C},
+	lcMap{'\u018E', '\u018E', LowercaseSet, 0x01DD},
+	lcMap{'\u018F', '\u018F', LowercaseSet, 0x0259},
+	lcMap{'\u0190', '\u0190', LowercaseSet, 0x025B},
+	lcMap{'\u0191', '\u0191', LowercaseSet, 0x0192},
+	lcMap{'\u0193', '\u0193', LowercaseSet, 0x0260},
+	lcMap{'\u0194', '\u0194', LowercaseSet, 0x0263},
+	lcMap{'\u0196', '\u0196', LowercaseSet, 0x0269},
+	lcMap{'\u0197', '\u0197', LowercaseSet, 0x0268},
+	lcMap{'\u0198', '\u0198', LowercaseSet, 0x0199},
+	lcMap{'\u019C', '\u019C', LowercaseSet, 0x026F},
+	lcMap{'\u019D', '\u019D', LowercaseSet, 0x0272},
+	lcMap{'\u019F', '\u019F', LowercaseSet, 0x0275},
+	lcMap{'\u01A0', '\u01A4', LowercaseBor, 0},
+	lcMap{'\u01A7', '\u01A7', LowercaseSet, 0x01A8},
+	lcMap{'\u01A9', '\u01A9', LowercaseSet, 0x0283},
+	lcMap{'\u01AC', '\u01AC', LowercaseSet, 0x01AD},
+	lcMap{'\u01AE', '\u01AE', LowercaseSet, 0x0288},
+	lcMap{'\u01AF', '\u01AF', LowercaseSet, 0x01B0},
+	lcMap{'\u01B1', '\u01B2', LowercaseAdd, 217},
+	lcMap{'\u01B3', '\u01B5', LowercaseBad, 0},
+	lcMap{'\u01B7', '\u01B7', LowercaseSet, 0x0292},
+	lcMap{'\u01B8', '\u01B8', LowercaseSet, 0x01B9},
+	lcMap{'\u01BC', '\u01BC', LowercaseSet, 0x01BD},
+	lcMap{'\u01C4', '\u01C5', LowercaseSet, 0x01C6},
+	lcMap{'\u01C7', '\u01C8', LowercaseSet, 0x01C9},
+	lcMap{'\u01CA', '\u01CB', LowercaseSet, 0x01CC},
+	lcMap{'\u01CD', '\u01DB', LowercaseBad, 0},
+	lcMap{'\u01DE', '\u01EE', LowercaseBor, 0},
+	lcMap{'\u01F1', '\u01F2', LowercaseSet, 0x01F3},
+	lcMap{'\u01F4', '\u01F4', LowercaseSet, 0x01F5},
+	lcMap{'\u01FA', '\u0216', LowercaseBor, 0},
+	lcMap{'\u0386', '\u0386', LowercaseSet, 0x03AC},
+	lcMap{'\u0388', '\u038A', LowercaseAdd, 37},
+	lcMap{'\u038C', '\u038C', LowercaseSet, 0x03CC},
+	lcMap{'\u038E', '\u038F', LowercaseAdd, 63},
+	lcMap{'\u0391', '\u03AB', LowercaseAdd, 32},
+	lcMap{'\u03E2', '\u03EE', LowercaseBor, 0},
+	lcMap{'\u0401', '\u040F', LowercaseAdd, 80},
+	lcMap{'\u0410', '\u042F', LowercaseAdd, 32},
+	lcMap{'\u0460', '\u0480', LowercaseBor, 0},
+	lcMap{'\u0490', '\u04BE', LowercaseBor, 0},
+	lcMap{'\u04C1', '\u04C3', LowercaseBad, 0},
+	lcMap{'\u04C7', '\u04C7', LowercaseSet, 0x04C8},
+	lcMap{'\u04CB', '\u04CB', LowercaseSet, 0x04CC},
+	lcMap{'\u04D0', '\u04EA', LowercaseBor, 0},
+	lcMap{'\u04EE', '\u04F4', LowercaseBor, 0},
+	lcMap{'\u04F8', '\u04F8', LowercaseSet, 0x04F9},
+	lcMap{'\u0531', '\u0556', LowercaseAdd, 48},
+	lcMap{'\u10A0', '\u10C5', LowercaseAdd, 48},
+	lcMap{'\u1E00', '\u1EF8', LowercaseBor, 0},
+	lcMap{'\u1F08', '\u1F0F', LowercaseAdd, -8},
+	lcMap{'\u1F18', '\u1F1F', LowercaseAdd, -8},
+	lcMap{'\u1F28', '\u1F2F', LowercaseAdd, -8},
+	lcMap{'\u1F38', '\u1F3F', LowercaseAdd, -8},
+	lcMap{'\u1F48', '\u1F4D', LowercaseAdd, -8},
+	lcMap{'\u1F59', '\u1F59', LowercaseSet, 0x1F51},
+	lcMap{'\u1F5B', '\u1F5B', LowercaseSet, 0x1F53},
+	lcMap{'\u1F5D', '\u1F5D', LowercaseSet, 0x1F55},
+	lcMap{'\u1F5F', '\u1F5F', LowercaseSet, 0x1F57},
+	lcMap{'\u1F68', '\u1F6F', LowercaseAdd, -8},
+	lcMap{'\u1F88', '\u1F8F', LowercaseAdd, -8},
+	lcMap{'\u1F98', '\u1F9F', LowercaseAdd, -8},
+	lcMap{'\u1FA8', '\u1FAF', LowercaseAdd, -8},
+	lcMap{'\u1FB8', '\u1FB9', LowercaseAdd, -8},
+	lcMap{'\u1FBA', '\u1FBB', LowercaseAdd, -74},
+	lcMap{'\u1FBC', '\u1FBC', LowercaseSet, 0x1FB3},
+	lcMap{'\u1FC8', '\u1FCB', LowercaseAdd, -86},
+	lcMap{'\u1FCC', '\u1FCC', LowercaseSet, 0x1FC3},
+	lcMap{'\u1FD8', '\u1FD9', LowercaseAdd, -8},
+	lcMap{'\u1FDA', '\u1FDB', LowercaseAdd, -100},
+	lcMap{'\u1FE8', '\u1FE9', LowercaseAdd, -8},
+	lcMap{'\u1FEA', '\u1FEB', LowercaseAdd, -112},
+	lcMap{'\u1FEC', '\u1FEC', LowercaseSet, 0x1FE5},
+	lcMap{'\u1FF8', '\u1FF9', LowercaseAdd, -128},
+	lcMap{'\u1FFA', '\u1FFB', LowercaseAdd, -126},
+	lcMap{'\u1FFC', '\u1FFC', LowercaseSet, 0x1FF3},
+	lcMap{'\u2160', '\u216F', LowercaseAdd, 16},
+	lcMap{'\u24B6', '\u24D0', LowercaseAdd, 26},
+	lcMap{'\uFF21', '\uFF3A', LowercaseAdd, 32},
+}
+
+func (c *CharSet) addLowercaseRange(chMin, chMax rune) {
+	var i, iMax, iMid int
+	var chMinT, chMaxT rune
+	var lc lcMap
+
+	for i, iMax = 0, len(lcTable); i < iMax; {
+		iMid = (i + iMax) / 2
+		if lcTable[iMid].chMax < chMin {
+			i = iMid + 1
+		} else {
+			iMax = iMid
+		}
+	}
+
+	for ; i < len(lcTable); i++ {
+		lc = lcTable[i]
+		if lc.chMin > chMax {
+			return
+		}
+		chMinT = lc.chMin
+		if chMinT < chMin {
+			chMinT = chMin
+		}
+
+		chMaxT = lc.chMax
+		if chMaxT > chMax {
+			chMaxT = chMax
+		}
+
+		switch lc.op {
+		case LowercaseSet:
+			chMinT = rune(lc.data)
+			chMaxT = rune(lc.data)
+			break
+		case LowercaseAdd:
+			chMinT += lc.data
+			chMaxT += lc.data
+			break
+		case LowercaseBor:
+			chMinT |= 1
+			chMaxT |= 1
+			break
+		case LowercaseBad:
+			chMinT += (chMinT & 1)
+			chMaxT += (chMaxT & 1)
+			break
+		}
+
+		if chMinT < chMin || chMaxT > chMax {
+			c.addRange(chMinT, chMaxT)
+		}
+	}
+}

--- a/vendor/github.com/dlclark/regexp2/syntax/code.go
+++ b/vendor/github.com/dlclark/regexp2/syntax/code.go
@@ -1,0 +1,274 @@
+package syntax
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+)
+
+// similar to prog.go in the go regex package...also with comment 'may not belong in this package'
+
+// File provides operator constants for use by the Builder and the Machine.
+
+// Implementation notes:
+//
+// Regexps are built into RegexCodes, which contain an operation array,
+// a string table, and some constants.
+//
+// Each operation is one of the codes below, followed by the integer
+// operands specified for each op.
+//
+// Strings and sets are indices into a string table.
+
+type InstOp int
+
+const (
+	// 					    lef/back operands        description
+
+	Onerep    InstOp = 0 // lef,back char,min,max    a {n}
+	Notonerep        = 1 // lef,back char,min,max    .{n}
+	Setrep           = 2 // lef,back set,min,max     [\d]{n}
+
+	Oneloop    = 3 // lef,back char,min,max    a {,n}
+	Notoneloop = 4 // lef,back char,min,max    .{,n}
+	Setloop    = 5 // lef,back set,min,max     [\d]{,n}
+
+	Onelazy    = 6 // lef,back char,min,max    a {,n}?
+	Notonelazy = 7 // lef,back char,min,max    .{,n}?
+	Setlazy    = 8 // lef,back set,min,max     [\d]{,n}?
+
+	One    = 9  // lef      char            a
+	Notone = 10 // lef      char            [^a]
+	Set    = 11 // lef      set             [a-z\s]  \w \s \d
+
+	Multi = 12 // lef      string          abcd
+	Ref   = 13 // lef      group           \#
+
+	Bol         = 14 //                          ^
+	Eol         = 15 //                          $
+	Boundary    = 16 //                          \b
+	Nonboundary = 17 //                          \B
+	Beginning   = 18 //                          \A
+	Start       = 19 //                          \G
+	EndZ        = 20 //                          \Z
+	End         = 21 //                          \Z
+
+	Nothing = 22 //                          Reject!
+
+	// Primitive control structures
+
+	Lazybranch      = 23 // back     jump            straight first
+	Branchmark      = 24 // back     jump            branch first for loop
+	Lazybranchmark  = 25 // back     jump            straight first for loop
+	Nullcount       = 26 // back     val             set counter, null mark
+	Setcount        = 27 // back     val             set counter, make mark
+	Branchcount     = 28 // back     jump,limit      branch++ if zero<=c<limit
+	Lazybranchcount = 29 // back     jump,limit      same, but straight first
+	Nullmark        = 30 // back                     save position
+	Setmark         = 31 // back                     save position
+	Capturemark     = 32 // back     group           define group
+	Getmark         = 33 // back                     recall position
+	Setjump         = 34 // back                     save backtrack state
+	Backjump        = 35 //                          zap back to saved state
+	Forejump        = 36 //                          zap backtracking state
+	Testref         = 37 //                          backtrack if ref undefined
+	Goto            = 38 //          jump            just go
+
+	Prune = 39 //                          prune it baby
+	Stop  = 40 //                          done!
+
+	ECMABoundary    = 41 //                          \b
+	NonECMABoundary = 42 //                          \B
+
+	// Modifiers for alternate modes
+
+	Mask  = 63  // Mask to get unmodified ordinary operator
+	Rtl   = 64  // bit to indicate that we're reverse scanning.
+	Back  = 128 // bit to indicate that we're backtracking.
+	Back2 = 256 // bit to indicate that we're backtracking on a second branch.
+	Ci    = 512 // bit to indicate that we're case-insensitive.
+)
+
+type Code struct {
+	Codes       []int       // the code
+	Strings     [][]rune    // string table
+	Sets        []*CharSet  //character set table
+	TrackCount  int         // how many instructions use backtracking
+	Caps        map[int]int // mapping of user group numbers -> impl group slots
+	Capsize     int         // number of impl group slots
+	FcPrefix    *Prefix     // the set of candidate first characters (may be null)
+	BmPrefix    *BmPrefix   // the fixed prefix string as a Boyer-Moore machine (may be null)
+	Anchors     AnchorLoc   // the set of zero-length start anchors (RegexFCD.Bol, etc)
+	RightToLeft bool        // true if right to left
+}
+
+func opcodeBacktracks(op InstOp) bool {
+	op &= Mask
+
+	switch op {
+	case Oneloop, Notoneloop, Setloop, Onelazy, Notonelazy, Setlazy, Lazybranch, Branchmark, Lazybranchmark,
+		Nullcount, Setcount, Branchcount, Lazybranchcount, Setmark, Capturemark, Getmark, Setjump, Backjump,
+		Forejump, Goto:
+		return true
+
+	default:
+		return false
+	}
+}
+
+func opcodeSize(op InstOp) int {
+	op &= Mask
+
+	switch op {
+	case Nothing, Bol, Eol, Boundary, Nonboundary, ECMABoundary, NonECMABoundary, Beginning, Start, EndZ,
+		End, Nullmark, Setmark, Getmark, Setjump, Backjump, Forejump, Stop:
+		return 1
+
+	case One, Notone, Multi, Ref, Testref, Goto, Nullcount, Setcount, Lazybranch, Branchmark, Lazybranchmark,
+		Prune, Set:
+		return 2
+
+	case Capturemark, Branchcount, Lazybranchcount, Onerep, Notonerep, Oneloop, Notoneloop, Onelazy, Notonelazy,
+		Setlazy, Setrep, Setloop:
+		return 3
+
+	default:
+		panic(fmt.Errorf("Unexpected op code: %v", op))
+	}
+}
+
+var codeStr = []string{
+	"Onerep", "Notonerep", "Setrep",
+	"Oneloop", "Notoneloop", "Setloop",
+	"Onelazy", "Notonelazy", "Setlazy",
+	"One", "Notone", "Set",
+	"Multi", "Ref",
+	"Bol", "Eol", "Boundary", "Nonboundary", "Beginning", "Start", "EndZ", "End",
+	"Nothing",
+	"Lazybranch", "Branchmark", "Lazybranchmark",
+	"Nullcount", "Setcount", "Branchcount", "Lazybranchcount",
+	"Nullmark", "Setmark", "Capturemark", "Getmark",
+	"Setjump", "Backjump", "Forejump", "Testref", "Goto",
+	"Prune", "Stop",
+	"ECMABoundary", "NonECMABoundary",
+}
+
+func operatorDescription(op InstOp) string {
+	desc := codeStr[op&Mask]
+	if (op & Ci) != 0 {
+		desc += "-Ci"
+	}
+	if (op & Rtl) != 0 {
+		desc += "-Rtl"
+	}
+	if (op & Back) != 0 {
+		desc += "-Back"
+	}
+	if (op & Back2) != 0 {
+		desc += "-Back2"
+	}
+
+	return desc
+}
+
+// OpcodeDescription is a humman readable string of the specific offset
+func (c *Code) OpcodeDescription(offset int) string {
+	buf := &bytes.Buffer{}
+
+	op := InstOp(c.Codes[offset])
+	fmt.Fprintf(buf, "%06d ", offset)
+
+	if opcodeBacktracks(op & Mask) {
+		buf.WriteString("*")
+	} else {
+		buf.WriteString(" ")
+	}
+	buf.WriteString(operatorDescription(op))
+	buf.WriteString("(")
+	op &= Mask
+
+	switch op {
+	case One, Notone, Onerep, Notonerep, Oneloop, Notoneloop, Onelazy, Notonelazy:
+		buf.WriteString("Ch = ")
+		buf.WriteString(CharDescription(rune(c.Codes[offset+1])))
+
+	case Set, Setrep, Setloop, Setlazy:
+		buf.WriteString("Set = ")
+		buf.WriteString(c.Sets[c.Codes[offset+1]].String())
+
+	case Multi:
+		fmt.Fprintf(buf, "String = %s", string(c.Strings[c.Codes[offset+1]]))
+
+	case Ref, Testref:
+		fmt.Fprintf(buf, "Index = %d", c.Codes[offset+1])
+
+	case Capturemark:
+		fmt.Fprintf(buf, "Index = %d", c.Codes[offset+1])
+		if c.Codes[offset+2] != -1 {
+			fmt.Fprintf(buf, ", Unindex = %d", c.Codes[offset+2])
+		}
+
+	case Nullcount, Setcount:
+		fmt.Fprintf(buf, "Value = %d", c.Codes[offset+1])
+
+	case Goto, Lazybranch, Branchmark, Lazybranchmark, Branchcount, Lazybranchcount:
+		fmt.Fprintf(buf, "Addr = %d", c.Codes[offset+1])
+	}
+
+	switch op {
+	case Onerep, Notonerep, Oneloop, Notoneloop, Onelazy, Notonelazy, Setrep, Setloop, Setlazy:
+		buf.WriteString(", Rep = ")
+		if c.Codes[offset+2] == math.MaxInt32 {
+			buf.WriteString("inf")
+		} else {
+			fmt.Fprintf(buf, "%d", c.Codes[offset+2])
+		}
+
+	case Branchcount, Lazybranchcount:
+		buf.WriteString(", Limit = ")
+		if c.Codes[offset+2] == math.MaxInt32 {
+			buf.WriteString("inf")
+		} else {
+			fmt.Fprintf(buf, "%d", c.Codes[offset+2])
+		}
+
+	}
+
+	buf.WriteString(")")
+
+	return buf.String()
+}
+
+func (c *Code) Dump() string {
+	buf := &bytes.Buffer{}
+
+	if c.RightToLeft {
+		fmt.Fprintln(buf, "Direction:  right-to-left")
+	} else {
+		fmt.Fprintln(buf, "Direction:  left-to-right")
+	}
+	if c.FcPrefix == nil {
+		fmt.Fprintln(buf, "Firstchars: n/a")
+	} else {
+		fmt.Fprintf(buf, "Firstchars: %v\n", c.FcPrefix.PrefixSet.String())
+	}
+
+	if c.BmPrefix == nil {
+		fmt.Fprintln(buf, "Prefix:     n/a")
+	} else {
+		fmt.Fprintf(buf, "Prefix:     %v\n", Escape(c.BmPrefix.String()))
+	}
+
+	fmt.Fprintf(buf, "Anchors:    %v\n", c.Anchors)
+	fmt.Fprintln(buf)
+
+	if c.BmPrefix != nil {
+		fmt.Fprintln(buf, "BoyerMoore:")
+		fmt.Fprintln(buf, c.BmPrefix.Dump("    "))
+	}
+	for i := 0; i < len(c.Codes); i += opcodeSize(InstOp(c.Codes[i])) {
+		fmt.Fprintln(buf, c.OpcodeDescription(i))
+	}
+
+	return buf.String()
+}

--- a/vendor/github.com/dlclark/regexp2/syntax/escape.go
+++ b/vendor/github.com/dlclark/regexp2/syntax/escape.go
@@ -1,0 +1,94 @@
+package syntax
+
+import (
+	"bytes"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+func Escape(input string) string {
+	b := &bytes.Buffer{}
+	for _, r := range input {
+		escape(b, r, false)
+	}
+	return b.String()
+}
+
+const meta = `\.+*?()|[]{}^$# `
+
+func escape(b *bytes.Buffer, r rune, force bool) {
+	if unicode.IsPrint(r) {
+		if strings.IndexRune(meta, r) >= 0 || force {
+			b.WriteRune('\\')
+		}
+		b.WriteRune(r)
+		return
+	}
+
+	switch r {
+	case '\a':
+		b.WriteString(`\a`)
+	case '\f':
+		b.WriteString(`\f`)
+	case '\n':
+		b.WriteString(`\n`)
+	case '\r':
+		b.WriteString(`\r`)
+	case '\t':
+		b.WriteString(`\t`)
+	case '\v':
+		b.WriteString(`\v`)
+	default:
+		if r < 0x100 {
+			b.WriteString(`\x`)
+			s := strconv.FormatInt(int64(r), 16)
+			if len(s) == 1 {
+				b.WriteRune('0')
+			}
+			b.WriteString(s)
+			break
+		}
+		b.WriteString(`\u`)
+		b.WriteString(strconv.FormatInt(int64(r), 16))
+	}
+}
+
+func Unescape(input string) (string, error) {
+	idx := strings.IndexRune(input, '\\')
+	// no slashes means no unescape needed
+	if idx == -1 {
+		return input, nil
+	}
+
+	buf := bytes.NewBufferString(input[:idx])
+	// get the runes for the rest of the string -- we're going full parser scan on this
+
+	p := parser{}
+	p.setPattern(input[idx+1:])
+	for {
+		if p.rightMost() {
+			return "", p.getErr(ErrIllegalEndEscape)
+		}
+		r, err := p.scanCharEscape()
+		if err != nil {
+			return "", err
+		}
+		buf.WriteRune(r)
+		// are we done?
+		if p.rightMost() {
+			return buf.String(), nil
+		}
+
+		r = p.moveRightGetChar()
+		for r != '\\' {
+			buf.WriteRune(r)
+			if p.rightMost() {
+				// we're done, no more slashes
+				return buf.String(), nil
+			}
+			// keep scanning until we get another slash
+			r = p.moveRightGetChar()
+		}
+	}
+}

--- a/vendor/github.com/dlclark/regexp2/syntax/fuzz.go
+++ b/vendor/github.com/dlclark/regexp2/syntax/fuzz.go
@@ -1,0 +1,20 @@
+// +build gofuzz
+
+package syntax
+
+// Fuzz is the input point for go-fuzz
+func Fuzz(data []byte) int {
+	sdata := string(data)
+	tree, err := Parse(sdata, RegexOptions(0))
+	if err != nil {
+		return 0
+	}
+
+	// translate it to code
+	_, err = Write(tree)
+	if err != nil {
+		panic(err)
+	}
+
+	return 1
+}

--- a/vendor/github.com/dlclark/regexp2/syntax/parser.go
+++ b/vendor/github.com/dlclark/regexp2/syntax/parser.go
@@ -1,0 +1,2262 @@
+package syntax
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"sort"
+	"strconv"
+	"unicode"
+)
+
+type RegexOptions int32
+
+const (
+	IgnoreCase              RegexOptions = 0x0001 // "i"
+	Multiline                            = 0x0002 // "m"
+	ExplicitCapture                      = 0x0004 // "n"
+	Compiled                             = 0x0008 // "c"
+	Singleline                           = 0x0010 // "s"
+	IgnorePatternWhitespace              = 0x0020 // "x"
+	RightToLeft                          = 0x0040 // "r"
+	Debug                                = 0x0080 // "d"
+	ECMAScript                           = 0x0100 // "e"
+	RE2                                  = 0x0200 // RE2 compat mode
+	Unicode                              = 0x0400 // "u"
+)
+
+func optionFromCode(ch rune) RegexOptions {
+	// case-insensitive
+	switch ch {
+	case 'i', 'I':
+		return IgnoreCase
+	case 'r', 'R':
+		return RightToLeft
+	case 'm', 'M':
+		return Multiline
+	case 'n', 'N':
+		return ExplicitCapture
+	case 's', 'S':
+		return Singleline
+	case 'x', 'X':
+		return IgnorePatternWhitespace
+	case 'd', 'D':
+		return Debug
+	case 'e', 'E':
+		return ECMAScript
+	case 'u', 'U':
+		return Unicode
+	default:
+		return 0
+	}
+}
+
+// An Error describes a failure to parse a regular expression
+// and gives the offending expression.
+type Error struct {
+	Code ErrorCode
+	Expr string
+	Args []interface{}
+}
+
+func (e *Error) Error() string {
+	if len(e.Args) == 0 {
+		return "error parsing regexp: " + e.Code.String() + " in `" + e.Expr + "`"
+	}
+	return "error parsing regexp: " + fmt.Sprintf(e.Code.String(), e.Args...) + " in `" + e.Expr + "`"
+}
+
+// An ErrorCode describes a failure to parse a regular expression.
+type ErrorCode string
+
+const (
+	// internal issue
+	ErrInternalError ErrorCode = "regexp/syntax: internal error"
+	// Parser errors
+	ErrUnterminatedComment        = "unterminated comment"
+	ErrInvalidCharRange           = "invalid character class range"
+	ErrInvalidRepeatSize          = "invalid repeat count"
+	ErrInvalidUTF8                = "invalid UTF-8"
+	ErrCaptureGroupOutOfRange     = "capture group number out of range"
+	ErrUnexpectedParen            = "unexpected )"
+	ErrMissingParen               = "missing closing )"
+	ErrMissingBrace               = "missing closing }"
+	ErrInvalidRepeatOp            = "invalid nested repetition operator"
+	ErrMissingRepeatArgument      = "missing argument to repetition operator"
+	ErrConditionalExpression      = "illegal conditional (?(...)) expression"
+	ErrTooManyAlternates          = "too many | in (?()|)"
+	ErrUnrecognizedGrouping       = "unrecognized grouping construct: (%v"
+	ErrInvalidGroupName           = "invalid group name: group names must begin with a word character and have a matching terminator"
+	ErrCapNumNotZero              = "capture number cannot be zero"
+	ErrUndefinedBackRef           = "reference to undefined group number %v"
+	ErrUndefinedNameRef           = "reference to undefined group name %v"
+	ErrAlternationCantCapture     = "alternation conditions do not capture and cannot be named"
+	ErrAlternationCantHaveComment = "alternation conditions cannot be comments"
+	ErrMalformedReference         = "(?(%v) ) malformed"
+	ErrUndefinedReference         = "(?(%v) ) reference to undefined group"
+	ErrIllegalEndEscape           = "illegal \\ at end of pattern"
+	ErrMalformedSlashP            = "malformed \\p{X} character escape"
+	ErrIncompleteSlashP           = "incomplete \\p{X} character escape"
+	ErrUnknownSlashP              = "unknown unicode category, script, or property '%v'"
+	ErrUnrecognizedEscape         = "unrecognized escape sequence \\%v"
+	ErrMissingControl             = "missing control character"
+	ErrUnrecognizedControl        = "unrecognized control character"
+	ErrTooFewHex                  = "insufficient hexadecimal digits"
+	ErrInvalidHex                 = "hex values may not be larger than 0x10FFFF"
+	ErrMalformedNameRef           = "malformed \\k<...> named back reference"
+	ErrBadClassInCharRange        = "cannot include class \\%v in character range"
+	ErrUnterminatedBracket        = "unterminated [] set"
+	ErrSubtractionMustBeLast      = "a subtraction must be the last element in a character class"
+	ErrReversedCharRange          = "[%c-%c] range in reverse order"
+)
+
+func (e ErrorCode) String() string {
+	return string(e)
+}
+
+type parser struct {
+	stack         *regexNode
+	group         *regexNode
+	alternation   *regexNode
+	concatenation *regexNode
+	unit          *regexNode
+
+	patternRaw string
+	pattern    []rune
+
+	currentPos  int
+	specialCase *unicode.SpecialCase
+
+	autocap  int
+	capcount int
+	captop   int
+	capsize  int
+
+	caps     map[int]int
+	capnames map[string]int
+
+	capnumlist  []int
+	capnamelist []string
+
+	options         RegexOptions
+	optionsStack    []RegexOptions
+	ignoreNextParen bool
+}
+
+const (
+	maxValueDiv10 int = math.MaxInt32 / 10
+	maxValueMod10     = math.MaxInt32 % 10
+)
+
+// Parse converts a regex string into a parse tree
+func Parse(re string, op RegexOptions) (*RegexTree, error) {
+	p := parser{
+		options: op,
+		caps:    make(map[int]int),
+	}
+	p.setPattern(re)
+
+	if err := p.countCaptures(); err != nil {
+		return nil, err
+	}
+
+	p.reset(op)
+	root, err := p.scanRegex()
+
+	if err != nil {
+		return nil, err
+	}
+	tree := &RegexTree{
+		root:       root,
+		caps:       p.caps,
+		capnumlist: p.capnumlist,
+		captop:     p.captop,
+		Capnames:   p.capnames,
+		Caplist:    p.capnamelist,
+		options:    op,
+	}
+
+	if tree.options&Debug > 0 {
+		os.Stdout.WriteString(tree.Dump())
+	}
+
+	return tree, nil
+}
+
+func (p *parser) setPattern(pattern string) {
+	p.patternRaw = pattern
+	p.pattern = make([]rune, 0, len(pattern))
+
+	//populate our rune array to handle utf8 encoding
+	for _, r := range pattern {
+		p.pattern = append(p.pattern, r)
+	}
+}
+func (p *parser) getErr(code ErrorCode, args ...interface{}) error {
+	return &Error{Code: code, Expr: p.patternRaw, Args: args}
+}
+
+func (p *parser) noteCaptureSlot(i, pos int) {
+	if _, ok := p.caps[i]; !ok {
+		// the rhs of the hashtable isn't used in the parser
+		p.caps[i] = pos
+		p.capcount++
+
+		if p.captop <= i {
+			if i == math.MaxInt32 {
+				p.captop = i
+			} else {
+				p.captop = i + 1
+			}
+		}
+	}
+}
+
+func (p *parser) noteCaptureName(name string, pos int) {
+	if p.capnames == nil {
+		p.capnames = make(map[string]int)
+	}
+
+	if _, ok := p.capnames[name]; !ok {
+		p.capnames[name] = pos
+		p.capnamelist = append(p.capnamelist, name)
+	}
+}
+
+func (p *parser) assignNameSlots() {
+	if p.capnames != nil {
+		for _, name := range p.capnamelist {
+			for p.isCaptureSlot(p.autocap) {
+				p.autocap++
+			}
+			pos := p.capnames[name]
+			p.capnames[name] = p.autocap
+			p.noteCaptureSlot(p.autocap, pos)
+
+			p.autocap++
+		}
+	}
+
+	// if the caps array has at least one gap, construct the list of used slots
+	if p.capcount < p.captop {
+		p.capnumlist = make([]int, p.capcount)
+		i := 0
+
+		for k := range p.caps {
+			p.capnumlist[i] = k
+			i++
+		}
+
+		sort.Ints(p.capnumlist)
+	}
+
+	// merge capsnumlist into capnamelist
+	if p.capnames != nil || p.capnumlist != nil {
+		var oldcapnamelist []string
+		var next int
+		var k int
+
+		if p.capnames == nil {
+			oldcapnamelist = nil
+			p.capnames = make(map[string]int)
+			p.capnamelist = []string{}
+			next = -1
+		} else {
+			oldcapnamelist = p.capnamelist
+			p.capnamelist = []string{}
+			next = p.capnames[oldcapnamelist[0]]
+		}
+
+		for i := 0; i < p.capcount; i++ {
+			j := i
+			if p.capnumlist != nil {
+				j = p.capnumlist[i]
+			}
+
+			if next == j {
+				p.capnamelist = append(p.capnamelist, oldcapnamelist[k])
+				k++
+
+				if k == len(oldcapnamelist) {
+					next = -1
+				} else {
+					next = p.capnames[oldcapnamelist[k]]
+				}
+
+			} else {
+				//feature: culture?
+				str := strconv.Itoa(j)
+				p.capnamelist = append(p.capnamelist, str)
+				p.capnames[str] = j
+			}
+		}
+	}
+}
+
+func (p *parser) consumeAutocap() int {
+	r := p.autocap
+	p.autocap++
+	return r
+}
+
+// CountCaptures is a prescanner for deducing the slots used for
+// captures by doing a partial tokenization of the pattern.
+func (p *parser) countCaptures() error {
+	var ch rune
+
+	p.noteCaptureSlot(0, 0)
+
+	p.autocap = 1
+
+	for p.charsRight() > 0 {
+		pos := p.textpos()
+		ch = p.moveRightGetChar()
+		switch ch {
+		case '\\':
+			if p.charsRight() > 0 {
+				p.scanBackslash(true)
+			}
+
+		case '#':
+			if p.useOptionX() {
+				p.moveLeft()
+				p.scanBlank()
+			}
+
+		case '[':
+			p.scanCharSet(false, true)
+
+		case ')':
+			if !p.emptyOptionsStack() {
+				p.popOptions()
+			}
+
+		case '(':
+			if p.charsRight() >= 2 && p.rightChar(1) == '#' && p.rightChar(0) == '?' {
+				p.moveLeft()
+				p.scanBlank()
+			} else {
+				p.pushOptions()
+				if p.charsRight() > 0 && p.rightChar(0) == '?' {
+					// we have (?...
+					p.moveRight(1)
+
+					if p.charsRight() > 1 && (p.rightChar(0) == '<' || p.rightChar(0) == '\'') {
+						// named group: (?<... or (?'...
+
+						p.moveRight(1)
+						ch = p.rightChar(0)
+
+						if ch != '0' && IsWordChar(ch) {
+							if ch >= '1' && ch <= '9' {
+								dec, err := p.scanDecimal()
+								if err != nil {
+									return err
+								}
+								p.noteCaptureSlot(dec, pos)
+							} else {
+								p.noteCaptureName(p.scanCapname(), pos)
+							}
+						}
+					} else if p.useRE2() && p.charsRight() > 2 && (p.rightChar(0) == 'P' && p.rightChar(1) == '<') {
+						// RE2-compat (?P<)
+						p.moveRight(2)
+						ch = p.rightChar(0)
+						if IsWordChar(ch) {
+							p.noteCaptureName(p.scanCapname(), pos)
+						}
+
+					} else {
+						// (?...
+
+						// get the options if it's an option construct (?cimsx-cimsx...)
+						p.scanOptions()
+
+						if p.charsRight() > 0 {
+							if p.rightChar(0) == ')' {
+								// (?cimsx-cimsx)
+								p.moveRight(1)
+								p.popKeepOptions()
+							} else if p.rightChar(0) == '(' {
+								// alternation construct: (?(foo)yes|no)
+								// ignore the next paren so we don't capture the condition
+								p.ignoreNextParen = true
+
+								// break from here so we don't reset ignoreNextParen
+								continue
+							}
+						}
+					}
+				} else {
+					if !p.useOptionN() && !p.ignoreNextParen {
+						p.noteCaptureSlot(p.consumeAutocap(), pos)
+					}
+				}
+			}
+
+			p.ignoreNextParen = false
+
+		}
+	}
+
+	p.assignNameSlots()
+	return nil
+}
+
+func (p *parser) reset(topopts RegexOptions) {
+	p.currentPos = 0
+	p.autocap = 1
+	p.ignoreNextParen = false
+
+	if len(p.optionsStack) > 0 {
+		p.optionsStack = p.optionsStack[:0]
+	}
+
+	p.options = topopts
+	p.stack = nil
+}
+
+func (p *parser) scanRegex() (*regexNode, error) {
+	ch := '@' // nonspecial ch, means at beginning
+	isQuant := false
+
+	p.startGroup(newRegexNodeMN(ntCapture, p.options, 0, -1))
+
+	for p.charsRight() > 0 {
+		wasPrevQuantifier := isQuant
+		isQuant = false
+
+		if err := p.scanBlank(); err != nil {
+			return nil, err
+		}
+
+		startpos := p.textpos()
+
+		// move past all of the normal characters.  We'll stop when we hit some kind of control character,
+		// or if IgnorePatternWhiteSpace is on, we'll stop when we see some whitespace.
+		if p.useOptionX() {
+			for p.charsRight() > 0 {
+				ch = p.rightChar(0)
+				//UGLY: clean up, this is ugly
+				if !(!isStopperX(ch) || (ch == '{' && !p.isTrueQuantifier())) {
+					break
+				}
+				p.moveRight(1)
+			}
+		} else {
+			for p.charsRight() > 0 {
+				ch = p.rightChar(0)
+				if !(!isSpecial(ch) || ch == '{' && !p.isTrueQuantifier()) {
+					break
+				}
+				p.moveRight(1)
+			}
+		}
+
+		endpos := p.textpos()
+
+		p.scanBlank()
+
+		if p.charsRight() == 0 {
+			ch = '!' // nonspecial, means at end
+		} else if ch = p.rightChar(0); isSpecial(ch) {
+			isQuant = isQuantifier(ch)
+			p.moveRight(1)
+		} else {
+			ch = ' ' // nonspecial, means at ordinary char
+		}
+
+		if startpos < endpos {
+			cchUnquantified := endpos - startpos
+			if isQuant {
+				cchUnquantified--
+			}
+			wasPrevQuantifier = false
+
+			if cchUnquantified > 0 {
+				p.addToConcatenate(startpos, cchUnquantified, false)
+			}
+
+			if isQuant {
+				p.addUnitOne(p.charAt(endpos - 1))
+			}
+		}
+
+		switch ch {
+		case '!':
+			goto BreakOuterScan
+
+		case ' ':
+			goto ContinueOuterScan
+
+		case '[':
+			cc, err := p.scanCharSet(p.useOptionI(), false)
+			if err != nil {
+				return nil, err
+			}
+			p.addUnitSet(cc)
+
+		case '(':
+			p.pushOptions()
+
+			if grouper, err := p.scanGroupOpen(); err != nil {
+				return nil, err
+			} else if grouper == nil {
+				p.popKeepOptions()
+			} else {
+				p.pushGroup()
+				p.startGroup(grouper)
+			}
+
+			continue
+
+		case '|':
+			p.addAlternate()
+			goto ContinueOuterScan
+
+		case ')':
+			if p.emptyStack() {
+				return nil, p.getErr(ErrUnexpectedParen)
+			}
+
+			if err := p.addGroup(); err != nil {
+				return nil, err
+			}
+			if err := p.popGroup(); err != nil {
+				return nil, err
+			}
+			p.popOptions()
+
+			if p.unit == nil {
+				goto ContinueOuterScan
+			}
+
+		case '\\':
+			n, err := p.scanBackslash(false)
+			if err != nil {
+				return nil, err
+			}
+			p.addUnitNode(n)
+
+		case '^':
+			if p.useOptionM() {
+				p.addUnitType(ntBol)
+			} else {
+				p.addUnitType(ntBeginning)
+			}
+
+		case '$':
+			if p.useOptionM() {
+				p.addUnitType(ntEol)
+			} else {
+				p.addUnitType(ntEndZ)
+			}
+
+		case '.':
+			if p.useOptionS() {
+				p.addUnitSet(AnyClass())
+			} else if p.useOptionE() {
+				p.addUnitSet(ECMAAnyClass())
+			} else {
+				p.addUnitNotone('\n')
+			}
+
+		case '{', '*', '+', '?':
+			if p.unit == nil {
+				if wasPrevQuantifier {
+					return nil, p.getErr(ErrInvalidRepeatOp)
+				} else {
+					return nil, p.getErr(ErrMissingRepeatArgument)
+				}
+			}
+			p.moveLeft()
+
+		default:
+			return nil, p.getErr(ErrInternalError)
+		}
+
+		if err := p.scanBlank(); err != nil {
+			return nil, err
+		}
+
+		if p.charsRight() > 0 {
+			isQuant = p.isTrueQuantifier()
+		}
+		if p.charsRight() == 0 || !isQuant {
+			//maintain odd C# assignment order -- not sure if required, could clean up?
+			p.addConcatenate()
+			goto ContinueOuterScan
+		}
+
+		ch = p.moveRightGetChar()
+
+		// Handle quantifiers
+		for p.unit != nil {
+			var min, max int
+			var lazy bool
+
+			switch ch {
+			case '*':
+				min = 0
+				max = math.MaxInt32
+
+			case '?':
+				min = 0
+				max = 1
+
+			case '+':
+				min = 1
+				max = math.MaxInt32
+
+			case '{':
+				{
+					var err error
+					startpos = p.textpos()
+					if min, err = p.scanDecimal(); err != nil {
+						return nil, err
+					}
+					max = min
+					if startpos < p.textpos() {
+						if p.charsRight() > 0 && p.rightChar(0) == ',' {
+							p.moveRight(1)
+							if p.charsRight() == 0 || p.rightChar(0) == '}' {
+								max = math.MaxInt32
+							} else {
+								if max, err = p.scanDecimal(); err != nil {
+									return nil, err
+								}
+							}
+						}
+					}
+
+					if startpos == p.textpos() || p.charsRight() == 0 || p.moveRightGetChar() != '}' {
+						p.addConcatenate()
+						p.textto(startpos - 1)
+						goto ContinueOuterScan
+					}
+				}
+
+			default:
+				return nil, p.getErr(ErrInternalError)
+			}
+
+			if err := p.scanBlank(); err != nil {
+				return nil, err
+			}
+
+			if p.charsRight() == 0 || p.rightChar(0) != '?' {
+				lazy = false
+			} else {
+				p.moveRight(1)
+				lazy = true
+			}
+
+			if min > max {
+				return nil, p.getErr(ErrInvalidRepeatSize)
+			}
+
+			p.addConcatenate3(lazy, min, max)
+		}
+
+	ContinueOuterScan:
+	}
+
+BreakOuterScan:
+	;
+
+	if !p.emptyStack() {
+		return nil, p.getErr(ErrMissingParen)
+	}
+
+	if err := p.addGroup(); err != nil {
+		return nil, err
+	}
+
+	return p.unit, nil
+
+}
+
+/*
+ * Simple parsing for replacement patterns
+ */
+func (p *parser) scanReplacement() (*regexNode, error) {
+	var c, startpos int
+
+	p.concatenation = newRegexNode(ntConcatenate, p.options)
+
+	for {
+		c = p.charsRight()
+		if c == 0 {
+			break
+		}
+
+		startpos = p.textpos()
+
+		for c > 0 && p.rightChar(0) != '$' {
+			p.moveRight(1)
+			c--
+		}
+
+		p.addToConcatenate(startpos, p.textpos()-startpos, true)
+
+		if c > 0 {
+			if p.moveRightGetChar() == '$' {
+				n, err := p.scanDollar()
+				if err != nil {
+					return nil, err
+				}
+				p.addUnitNode(n)
+			}
+			p.addConcatenate()
+		}
+	}
+
+	return p.concatenation, nil
+}
+
+/*
+ * Scans $ patterns recognized within replacement patterns
+ */
+func (p *parser) scanDollar() (*regexNode, error) {
+	if p.charsRight() == 0 {
+		return newRegexNodeCh(ntOne, p.options, '$'), nil
+	}
+
+	ch := p.rightChar(0)
+	angled := false
+	backpos := p.textpos()
+	lastEndPos := backpos
+
+	// Note angle
+
+	if ch == '{' && p.charsRight() > 1 {
+		angled = true
+		p.moveRight(1)
+		ch = p.rightChar(0)
+	}
+
+	// Try to parse backreference: \1 or \{1} or \{cap}
+
+	if ch >= '0' && ch <= '9' {
+		if !angled && p.useOptionE() {
+			capnum := -1
+			newcapnum := int(ch - '0')
+			p.moveRight(1)
+			if p.isCaptureSlot(newcapnum) {
+				capnum = newcapnum
+				lastEndPos = p.textpos()
+			}
+
+			for p.charsRight() > 0 {
+				ch = p.rightChar(0)
+				if ch < '0' || ch > '9' {
+					break
+				}
+				digit := int(ch - '0')
+				if newcapnum > maxValueDiv10 || (newcapnum == maxValueDiv10 && digit > maxValueMod10) {
+					return nil, p.getErr(ErrCaptureGroupOutOfRange)
+				}
+
+				newcapnum = newcapnum*10 + digit
+
+				p.moveRight(1)
+				if p.isCaptureSlot(newcapnum) {
+					capnum = newcapnum
+					lastEndPos = p.textpos()
+				}
+			}
+			p.textto(lastEndPos)
+			if capnum >= 0 {
+				return newRegexNodeM(ntRef, p.options, capnum), nil
+			}
+		} else {
+			capnum, err := p.scanDecimal()
+			if err != nil {
+				return nil, err
+			}
+			if !angled || p.charsRight() > 0 && p.moveRightGetChar() == '}' {
+				if p.isCaptureSlot(capnum) {
+					return newRegexNodeM(ntRef, p.options, capnum), nil
+				}
+			}
+		}
+	} else if angled && IsWordChar(ch) {
+		capname := p.scanCapname()
+
+		if p.charsRight() > 0 && p.moveRightGetChar() == '}' {
+			if p.isCaptureName(capname) {
+				return newRegexNodeM(ntRef, p.options, p.captureSlotFromName(capname)), nil
+			}
+		}
+	} else if !angled {
+		capnum := 1
+
+		switch ch {
+		case '$':
+			p.moveRight(1)
+			return newRegexNodeCh(ntOne, p.options, '$'), nil
+		case '&':
+			capnum = 0
+		case '`':
+			capnum = replaceLeftPortion
+		case '\'':
+			capnum = replaceRightPortion
+		case '+':
+			capnum = replaceLastGroup
+		case '_':
+			capnum = replaceWholeString
+		}
+
+		if capnum != 1 {
+			p.moveRight(1)
+			return newRegexNodeM(ntRef, p.options, capnum), nil
+		}
+	}
+
+	// unrecognized $: literalize
+
+	p.textto(backpos)
+	return newRegexNodeCh(ntOne, p.options, '$'), nil
+}
+
+// scanGroupOpen scans chars following a '(' (not counting the '('), and returns
+// a RegexNode for the type of group scanned, or nil if the group
+// simply changed options (?cimsx-cimsx) or was a comment (#...).
+func (p *parser) scanGroupOpen() (*regexNode, error) {
+	var ch rune
+	var nt nodeType
+	var err error
+	close := '>'
+	start := p.textpos()
+
+	// just return a RegexNode if we have:
+	// 1. "(" followed by nothing
+	// 2. "(x" where x != ?
+	// 3. "(?)"
+	if p.charsRight() == 0 || p.rightChar(0) != '?' || (p.rightChar(0) == '?' && (p.charsRight() > 1 && p.rightChar(1) == ')')) {
+		if p.useOptionN() || p.ignoreNextParen {
+			p.ignoreNextParen = false
+			return newRegexNode(ntGroup, p.options), nil
+		}
+		return newRegexNodeMN(ntCapture, p.options, p.consumeAutocap(), -1), nil
+	}
+
+	p.moveRight(1)
+
+	for {
+		if p.charsRight() == 0 {
+			break
+		}
+
+		switch ch = p.moveRightGetChar(); ch {
+		case ':':
+			nt = ntGroup
+
+		case '=':
+			p.options &= ^RightToLeft
+			nt = ntRequire
+
+		case '!':
+			p.options &= ^RightToLeft
+			nt = ntPrevent
+
+		case '>':
+			nt = ntGreedy
+
+		case '\'':
+			close = '\''
+			fallthrough
+
+		case '<':
+			if p.charsRight() == 0 {
+				goto BreakRecognize
+			}
+
+			switch ch = p.moveRightGetChar(); ch {
+			case '=':
+				if close == '\'' {
+					goto BreakRecognize
+				}
+
+				p.options |= RightToLeft
+				nt = ntRequire
+
+			case '!':
+				if close == '\'' {
+					goto BreakRecognize
+				}
+
+				p.options |= RightToLeft
+				nt = ntPrevent
+
+			default:
+				p.moveLeft()
+				capnum := -1
+				uncapnum := -1
+				proceed := false
+
+				// grab part before -
+
+				if ch >= '0' && ch <= '9' {
+					if capnum, err = p.scanDecimal(); err != nil {
+						return nil, err
+					}
+
+					if !p.isCaptureSlot(capnum) {
+						capnum = -1
+					}
+
+					// check if we have bogus characters after the number
+					if p.charsRight() > 0 && !(p.rightChar(0) == close || p.rightChar(0) == '-') {
+						return nil, p.getErr(ErrInvalidGroupName)
+					}
+					if capnum == 0 {
+						return nil, p.getErr(ErrCapNumNotZero)
+					}
+				} else if IsWordChar(ch) {
+					capname := p.scanCapname()
+
+					if p.isCaptureName(capname) {
+						capnum = p.captureSlotFromName(capname)
+					}
+
+					// check if we have bogus character after the name
+					if p.charsRight() > 0 && !(p.rightChar(0) == close || p.rightChar(0) == '-') {
+						return nil, p.getErr(ErrInvalidGroupName)
+					}
+				} else if ch == '-' {
+					proceed = true
+				} else {
+					// bad group name - starts with something other than a word character and isn't a number
+					return nil, p.getErr(ErrInvalidGroupName)
+				}
+
+				// grab part after - if any
+
+				if (capnum != -1 || proceed == true) && p.charsRight() > 0 && p.rightChar(0) == '-' {
+					p.moveRight(1)
+
+					//no more chars left, no closing char, etc
+					if p.charsRight() == 0 {
+						return nil, p.getErr(ErrInvalidGroupName)
+					}
+
+					ch = p.rightChar(0)
+					if ch >= '0' && ch <= '9' {
+						if uncapnum, err = p.scanDecimal(); err != nil {
+							return nil, err
+						}
+
+						if !p.isCaptureSlot(uncapnum) {
+							return nil, p.getErr(ErrUndefinedBackRef, uncapnum)
+						}
+
+						// check if we have bogus characters after the number
+						if p.charsRight() > 0 && p.rightChar(0) != close {
+							return nil, p.getErr(ErrInvalidGroupName)
+						}
+					} else if IsWordChar(ch) {
+						uncapname := p.scanCapname()
+
+						if !p.isCaptureName(uncapname) {
+							return nil, p.getErr(ErrUndefinedNameRef, uncapname)
+						}
+						uncapnum = p.captureSlotFromName(uncapname)
+
+						// check if we have bogus character after the name
+						if p.charsRight() > 0 && p.rightChar(0) != close {
+							return nil, p.getErr(ErrInvalidGroupName)
+						}
+					} else {
+						// bad group name - starts with something other than a word character and isn't a number
+						return nil, p.getErr(ErrInvalidGroupName)
+					}
+				}
+
+				// actually make the node
+
+				if (capnum != -1 || uncapnum != -1) && p.charsRight() > 0 && p.moveRightGetChar() == close {
+					return newRegexNodeMN(ntCapture, p.options, capnum, uncapnum), nil
+				}
+				goto BreakRecognize
+			}
+
+		case '(':
+			// alternation construct (?(...) | )
+
+			parenPos := p.textpos()
+			if p.charsRight() > 0 {
+				ch = p.rightChar(0)
+
+				// check if the alternation condition is a backref
+				if ch >= '0' && ch <= '9' {
+					var capnum int
+					if capnum, err = p.scanDecimal(); err != nil {
+						return nil, err
+					}
+					if p.charsRight() > 0 && p.moveRightGetChar() == ')' {
+						if p.isCaptureSlot(capnum) {
+							return newRegexNodeM(ntTestref, p.options, capnum), nil
+						}
+						return nil, p.getErr(ErrUndefinedReference, capnum)
+					}
+
+					return nil, p.getErr(ErrMalformedReference, capnum)
+
+				} else if IsWordChar(ch) {
+					capname := p.scanCapname()
+
+					if p.isCaptureName(capname) && p.charsRight() > 0 && p.moveRightGetChar() == ')' {
+						return newRegexNodeM(ntTestref, p.options, p.captureSlotFromName(capname)), nil
+					}
+				}
+			}
+			// not a backref
+			nt = ntTestgroup
+			p.textto(parenPos - 1)   // jump to the start of the parentheses
+			p.ignoreNextParen = true // but make sure we don't try to capture the insides
+
+			charsRight := p.charsRight()
+			if charsRight >= 3 && p.rightChar(1) == '?' {
+				rightchar2 := p.rightChar(2)
+				// disallow comments in the condition
+				if rightchar2 == '#' {
+					return nil, p.getErr(ErrAlternationCantHaveComment)
+				}
+
+				// disallow named capture group (?<..>..) in the condition
+				if rightchar2 == '\'' {
+					return nil, p.getErr(ErrAlternationCantCapture)
+				}
+
+				if charsRight >= 4 && (rightchar2 == '<' && p.rightChar(3) != '!' && p.rightChar(3) != '=') {
+					return nil, p.getErr(ErrAlternationCantCapture)
+				}
+			}
+
+		case 'P':
+			if p.useRE2() {
+				// support for P<name> syntax
+				if p.charsRight() < 3 {
+					goto BreakRecognize
+				}
+
+				ch = p.moveRightGetChar()
+				if ch != '<' {
+					goto BreakRecognize
+				}
+
+				ch = p.moveRightGetChar()
+				p.moveLeft()
+
+				if IsWordChar(ch) {
+					capnum := -1
+					capname := p.scanCapname()
+
+					if p.isCaptureName(capname) {
+						capnum = p.captureSlotFromName(capname)
+					}
+
+					// check if we have bogus character after the name
+					if p.charsRight() > 0 && p.rightChar(0) != '>' {
+						return nil, p.getErr(ErrInvalidGroupName)
+					}
+
+					// actually make the node
+
+					if capnum != -1 && p.charsRight() > 0 && p.moveRightGetChar() == '>' {
+						return newRegexNodeMN(ntCapture, p.options, capnum, -1), nil
+					}
+					goto BreakRecognize
+
+				} else {
+					// bad group name - starts with something other than a word character and isn't a number
+					return nil, p.getErr(ErrInvalidGroupName)
+				}
+			}
+			// if we're not using RE2 compat mode then
+			// we just behave like normal
+			fallthrough
+
+		default:
+			p.moveLeft()
+
+			nt = ntGroup
+			// disallow options in the children of a testgroup node
+			if p.group.t != ntTestgroup {
+				p.scanOptions()
+			}
+			if p.charsRight() == 0 {
+				goto BreakRecognize
+			}
+
+			if ch = p.moveRightGetChar(); ch == ')' {
+				return nil, nil
+			}
+
+			if ch != ':' {
+				goto BreakRecognize
+			}
+
+		}
+
+		return newRegexNode(nt, p.options), nil
+	}
+
+BreakRecognize:
+
+	// break Recognize comes here
+
+	return nil, p.getErr(ErrUnrecognizedGrouping, string(p.pattern[start:p.textpos()]))
+}
+
+// scans backslash specials and basics
+func (p *parser) scanBackslash(scanOnly bool) (*regexNode, error) {
+
+	if p.charsRight() == 0 {
+		return nil, p.getErr(ErrIllegalEndEscape)
+	}
+
+	switch ch := p.rightChar(0); ch {
+	case 'b', 'B', 'A', 'G', 'Z', 'z':
+		p.moveRight(1)
+		return newRegexNode(p.typeFromCode(ch), p.options), nil
+
+	case 'w':
+		p.moveRight(1)
+		if p.useOptionE() || p.useRE2() {
+			return newRegexNodeSet(ntSet, p.options, ECMAWordClass()), nil
+		}
+		return newRegexNodeSet(ntSet, p.options, WordClass()), nil
+
+	case 'W':
+		p.moveRight(1)
+		if p.useOptionE() || p.useRE2() {
+			return newRegexNodeSet(ntSet, p.options, NotECMAWordClass()), nil
+		}
+		return newRegexNodeSet(ntSet, p.options, NotWordClass()), nil
+
+	case 's':
+		p.moveRight(1)
+		if p.useOptionE() {
+			return newRegexNodeSet(ntSet, p.options, ECMASpaceClass()), nil
+		} else if p.useRE2() {
+			return newRegexNodeSet(ntSet, p.options, RE2SpaceClass()), nil
+		}
+		return newRegexNodeSet(ntSet, p.options, SpaceClass()), nil
+
+	case 'S':
+		p.moveRight(1)
+		if p.useOptionE() {
+			return newRegexNodeSet(ntSet, p.options, NotECMASpaceClass()), nil
+		} else if p.useRE2() {
+			return newRegexNodeSet(ntSet, p.options, NotRE2SpaceClass()), nil
+		}
+		return newRegexNodeSet(ntSet, p.options, NotSpaceClass()), nil
+
+	case 'd':
+		p.moveRight(1)
+		if p.useOptionE() || p.useRE2() {
+			return newRegexNodeSet(ntSet, p.options, ECMADigitClass()), nil
+		}
+		return newRegexNodeSet(ntSet, p.options, DigitClass()), nil
+
+	case 'D':
+		p.moveRight(1)
+		if p.useOptionE() || p.useRE2() {
+			return newRegexNodeSet(ntSet, p.options, NotECMADigitClass()), nil
+		}
+		return newRegexNodeSet(ntSet, p.options, NotDigitClass()), nil
+
+	case 'p', 'P':
+		p.moveRight(1)
+		prop, err := p.parseProperty()
+		if err != nil {
+			return nil, err
+		}
+		cc := &CharSet{}
+		cc.addCategory(prop, (ch != 'p'), p.useOptionI(), p.patternRaw)
+		if p.useOptionI() {
+			cc.addLowercase()
+		}
+
+		return newRegexNodeSet(ntSet, p.options, cc), nil
+
+	default:
+		return p.scanBasicBackslash(scanOnly)
+	}
+}
+
+// Scans \-style backreferences and character escapes
+func (p *parser) scanBasicBackslash(scanOnly bool) (*regexNode, error) {
+	if p.charsRight() == 0 {
+		return nil, p.getErr(ErrIllegalEndEscape)
+	}
+	angled := false
+	k := false
+	close := '\x00'
+
+	backpos := p.textpos()
+	ch := p.rightChar(0)
+
+	// Allow \k<foo> instead of \<foo>, which is now deprecated.
+
+	// According to ECMAScript specification, \k<name> is only parsed as a named group reference if
+	// there is at least one group name in the regexp.
+	// See https://www.ecma-international.org/ecma-262/#sec-isvalidregularexpressionliteral, step 7.
+	// Note, during the first (scanOnly) run we may not have all group names scanned, but that's ok.
+	if ch == 'k' && (!p.useOptionE() || len(p.capnames) > 0) {
+		if p.charsRight() >= 2 {
+			p.moveRight(1)
+			ch = p.moveRightGetChar()
+
+			if ch == '<' || (!p.useOptionE() && ch == '\'') { // No support for \k'name' in ECMAScript
+				angled = true
+				if ch == '\'' {
+					close = '\''
+				} else {
+					close = '>'
+				}
+			}
+		}
+
+		if !angled || p.charsRight() <= 0 {
+			return nil, p.getErr(ErrMalformedNameRef)
+		}
+
+		ch = p.rightChar(0)
+		k = true
+
+	} else if !p.useOptionE() && (ch == '<' || ch == '\'') && p.charsRight() > 1 { // Note angle without \g
+		angled = true
+		if ch == '\'' {
+			close = '\''
+		} else {
+			close = '>'
+		}
+
+		p.moveRight(1)
+		ch = p.rightChar(0)
+	}
+
+	// Try to parse backreference: \<1> or \<cap>
+
+	if angled && ch >= '0' && ch <= '9' {
+		capnum, err := p.scanDecimal()
+		if err != nil {
+			return nil, err
+		}
+
+		if p.charsRight() > 0 && p.moveRightGetChar() == close {
+			if p.isCaptureSlot(capnum) {
+				return newRegexNodeM(ntRef, p.options, capnum), nil
+			}
+			return nil, p.getErr(ErrUndefinedBackRef, capnum)
+		}
+	} else if !angled && ch >= '1' && ch <= '9' { // Try to parse backreference or octal: \1
+		capnum, err := p.scanDecimal()
+		if err != nil {
+			return nil, err
+		}
+
+		if scanOnly {
+			return nil, nil
+		}
+
+		if p.isCaptureSlot(capnum) {
+			return newRegexNodeM(ntRef, p.options, capnum), nil
+		}
+		if capnum <= 9 && !p.useOptionE() {
+			return nil, p.getErr(ErrUndefinedBackRef, capnum)
+		}
+
+	} else if angled {
+		capname := p.scanCapname()
+
+		if capname != "" && p.charsRight() > 0 && p.moveRightGetChar() == close {
+
+			if scanOnly {
+				return nil, nil
+			}
+
+			if p.isCaptureName(capname) {
+				return newRegexNodeM(ntRef, p.options, p.captureSlotFromName(capname)), nil
+			}
+			return nil, p.getErr(ErrUndefinedNameRef, capname)
+		} else {
+			if k {
+				return nil, p.getErr(ErrMalformedNameRef)
+			}
+		}
+	}
+
+	// Not backreference: must be char code
+
+	p.textto(backpos)
+	ch, err := p.scanCharEscape()
+	if err != nil {
+		return nil, err
+	}
+
+	if scanOnly {
+		return nil, nil
+	}
+
+	if p.useOptionI() {
+		ch = unicode.ToLower(ch)
+	}
+
+	return newRegexNodeCh(ntOne, p.options, ch), nil
+}
+
+// Scans X for \p{X} or \P{X}
+func (p *parser) parseProperty() (string, error) {
+	// RE2 and PCRE supports \pX syntax (no {} and only 1 letter unicode cats supported)
+	// since this is purely additive syntax it's not behind a flag
+	if p.charsRight() >= 1 && p.rightChar(0) != '{' {
+		ch := string(p.moveRightGetChar())
+		// check if it's a valid cat
+		if !isValidUnicodeCat(ch) {
+			return "", p.getErr(ErrUnknownSlashP, ch)
+		}
+		return ch, nil
+	}
+
+	if p.charsRight() < 3 {
+		return "", p.getErr(ErrIncompleteSlashP)
+	}
+	ch := p.moveRightGetChar()
+	if ch != '{' {
+		return "", p.getErr(ErrMalformedSlashP)
+	}
+
+	startpos := p.textpos()
+	for p.charsRight() > 0 {
+		ch = p.moveRightGetChar()
+		if !(IsWordChar(ch) || ch == '-') {
+			p.moveLeft()
+			break
+		}
+	}
+	capname := string(p.pattern[startpos:p.textpos()])
+
+	if p.charsRight() == 0 || p.moveRightGetChar() != '}' {
+		return "", p.getErr(ErrIncompleteSlashP)
+	}
+
+	if !isValidUnicodeCat(capname) {
+		return "", p.getErr(ErrUnknownSlashP, capname)
+	}
+
+	return capname, nil
+}
+
+// Returns ReNode type for zero-length assertions with a \ code.
+func (p *parser) typeFromCode(ch rune) nodeType {
+	switch ch {
+	case 'b':
+		if p.useOptionE() {
+			return ntECMABoundary
+		}
+		return ntBoundary
+	case 'B':
+		if p.useOptionE() {
+			return ntNonECMABoundary
+		}
+		return ntNonboundary
+	case 'A':
+		return ntBeginning
+	case 'G':
+		return ntStart
+	case 'Z':
+		return ntEndZ
+	case 'z':
+		return ntEnd
+	default:
+		return ntNothing
+	}
+}
+
+// Scans whitespace or x-mode comments.
+func (p *parser) scanBlank() error {
+	if p.useOptionX() {
+		for {
+			for p.charsRight() > 0 && isSpace(p.rightChar(0)) {
+				p.moveRight(1)
+			}
+
+			if p.charsRight() == 0 {
+				break
+			}
+
+			if p.rightChar(0) == '#' {
+				for p.charsRight() > 0 && p.rightChar(0) != '\n' {
+					p.moveRight(1)
+				}
+			} else if p.charsRight() >= 3 && p.rightChar(2) == '#' &&
+				p.rightChar(1) == '?' && p.rightChar(0) == '(' {
+				for p.charsRight() > 0 && p.rightChar(0) != ')' {
+					p.moveRight(1)
+				}
+				if p.charsRight() == 0 {
+					return p.getErr(ErrUnterminatedComment)
+				}
+				p.moveRight(1)
+			} else {
+				break
+			}
+		}
+	} else {
+		for {
+			if p.charsRight() < 3 || p.rightChar(2) != '#' ||
+				p.rightChar(1) != '?' || p.rightChar(0) != '(' {
+				return nil
+			}
+
+			for p.charsRight() > 0 && p.rightChar(0) != ')' {
+				p.moveRight(1)
+			}
+			if p.charsRight() == 0 {
+				return p.getErr(ErrUnterminatedComment)
+			}
+			p.moveRight(1)
+		}
+	}
+	return nil
+}
+
+func (p *parser) scanCapname() string {
+	startpos := p.textpos()
+
+	for p.charsRight() > 0 {
+		if !IsWordChar(p.moveRightGetChar()) {
+			p.moveLeft()
+			break
+		}
+	}
+
+	return string(p.pattern[startpos:p.textpos()])
+}
+
+// Scans contents of [] (not including []'s), and converts to a set.
+func (p *parser) scanCharSet(caseInsensitive, scanOnly bool) (*CharSet, error) {
+	ch := '\x00'
+	chPrev := '\x00'
+	inRange := false
+	firstChar := true
+	closed := false
+
+	var cc *CharSet
+	if !scanOnly {
+		cc = &CharSet{}
+	}
+
+	if p.charsRight() > 0 && p.rightChar(0) == '^' {
+		p.moveRight(1)
+		if !scanOnly {
+			cc.negate = true
+		}
+	}
+
+	for ; p.charsRight() > 0; firstChar = false {
+		fTranslatedChar := false
+		ch = p.moveRightGetChar()
+		if ch == ']' {
+			if !firstChar {
+				closed = true
+				break
+			} else if p.useOptionE() {
+				if !scanOnly {
+					cc.addRanges(NoneClass().ranges)
+				}
+				closed = true
+				break
+			}
+
+		} else if ch == '\\' && p.charsRight() > 0 {
+			switch ch = p.moveRightGetChar(); ch {
+			case 'D', 'd':
+				if !scanOnly {
+					if inRange {
+						return nil, p.getErr(ErrBadClassInCharRange, ch)
+					}
+					cc.addDigit(p.useOptionE() || p.useRE2(), ch == 'D', p.patternRaw)
+				}
+				continue
+
+			case 'S', 's':
+				if !scanOnly {
+					if inRange {
+						return nil, p.getErr(ErrBadClassInCharRange, ch)
+					}
+					cc.addSpace(p.useOptionE(), p.useRE2(), ch == 'S')
+				}
+				continue
+
+			case 'W', 'w':
+				if !scanOnly {
+					if inRange {
+						return nil, p.getErr(ErrBadClassInCharRange, ch)
+					}
+
+					cc.addWord(p.useOptionE() || p.useRE2(), ch == 'W')
+				}
+				continue
+
+			case 'p', 'P':
+				if !scanOnly {
+					if inRange {
+						return nil, p.getErr(ErrBadClassInCharRange, ch)
+					}
+					prop, err := p.parseProperty()
+					if err != nil {
+						return nil, err
+					}
+					cc.addCategory(prop, (ch != 'p'), caseInsensitive, p.patternRaw)
+				} else {
+					p.parseProperty()
+				}
+
+				continue
+
+			case '-':
+				if !scanOnly {
+					cc.addRange(ch, ch)
+				}
+				continue
+
+			default:
+				p.moveLeft()
+				var err error
+				ch, err = p.scanCharEscape() // non-literal character
+				if err != nil {
+					return nil, err
+				}
+				fTranslatedChar = true
+				break // this break will only break out of the switch
+			}
+		} else if ch == '[' {
+			// This is code for Posix style properties - [:Ll:] or [:IsTibetan:].
+			// It currently doesn't do anything other than skip the whole thing!
+			if p.charsRight() > 0 && p.rightChar(0) == ':' && !inRange {
+				savePos := p.textpos()
+
+				p.moveRight(1)
+				negate := false
+				if p.charsRight() > 1 && p.rightChar(0) == '^' {
+					negate = true
+					p.moveRight(1)
+				}
+
+				nm := p.scanCapname() // snag the name
+				if !scanOnly && p.useRE2() {
+					// look up the name since these are valid for RE2
+					// add the group based on the name
+					if ok := cc.addNamedASCII(nm, negate); !ok {
+						return nil, p.getErr(ErrInvalidCharRange)
+					}
+				}
+				if p.charsRight() < 2 || p.moveRightGetChar() != ':' || p.moveRightGetChar() != ']' {
+					p.textto(savePos)
+				} else if p.useRE2() {
+					// move on
+					continue
+				}
+			}
+		}
+
+		if inRange {
+			inRange = false
+			if !scanOnly {
+				if ch == '[' && !fTranslatedChar && !firstChar {
+					// We thought we were in a range, but we're actually starting a subtraction.
+					// In that case, we'll add chPrev to our char class, skip the opening [, and
+					// scan the new character class recursively.
+					cc.addChar(chPrev)
+					sub, err := p.scanCharSet(caseInsensitive, false)
+					if err != nil {
+						return nil, err
+					}
+					cc.addSubtraction(sub)
+
+					if p.charsRight() > 0 && p.rightChar(0) != ']' {
+						return nil, p.getErr(ErrSubtractionMustBeLast)
+					}
+				} else {
+					// a regular range, like a-z
+					if chPrev > ch {
+						return nil, p.getErr(ErrReversedCharRange, chPrev, ch)
+					}
+					cc.addRange(chPrev, ch)
+				}
+			}
+		} else if p.charsRight() >= 2 && p.rightChar(0) == '-' && p.rightChar(1) != ']' {
+			// this could be the start of a range
+			chPrev = ch
+			inRange = true
+			p.moveRight(1)
+		} else if p.charsRight() >= 1 && ch == '-' && !fTranslatedChar && p.rightChar(0) == '[' && !firstChar {
+			// we aren't in a range, and now there is a subtraction.  Usually this happens
+			// only when a subtraction follows a range, like [a-z-[b]]
+			if !scanOnly {
+				p.moveRight(1)
+				sub, err := p.scanCharSet(caseInsensitive, false)
+				if err != nil {
+					return nil, err
+				}
+				cc.addSubtraction(sub)
+
+				if p.charsRight() > 0 && p.rightChar(0) != ']' {
+					return nil, p.getErr(ErrSubtractionMustBeLast)
+				}
+			} else {
+				p.moveRight(1)
+				p.scanCharSet(caseInsensitive, true)
+			}
+		} else {
+			if !scanOnly {
+				cc.addRange(ch, ch)
+			}
+		}
+	}
+
+	if !closed {
+		return nil, p.getErr(ErrUnterminatedBracket)
+	}
+
+	if !scanOnly && caseInsensitive {
+		cc.addLowercase()
+	}
+
+	return cc, nil
+}
+
+// Scans any number of decimal digits (pegs value at 2^31-1 if too large)
+func (p *parser) scanDecimal() (int, error) {
+	i := 0
+	var d int
+
+	for p.charsRight() > 0 {
+		d = int(p.rightChar(0) - '0')
+		if d < 0 || d > 9 {
+			break
+		}
+		p.moveRight(1)
+
+		if i > maxValueDiv10 || (i == maxValueDiv10 && d > maxValueMod10) {
+			return 0, p.getErr(ErrCaptureGroupOutOfRange)
+		}
+
+		i *= 10
+		i += d
+	}
+
+	return int(i), nil
+}
+
+// Returns true for options allowed only at the top level
+func isOnlyTopOption(option RegexOptions) bool {
+	return option == RightToLeft || option == ECMAScript || option == RE2
+}
+
+// Scans cimsx-cimsx option string, stops at the first unrecognized char.
+func (p *parser) scanOptions() {
+
+	for off := false; p.charsRight() > 0; p.moveRight(1) {
+		ch := p.rightChar(0)
+
+		if ch == '-' {
+			off = true
+		} else if ch == '+' {
+			off = false
+		} else {
+			option := optionFromCode(ch)
+			if option == 0 || isOnlyTopOption(option) {
+				return
+			}
+
+			if off {
+				p.options &= ^option
+			} else {
+				p.options |= option
+			}
+		}
+	}
+}
+
+// Scans \ code for escape codes that map to single unicode chars.
+func (p *parser) scanCharEscape() (r rune, err error) {
+
+	ch := p.moveRightGetChar()
+
+	if ch >= '0' && ch <= '7' {
+		p.moveLeft()
+		return p.scanOctal(), nil
+	}
+
+	pos := p.textpos()
+
+	switch ch {
+	case 'x':
+		// support for \x{HEX} syntax from Perl and PCRE
+		if p.charsRight() > 0 && p.rightChar(0) == '{' {
+			if p.useOptionE() {
+				return ch, nil
+			}
+			p.moveRight(1)
+			return p.scanHexUntilBrace()
+		} else {
+			r, err = p.scanHex(2)
+		}
+	case 'u':
+		// ECMAscript suppot \u{HEX} only if `u` is also set
+		if p.useOptionE() && p.useOptionU() && p.charsRight() > 0 && p.rightChar(0) == '{' {
+			p.moveRight(1)
+			return p.scanHexUntilBrace()
+		} else {
+			r, err = p.scanHex(4)
+		}
+	case 'a':
+		return '\u0007', nil
+	case 'b':
+		return '\b', nil
+	case 'e':
+		return '\u001B', nil
+	case 'f':
+		return '\f', nil
+	case 'n':
+		return '\n', nil
+	case 'r':
+		return '\r', nil
+	case 't':
+		return '\t', nil
+	case 'v':
+		return '\u000B', nil
+	case 'c':
+		r, err = p.scanControl()
+	default:
+		if !p.useOptionE() && !p.useRE2() && IsWordChar(ch) {
+			return 0, p.getErr(ErrUnrecognizedEscape, string(ch))
+		}
+		return ch, nil
+	}
+	if err != nil && p.useOptionE() {
+		p.textto(pos)
+		return ch, nil
+	}
+	return
+}
+
+// Grabs and converts an ascii control character
+func (p *parser) scanControl() (rune, error) {
+	if p.charsRight() <= 0 {
+		return 0, p.getErr(ErrMissingControl)
+	}
+
+	ch := p.moveRightGetChar()
+
+	// \ca interpreted as \cA
+
+	if ch >= 'a' && ch <= 'z' {
+		ch = (ch - ('a' - 'A'))
+	}
+	ch = (ch - '@')
+	if ch >= 0 && ch < ' ' {
+		return ch, nil
+	}
+
+	return 0, p.getErr(ErrUnrecognizedControl)
+
+}
+
+// Scan hex digits until we hit a closing brace.
+// Non-hex digits, hex value too large for UTF-8, or running out of chars are errors
+func (p *parser) scanHexUntilBrace() (rune, error) {
+	// PCRE spec reads like unlimited hex digits are allowed, but unicode has a limit
+	// so we can enforce that
+	i := 0
+	hasContent := false
+
+	for p.charsRight() > 0 {
+		ch := p.moveRightGetChar()
+		if ch == '}' {
+			// hit our close brace, we're done here
+			// prevent \x{}
+			if !hasContent {
+				return 0, p.getErr(ErrTooFewHex)
+			}
+			return rune(i), nil
+		}
+		hasContent = true
+		// no brace needs to be hex digit
+		d := hexDigit(ch)
+		if d < 0 {
+			return 0, p.getErr(ErrMissingBrace)
+		}
+
+		i *= 0x10
+		i += d
+
+		if i > unicode.MaxRune {
+			return 0, p.getErr(ErrInvalidHex)
+		}
+	}
+
+	// we only make it here if we run out of digits without finding the brace
+	return 0, p.getErr(ErrMissingBrace)
+}
+
+// Scans exactly c hex digits (c=2 for \xFF, c=4 for \uFFFF)
+func (p *parser) scanHex(c int) (rune, error) {
+
+	i := 0
+
+	if p.charsRight() >= c {
+		for c > 0 {
+			d := hexDigit(p.moveRightGetChar())
+			if d < 0 {
+				break
+			}
+			i *= 0x10
+			i += d
+			c--
+		}
+	}
+
+	if c > 0 {
+		return 0, p.getErr(ErrTooFewHex)
+	}
+
+	return rune(i), nil
+}
+
+// Returns n <= 0xF for a hex digit.
+func hexDigit(ch rune) int {
+
+	if d := uint(ch - '0'); d <= 9 {
+		return int(d)
+	}
+
+	if d := uint(ch - 'a'); d <= 5 {
+		return int(d + 0xa)
+	}
+
+	if d := uint(ch - 'A'); d <= 5 {
+		return int(d + 0xa)
+	}
+
+	return -1
+}
+
+// Scans up to three octal digits (stops before exceeding 0377).
+func (p *parser) scanOctal() rune {
+	// Consume octal chars only up to 3 digits and value 0377
+
+	c := 3
+
+	if c > p.charsRight() {
+		c = p.charsRight()
+	}
+
+	//we know the first char is good because the caller had to check
+	i := 0
+	d := int(p.rightChar(0) - '0')
+	for c > 0 && d <= 7 && d >= 0 {
+		if i >= 0x20 && p.useOptionE() {
+			break
+		}
+		i *= 8
+		i += d
+		c--
+
+		p.moveRight(1)
+		if !p.rightMost() {
+			d = int(p.rightChar(0) - '0')
+		}
+	}
+
+	// Octal codes only go up to 255.  Any larger and the behavior that Perl follows
+	// is simply to truncate the high bits.
+	i &= 0xFF
+
+	return rune(i)
+}
+
+// Returns the current parsing position.
+func (p *parser) textpos() int {
+	return p.currentPos
+}
+
+// Zaps to a specific parsing position.
+func (p *parser) textto(pos int) {
+	p.currentPos = pos
+}
+
+// Returns the char at the right of the current parsing position and advances to the right.
+func (p *parser) moveRightGetChar() rune {
+	ch := p.pattern[p.currentPos]
+	p.currentPos++
+	return ch
+}
+
+// Moves the current position to the right.
+func (p *parser) moveRight(i int) {
+	// default would be 1
+	p.currentPos += i
+}
+
+// Moves the current parsing position one to the left.
+func (p *parser) moveLeft() {
+	p.currentPos--
+}
+
+// Returns the char left of the current parsing position.
+func (p *parser) charAt(i int) rune {
+	return p.pattern[i]
+}
+
+// Returns the char i chars right of the current parsing position.
+func (p *parser) rightChar(i int) rune {
+	// default would be 0
+	return p.pattern[p.currentPos+i]
+}
+
+// Number of characters to the right of the current parsing position.
+func (p *parser) charsRight() int {
+	return len(p.pattern) - p.currentPos
+}
+
+func (p *parser) rightMost() bool {
+	return p.currentPos == len(p.pattern)
+}
+
+// Looks up the slot number for a given name
+func (p *parser) captureSlotFromName(capname string) int {
+	return p.capnames[capname]
+}
+
+// True if the capture slot was noted
+func (p *parser) isCaptureSlot(i int) bool {
+	if p.caps != nil {
+		_, ok := p.caps[i]
+		return ok
+	}
+
+	return (i >= 0 && i < p.capsize)
+}
+
+// Looks up the slot number for a given name
+func (p *parser) isCaptureName(capname string) bool {
+	if p.capnames == nil {
+		return false
+	}
+
+	_, ok := p.capnames[capname]
+	return ok
+}
+
+// option shortcuts
+
+// True if N option disabling '(' autocapture is on.
+func (p *parser) useOptionN() bool {
+	return (p.options & ExplicitCapture) != 0
+}
+
+// True if I option enabling case-insensitivity is on.
+func (p *parser) useOptionI() bool {
+	return (p.options & IgnoreCase) != 0
+}
+
+// True if M option altering meaning of $ and ^ is on.
+func (p *parser) useOptionM() bool {
+	return (p.options & Multiline) != 0
+}
+
+// True if S option altering meaning of . is on.
+func (p *parser) useOptionS() bool {
+	return (p.options & Singleline) != 0
+}
+
+// True if X option enabling whitespace/comment mode is on.
+func (p *parser) useOptionX() bool {
+	return (p.options & IgnorePatternWhitespace) != 0
+}
+
+// True if E option enabling ECMAScript behavior on.
+func (p *parser) useOptionE() bool {
+	return (p.options & ECMAScript) != 0
+}
+
+// true to use RE2 compatibility parsing behavior.
+func (p *parser) useRE2() bool {
+	return (p.options & RE2) != 0
+}
+
+// True if U option enabling ECMAScript's Unicode behavior on.
+func (p *parser) useOptionU() bool {
+	return (p.options & Unicode) != 0
+}
+
+// True if options stack is empty.
+func (p *parser) emptyOptionsStack() bool {
+	return len(p.optionsStack) == 0
+}
+
+// Finish the current quantifiable (when a quantifier is not found or is not possible)
+func (p *parser) addConcatenate() {
+	// The first (| inside a Testgroup group goes directly to the group
+	p.concatenation.addChild(p.unit)
+	p.unit = nil
+}
+
+// Finish the current quantifiable (when a quantifier is found)
+func (p *parser) addConcatenate3(lazy bool, min, max int) {
+	p.concatenation.addChild(p.unit.makeQuantifier(lazy, min, max))
+	p.unit = nil
+}
+
+// Sets the current unit to a single char node
+func (p *parser) addUnitOne(ch rune) {
+	if p.useOptionI() {
+		ch = unicode.ToLower(ch)
+	}
+
+	p.unit = newRegexNodeCh(ntOne, p.options, ch)
+}
+
+// Sets the current unit to a single inverse-char node
+func (p *parser) addUnitNotone(ch rune) {
+	if p.useOptionI() {
+		ch = unicode.ToLower(ch)
+	}
+
+	p.unit = newRegexNodeCh(ntNotone, p.options, ch)
+}
+
+// Sets the current unit to a single set node
+func (p *parser) addUnitSet(set *CharSet) {
+	p.unit = newRegexNodeSet(ntSet, p.options, set)
+}
+
+// Sets the current unit to a subtree
+func (p *parser) addUnitNode(node *regexNode) {
+	p.unit = node
+}
+
+// Sets the current unit to an assertion of the specified type
+func (p *parser) addUnitType(t nodeType) {
+	p.unit = newRegexNode(t, p.options)
+}
+
+// Finish the current group (in response to a ')' or end)
+func (p *parser) addGroup() error {
+	if p.group.t == ntTestgroup || p.group.t == ntTestref {
+		p.group.addChild(p.concatenation.reverseLeft())
+		if (p.group.t == ntTestref && len(p.group.children) > 2) || len(p.group.children) > 3 {
+			return p.getErr(ErrTooManyAlternates)
+		}
+	} else {
+		p.alternation.addChild(p.concatenation.reverseLeft())
+		p.group.addChild(p.alternation)
+	}
+
+	p.unit = p.group
+	return nil
+}
+
+// Pops the option stack, but keeps the current options unchanged.
+func (p *parser) popKeepOptions() {
+	lastIdx := len(p.optionsStack) - 1
+	p.optionsStack = p.optionsStack[:lastIdx]
+}
+
+// Recalls options from the stack.
+func (p *parser) popOptions() {
+	lastIdx := len(p.optionsStack) - 1
+	// get the last item on the stack and then remove it by reslicing
+	p.options = p.optionsStack[lastIdx]
+	p.optionsStack = p.optionsStack[:lastIdx]
+}
+
+// Saves options on a stack.
+func (p *parser) pushOptions() {
+	p.optionsStack = append(p.optionsStack, p.options)
+}
+
+// Add a string to the last concatenate.
+func (p *parser) addToConcatenate(pos, cch int, isReplacement bool) {
+	var node *regexNode
+
+	if cch == 0 {
+		return
+	}
+
+	if cch > 1 {
+		str := make([]rune, cch)
+		copy(str, p.pattern[pos:pos+cch])
+
+		if p.useOptionI() && !isReplacement {
+			// We do the ToLower character by character for consistency.  With surrogate chars, doing
+			// a ToLower on the entire string could actually change the surrogate pair.  This is more correct
+			// linguistically, but since Regex doesn't support surrogates, it's more important to be
+			// consistent.
+			for i := 0; i < len(str); i++ {
+				str[i] = unicode.ToLower(str[i])
+			}
+		}
+
+		node = newRegexNodeStr(ntMulti, p.options, str)
+	} else {
+		ch := p.charAt(pos)
+
+		if p.useOptionI() && !isReplacement {
+			ch = unicode.ToLower(ch)
+		}
+
+		node = newRegexNodeCh(ntOne, p.options, ch)
+	}
+
+	p.concatenation.addChild(node)
+}
+
+// Push the parser state (in response to an open paren)
+func (p *parser) pushGroup() {
+	p.group.next = p.stack
+	p.alternation.next = p.group
+	p.concatenation.next = p.alternation
+	p.stack = p.concatenation
+}
+
+// Remember the pushed state (in response to a ')')
+func (p *parser) popGroup() error {
+	p.concatenation = p.stack
+	p.alternation = p.concatenation.next
+	p.group = p.alternation.next
+	p.stack = p.group.next
+
+	// The first () inside a Testgroup group goes directly to the group
+	if p.group.t == ntTestgroup && len(p.group.children) == 0 {
+		if p.unit == nil {
+			return p.getErr(ErrConditionalExpression)
+		}
+
+		p.group.addChild(p.unit)
+		p.unit = nil
+	}
+	return nil
+}
+
+// True if the group stack is empty.
+func (p *parser) emptyStack() bool {
+	return p.stack == nil
+}
+
+// Start a new round for the parser state (in response to an open paren or string start)
+func (p *parser) startGroup(openGroup *regexNode) {
+	p.group = openGroup
+	p.alternation = newRegexNode(ntAlternate, p.options)
+	p.concatenation = newRegexNode(ntConcatenate, p.options)
+}
+
+// Finish the current concatenation (in response to a |)
+func (p *parser) addAlternate() {
+	// The | parts inside a Testgroup group go directly to the group
+
+	if p.group.t == ntTestgroup || p.group.t == ntTestref {
+		p.group.addChild(p.concatenation.reverseLeft())
+	} else {
+		p.alternation.addChild(p.concatenation.reverseLeft())
+	}
+
+	p.concatenation = newRegexNode(ntConcatenate, p.options)
+}
+
+// For categorizing ascii characters.
+
+const (
+	Q byte = 5 // quantifier
+	S      = 4 // ordinary stopper
+	Z      = 3 // ScanBlank stopper
+	X      = 2 // whitespace
+	E      = 1 // should be escaped
+)
+
+var _category = []byte{
+	//01  2  3  4  5  6  7  8  9  A  B  C  D  E  F  0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F
+	0, 0, 0, 0, 0, 0, 0, 0, 0, X, X, X, X, X, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	// !  "  #  $  %  &  '  (  )  *  +  ,  -  .  /  0  1  2  3  4  5  6  7  8  9  :  ;  <  =  >  ?
+	X, 0, 0, Z, S, 0, 0, 0, S, S, Q, Q, 0, 0, S, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, Q,
+	//@A  B  C  D  E  F  G  H  I  J  K  L  M  N  O  P  Q  R  S  T  U  V  W  X  Y  Z  [  \  ]  ^  _
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, S, S, 0, S, 0,
+	//'a  b  c  d  e  f  g  h  i  j  k  l  m  n  o  p  q  r  s  t  u  v  w  x  y  z  {  |  }  ~
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, Q, S, 0, 0, 0,
+}
+
+func isSpace(ch rune) bool {
+	return (ch <= ' ' && _category[ch] == X)
+}
+
+// Returns true for those characters that terminate a string of ordinary chars.
+func isSpecial(ch rune) bool {
+	return (ch <= '|' && _category[ch] >= S)
+}
+
+// Returns true for those characters that terminate a string of ordinary chars.
+func isStopperX(ch rune) bool {
+	return (ch <= '|' && _category[ch] >= X)
+}
+
+// Returns true for those characters that begin a quantifier.
+func isQuantifier(ch rune) bool {
+	return (ch <= '{' && _category[ch] >= Q)
+}
+
+func (p *parser) isTrueQuantifier() bool {
+	nChars := p.charsRight()
+	if nChars == 0 {
+		return false
+	}
+
+	startpos := p.textpos()
+	ch := p.charAt(startpos)
+	if ch != '{' {
+		return ch <= '{' && _category[ch] >= Q
+	}
+
+	//UGLY: this is ugly -- the original code was ugly too
+	pos := startpos
+	for {
+		nChars--
+		if nChars <= 0 {
+			break
+		}
+		pos++
+		ch = p.charAt(pos)
+		if ch < '0' || ch > '9' {
+			break
+		}
+	}
+
+	if nChars == 0 || pos-startpos == 1 {
+		return false
+	}
+	if ch == '}' {
+		return true
+	}
+	if ch != ',' {
+		return false
+	}
+	for {
+		nChars--
+		if nChars <= 0 {
+			break
+		}
+		pos++
+		ch = p.charAt(pos)
+		if ch < '0' || ch > '9' {
+			break
+		}
+	}
+
+	return nChars > 0 && ch == '}'
+}

--- a/vendor/github.com/dlclark/regexp2/syntax/prefix.go
+++ b/vendor/github.com/dlclark/regexp2/syntax/prefix.go
@@ -1,0 +1,896 @@
+package syntax
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"unicode"
+	"unicode/utf8"
+)
+
+type Prefix struct {
+	PrefixStr       []rune
+	PrefixSet       CharSet
+	CaseInsensitive bool
+}
+
+// It takes a RegexTree and computes the set of chars that can start it.
+func getFirstCharsPrefix(tree *RegexTree) *Prefix {
+	s := regexFcd{
+		fcStack:  make([]regexFc, 32),
+		intStack: make([]int, 32),
+	}
+	fc := s.regexFCFromRegexTree(tree)
+
+	if fc == nil || fc.nullable || fc.cc.IsEmpty() {
+		return nil
+	}
+	fcSet := fc.getFirstChars()
+	return &Prefix{PrefixSet: fcSet, CaseInsensitive: fc.caseInsensitive}
+}
+
+type regexFcd struct {
+	intStack        []int
+	intDepth        int
+	fcStack         []regexFc
+	fcDepth         int
+	skipAllChildren bool // don't process any more children at the current level
+	skipchild       bool // don't process the current child.
+	failed          bool
+}
+
+/*
+ * The main FC computation. It does a shortcutted depth-first walk
+ * through the tree and calls CalculateFC to emits code before
+ * and after each child of an interior node, and at each leaf.
+ */
+func (s *regexFcd) regexFCFromRegexTree(tree *RegexTree) *regexFc {
+	curNode := tree.root
+	curChild := 0
+
+	for {
+		if len(curNode.children) == 0 {
+			// This is a leaf node
+			s.calculateFC(curNode.t, curNode, 0)
+		} else if curChild < len(curNode.children) && !s.skipAllChildren {
+			// This is an interior node, and we have more children to analyze
+			s.calculateFC(curNode.t|beforeChild, curNode, curChild)
+
+			if !s.skipchild {
+				curNode = curNode.children[curChild]
+				// this stack is how we get a depth first walk of the tree.
+				s.pushInt(curChild)
+				curChild = 0
+			} else {
+				curChild++
+				s.skipchild = false
+			}
+			continue
+		}
+
+		// This is an interior node where we've finished analyzing all the children, or
+		// the end of a leaf node.
+		s.skipAllChildren = false
+
+		if s.intIsEmpty() {
+			break
+		}
+
+		curChild = s.popInt()
+		curNode = curNode.next
+
+		s.calculateFC(curNode.t|afterChild, curNode, curChild)
+		if s.failed {
+			return nil
+		}
+
+		curChild++
+	}
+
+	if s.fcIsEmpty() {
+		return nil
+	}
+
+	return s.popFC()
+}
+
+// To avoid recursion, we use a simple integer stack.
+// This is the push.
+func (s *regexFcd) pushInt(I int) {
+	if s.intDepth >= len(s.intStack) {
+		expanded := make([]int, s.intDepth*2)
+		copy(expanded, s.intStack)
+		s.intStack = expanded
+	}
+
+	s.intStack[s.intDepth] = I
+	s.intDepth++
+}
+
+// True if the stack is empty.
+func (s *regexFcd) intIsEmpty() bool {
+	return s.intDepth == 0
+}
+
+// This is the pop.
+func (s *regexFcd) popInt() int {
+	s.intDepth--
+	return s.intStack[s.intDepth]
+}
+
+// We also use a stack of RegexFC objects.
+// This is the push.
+func (s *regexFcd) pushFC(fc regexFc) {
+	if s.fcDepth >= len(s.fcStack) {
+		expanded := make([]regexFc, s.fcDepth*2)
+		copy(expanded, s.fcStack)
+		s.fcStack = expanded
+	}
+
+	s.fcStack[s.fcDepth] = fc
+	s.fcDepth++
+}
+
+// True if the stack is empty.
+func (s *regexFcd) fcIsEmpty() bool {
+	return s.fcDepth == 0
+}
+
+// This is the pop.
+func (s *regexFcd) popFC() *regexFc {
+	s.fcDepth--
+	return &s.fcStack[s.fcDepth]
+}
+
+// This is the top.
+func (s *regexFcd) topFC() *regexFc {
+	return &s.fcStack[s.fcDepth-1]
+}
+
+// Called in Beforechild to prevent further processing of the current child
+func (s *regexFcd) skipChild() {
+	s.skipchild = true
+}
+
+// FC computation and shortcut cases for each node type
+func (s *regexFcd) calculateFC(nt nodeType, node *regexNode, CurIndex int) {
+	//fmt.Printf("NodeType: %v, CurIndex: %v, Desc: %v\n", nt, CurIndex, node.description())
+	ci := false
+	rtl := false
+
+	if nt <= ntRef {
+		if (node.options & IgnoreCase) != 0 {
+			ci = true
+		}
+		if (node.options & RightToLeft) != 0 {
+			rtl = true
+		}
+	}
+
+	switch nt {
+	case ntConcatenate | beforeChild, ntAlternate | beforeChild, ntTestref | beforeChild, ntLoop | beforeChild, ntLazyloop | beforeChild:
+		break
+
+	case ntTestgroup | beforeChild:
+		if CurIndex == 0 {
+			s.skipChild()
+		}
+		break
+
+	case ntEmpty:
+		s.pushFC(regexFc{nullable: true})
+		break
+
+	case ntConcatenate | afterChild:
+		if CurIndex != 0 {
+			child := s.popFC()
+			cumul := s.topFC()
+
+			s.failed = !cumul.addFC(*child, true)
+		}
+
+		fc := s.topFC()
+		if !fc.nullable {
+			s.skipAllChildren = true
+		}
+		break
+
+	case ntTestgroup | afterChild:
+		if CurIndex > 1 {
+			child := s.popFC()
+			cumul := s.topFC()
+
+			s.failed = !cumul.addFC(*child, false)
+		}
+		break
+
+	case ntAlternate | afterChild, ntTestref | afterChild:
+		if CurIndex != 0 {
+			child := s.popFC()
+			cumul := s.topFC()
+
+			s.failed = !cumul.addFC(*child, false)
+		}
+		break
+
+	case ntLoop | afterChild, ntLazyloop | afterChild:
+		if node.m == 0 {
+			fc := s.topFC()
+			fc.nullable = true
+		}
+		break
+
+	case ntGroup | beforeChild, ntGroup | afterChild, ntCapture | beforeChild, ntCapture | afterChild, ntGreedy | beforeChild, ntGreedy | afterChild:
+		break
+
+	case ntRequire | beforeChild, ntPrevent | beforeChild:
+		s.skipChild()
+		s.pushFC(regexFc{nullable: true})
+		break
+
+	case ntRequire | afterChild, ntPrevent | afterChild:
+		break
+
+	case ntOne, ntNotone:
+		s.pushFC(newRegexFc(node.ch, nt == ntNotone, false, ci))
+		break
+
+	case ntOneloop, ntOnelazy:
+		s.pushFC(newRegexFc(node.ch, false, node.m == 0, ci))
+		break
+
+	case ntNotoneloop, ntNotonelazy:
+		s.pushFC(newRegexFc(node.ch, true, node.m == 0, ci))
+		break
+
+	case ntMulti:
+		if len(node.str) == 0 {
+			s.pushFC(regexFc{nullable: true})
+		} else if !rtl {
+			s.pushFC(newRegexFc(node.str[0], false, false, ci))
+		} else {
+			s.pushFC(newRegexFc(node.str[len(node.str)-1], false, false, ci))
+		}
+		break
+
+	case ntSet:
+		s.pushFC(regexFc{cc: node.set.Copy(), nullable: false, caseInsensitive: ci})
+		break
+
+	case ntSetloop, ntSetlazy:
+		s.pushFC(regexFc{cc: node.set.Copy(), nullable: node.m == 0, caseInsensitive: ci})
+		break
+
+	case ntRef:
+		s.pushFC(regexFc{cc: *AnyClass(), nullable: true, caseInsensitive: false})
+		break
+
+	case ntNothing, ntBol, ntEol, ntBoundary, ntNonboundary, ntECMABoundary, ntNonECMABoundary, ntBeginning, ntStart, ntEndZ, ntEnd:
+		s.pushFC(regexFc{nullable: true})
+		break
+
+	default:
+		panic(fmt.Sprintf("unexpected op code: %v", nt))
+	}
+}
+
+type regexFc struct {
+	cc              CharSet
+	nullable        bool
+	caseInsensitive bool
+}
+
+func newRegexFc(ch rune, not, nullable, caseInsensitive bool) regexFc {
+	r := regexFc{
+		caseInsensitive: caseInsensitive,
+		nullable:        nullable,
+	}
+	if not {
+		if ch > 0 {
+			r.cc.addRange('\x00', ch-1)
+		}
+		if ch < 0xFFFF {
+			r.cc.addRange(ch+1, utf8.MaxRune)
+		}
+	} else {
+		r.cc.addRange(ch, ch)
+	}
+	return r
+}
+
+func (r *regexFc) getFirstChars() CharSet {
+	if r.caseInsensitive {
+		r.cc.addLowercase()
+	}
+
+	return r.cc
+}
+
+func (r *regexFc) addFC(fc regexFc, concatenate bool) bool {
+	if !r.cc.IsMergeable() || !fc.cc.IsMergeable() {
+		return false
+	}
+
+	if concatenate {
+		if !r.nullable {
+			return true
+		}
+
+		if !fc.nullable {
+			r.nullable = false
+		}
+	} else {
+		if fc.nullable {
+			r.nullable = true
+		}
+	}
+
+	r.caseInsensitive = r.caseInsensitive || fc.caseInsensitive
+	r.cc.addSet(fc.cc)
+
+	return true
+}
+
+// This is a related computation: it takes a RegexTree and computes the
+// leading substring if it sees one. It's quite trivial and gives up easily.
+func getPrefix(tree *RegexTree) *Prefix {
+	var concatNode *regexNode
+	nextChild := 0
+
+	curNode := tree.root
+
+	for {
+		switch curNode.t {
+		case ntConcatenate:
+			if len(curNode.children) > 0 {
+				concatNode = curNode
+				nextChild = 0
+			}
+
+		case ntGreedy, ntCapture:
+			curNode = curNode.children[0]
+			concatNode = nil
+			continue
+
+		case ntOneloop, ntOnelazy:
+			if curNode.m > 0 {
+				return &Prefix{
+					PrefixStr:       repeat(curNode.ch, curNode.m),
+					CaseInsensitive: (curNode.options & IgnoreCase) != 0,
+				}
+			}
+			return nil
+
+		case ntOne:
+			return &Prefix{
+				PrefixStr:       []rune{curNode.ch},
+				CaseInsensitive: (curNode.options & IgnoreCase) != 0,
+			}
+
+		case ntMulti:
+			return &Prefix{
+				PrefixStr:       curNode.str,
+				CaseInsensitive: (curNode.options & IgnoreCase) != 0,
+			}
+
+		case ntBol, ntEol, ntBoundary, ntECMABoundary, ntBeginning, ntStart,
+			ntEndZ, ntEnd, ntEmpty, ntRequire, ntPrevent:
+
+		default:
+			return nil
+		}
+
+		if concatNode == nil || nextChild >= len(concatNode.children) {
+			return nil
+		}
+
+		curNode = concatNode.children[nextChild]
+		nextChild++
+	}
+}
+
+// repeat the rune r, c times... up to the max of MaxPrefixSize
+func repeat(r rune, c int) []rune {
+	if c > MaxPrefixSize {
+		c = MaxPrefixSize
+	}
+
+	ret := make([]rune, c)
+
+	// binary growth using copy for speed
+	ret[0] = r
+	bp := 1
+	for bp < len(ret) {
+		copy(ret[bp:], ret[:bp])
+		bp *= 2
+	}
+
+	return ret
+}
+
+// BmPrefix precomputes the Boyer-Moore
+// tables for fast string scanning. These tables allow
+// you to scan for the first occurrence of a string within
+// a large body of text without examining every character.
+// The performance of the heuristic depends on the actual
+// string and the text being searched, but usually, the longer
+// the string that is being searched for, the fewer characters
+// need to be examined.
+type BmPrefix struct {
+	positive        []int
+	negativeASCII   []int
+	negativeUnicode [][]int
+	pattern         []rune
+	lowASCII        rune
+	highASCII       rune
+	rightToLeft     bool
+	caseInsensitive bool
+}
+
+func newBmPrefix(pattern []rune, caseInsensitive, rightToLeft bool) *BmPrefix {
+
+	b := &BmPrefix{
+		rightToLeft:     rightToLeft,
+		caseInsensitive: caseInsensitive,
+		pattern:         pattern,
+	}
+
+	if caseInsensitive {
+		for i := 0; i < len(b.pattern); i++ {
+			// We do the ToLower character by character for consistency.  With surrogate chars, doing
+			// a ToLower on the entire string could actually change the surrogate pair.  This is more correct
+			// linguistically, but since Regex doesn't support surrogates, it's more important to be
+			// consistent.
+
+			b.pattern[i] = unicode.ToLower(b.pattern[i])
+		}
+	}
+
+	var beforefirst, last, bump int
+	var scan, match int
+
+	if !rightToLeft {
+		beforefirst = -1
+		last = len(b.pattern) - 1
+		bump = 1
+	} else {
+		beforefirst = len(b.pattern)
+		last = 0
+		bump = -1
+	}
+
+	// PART I - the good-suffix shift table
+	//
+	// compute the positive requirement:
+	// if char "i" is the first one from the right that doesn't match,
+	// then we know the matcher can advance by _positive[i].
+	//
+	// This algorithm is a simplified variant of the standard
+	// Boyer-Moore good suffix calculation.
+
+	b.positive = make([]int, len(b.pattern))
+
+	examine := last
+	ch := b.pattern[examine]
+	b.positive[examine] = bump
+	examine -= bump
+
+Outerloop:
+	for {
+		// find an internal char (examine) that matches the tail
+
+		for {
+			if examine == beforefirst {
+				break Outerloop
+			}
+			if b.pattern[examine] == ch {
+				break
+			}
+			examine -= bump
+		}
+
+		match = last
+		scan = examine
+
+		// find the length of the match
+		for {
+			if scan == beforefirst || b.pattern[match] != b.pattern[scan] {
+				// at the end of the match, note the difference in _positive
+				// this is not the length of the match, but the distance from the internal match
+				// to the tail suffix.
+				if b.positive[match] == 0 {
+					b.positive[match] = match - scan
+				}
+
+				// System.Diagnostics.Debug.WriteLine("Set positive[" + match + "] to " + (match - scan));
+
+				break
+			}
+
+			scan -= bump
+			match -= bump
+		}
+
+		examine -= bump
+	}
+
+	match = last - bump
+
+	// scan for the chars for which there are no shifts that yield a different candidate
+
+	// The inside of the if statement used to say
+	// "_positive[match] = last - beforefirst;"
+	// This is slightly less aggressive in how much we skip, but at worst it
+	// should mean a little more work rather than skipping a potential match.
+	for match != beforefirst {
+		if b.positive[match] == 0 {
+			b.positive[match] = bump
+		}
+
+		match -= bump
+	}
+
+	// PART II - the bad-character shift table
+	//
+	// compute the negative requirement:
+	// if char "ch" is the reject character when testing position "i",
+	// we can slide up by _negative[ch];
+	// (_negative[ch] = str.Length - 1 - str.LastIndexOf(ch))
+	//
+	// the lookup table is divided into ASCII and Unicode portions;
+	// only those parts of the Unicode 16-bit code set that actually
+	// appear in the string are in the table. (Maximum size with
+	// Unicode is 65K; ASCII only case is 512 bytes.)
+
+	b.negativeASCII = make([]int, 128)
+
+	for i := 0; i < len(b.negativeASCII); i++ {
+		b.negativeASCII[i] = last - beforefirst
+	}
+
+	b.lowASCII = 127
+	b.highASCII = 0
+
+	for examine = last; examine != beforefirst; examine -= bump {
+		ch = b.pattern[examine]
+
+		switch {
+		case ch < 128:
+			if b.lowASCII > ch {
+				b.lowASCII = ch
+			}
+
+			if b.highASCII < ch {
+				b.highASCII = ch
+			}
+
+			if b.negativeASCII[ch] == last-beforefirst {
+				b.negativeASCII[ch] = last - examine
+			}
+		case ch <= 0xffff:
+			i, j := ch>>8, ch&0xFF
+
+			if b.negativeUnicode == nil {
+				b.negativeUnicode = make([][]int, 256)
+			}
+
+			if b.negativeUnicode[i] == nil {
+				newarray := make([]int, 256)
+
+				for k := 0; k < len(newarray); k++ {
+					newarray[k] = last - beforefirst
+				}
+
+				if i == 0 {
+					copy(newarray, b.negativeASCII)
+					//TODO: this line needed?
+					b.negativeASCII = newarray
+				}
+
+				b.negativeUnicode[i] = newarray
+			}
+
+			if b.negativeUnicode[i][j] == last-beforefirst {
+				b.negativeUnicode[i][j] = last - examine
+			}
+		default:
+			// we can't do the filter because this algo doesn't support
+			// unicode chars >0xffff
+			return nil
+		}
+	}
+
+	return b
+}
+
+func (b *BmPrefix) String() string {
+	return string(b.pattern)
+}
+
+// Dump returns the contents of the filter as a human readable string
+func (b *BmPrefix) Dump(indent string) string {
+	buf := &bytes.Buffer{}
+
+	fmt.Fprintf(buf, "%sBM Pattern: %s\n%sPositive: ", indent, string(b.pattern), indent)
+	for i := 0; i < len(b.positive); i++ {
+		buf.WriteString(strconv.Itoa(b.positive[i]))
+		buf.WriteRune(' ')
+	}
+	buf.WriteRune('\n')
+
+	if b.negativeASCII != nil {
+		buf.WriteString(indent)
+		buf.WriteString("Negative table\n")
+		for i := 0; i < len(b.negativeASCII); i++ {
+			if b.negativeASCII[i] != len(b.pattern) {
+				fmt.Fprintf(buf, "%s  %s %s\n", indent, Escape(string(rune(i))), strconv.Itoa(b.negativeASCII[i]))
+			}
+		}
+	}
+
+	return buf.String()
+}
+
+// Scan uses the Boyer-Moore algorithm to find the first occurrence
+// of the specified string within text, beginning at index, and
+// constrained within beglimit and endlimit.
+//
+// The direction and case-sensitivity of the match is determined
+// by the arguments to the RegexBoyerMoore constructor.
+func (b *BmPrefix) Scan(text []rune, index, beglimit, endlimit int) int {
+	var (
+		defadv, test, test2         int
+		match, startmatch, endmatch int
+		bump, advance               int
+		chTest                      rune
+		unicodeLookup               []int
+	)
+
+	if !b.rightToLeft {
+		defadv = len(b.pattern)
+		startmatch = len(b.pattern) - 1
+		endmatch = 0
+		test = index + defadv - 1
+		bump = 1
+	} else {
+		defadv = -len(b.pattern)
+		startmatch = 0
+		endmatch = -defadv - 1
+		test = index + defadv
+		bump = -1
+	}
+
+	chMatch := b.pattern[startmatch]
+
+	for {
+		if test >= endlimit || test < beglimit {
+			return -1
+		}
+
+		chTest = text[test]
+
+		if b.caseInsensitive {
+			chTest = unicode.ToLower(chTest)
+		}
+
+		if chTest != chMatch {
+			if chTest < 128 {
+				advance = b.negativeASCII[chTest]
+			} else if chTest < 0xffff && len(b.negativeUnicode) > 0 {
+				unicodeLookup = b.negativeUnicode[chTest>>8]
+				if len(unicodeLookup) > 0 {
+					advance = unicodeLookup[chTest&0xFF]
+				} else {
+					advance = defadv
+				}
+			} else {
+				advance = defadv
+			}
+
+			test += advance
+		} else { // if (chTest == chMatch)
+			test2 = test
+			match = startmatch
+
+			for {
+				if match == endmatch {
+					if b.rightToLeft {
+						return test2 + 1
+					} else {
+						return test2
+					}
+				}
+
+				match -= bump
+				test2 -= bump
+
+				chTest = text[test2]
+
+				if b.caseInsensitive {
+					chTest = unicode.ToLower(chTest)
+				}
+
+				if chTest != b.pattern[match] {
+					advance = b.positive[match]
+					if chTest < 128 {
+						test2 = (match - startmatch) + b.negativeASCII[chTest]
+					} else if chTest < 0xffff && len(b.negativeUnicode) > 0 {
+						unicodeLookup = b.negativeUnicode[chTest>>8]
+						if len(unicodeLookup) > 0 {
+							test2 = (match - startmatch) + unicodeLookup[chTest&0xFF]
+						} else {
+							test += advance
+							break
+						}
+					} else {
+						test += advance
+						break
+					}
+
+					if b.rightToLeft {
+						if test2 < advance {
+							advance = test2
+						}
+					} else if test2 > advance {
+						advance = test2
+					}
+
+					test += advance
+					break
+				}
+			}
+		}
+	}
+}
+
+// When a regex is anchored, we can do a quick IsMatch test instead of a Scan
+func (b *BmPrefix) IsMatch(text []rune, index, beglimit, endlimit int) bool {
+	if !b.rightToLeft {
+		if index < beglimit || endlimit-index < len(b.pattern) {
+			return false
+		}
+
+		return b.matchPattern(text, index)
+	} else {
+		if index > endlimit || index-beglimit < len(b.pattern) {
+			return false
+		}
+
+		return b.matchPattern(text, index-len(b.pattern))
+	}
+}
+
+func (b *BmPrefix) matchPattern(text []rune, index int) bool {
+	if len(text)-index < len(b.pattern) {
+		return false
+	}
+
+	if b.caseInsensitive {
+		for i := 0; i < len(b.pattern); i++ {
+			//Debug.Assert(textinfo.ToLower(_pattern[i]) == _pattern[i], "pattern should be converted to lower case in constructor!");
+			if unicode.ToLower(text[index+i]) != b.pattern[i] {
+				return false
+			}
+		}
+		return true
+	} else {
+		for i := 0; i < len(b.pattern); i++ {
+			if text[index+i] != b.pattern[i] {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+type AnchorLoc int16
+
+// where the regex can be pegged
+const (
+	AnchorBeginning    AnchorLoc = 0x0001
+	AnchorBol                    = 0x0002
+	AnchorStart                  = 0x0004
+	AnchorEol                    = 0x0008
+	AnchorEndZ                   = 0x0010
+	AnchorEnd                    = 0x0020
+	AnchorBoundary               = 0x0040
+	AnchorECMABoundary           = 0x0080
+)
+
+func getAnchors(tree *RegexTree) AnchorLoc {
+
+	var concatNode *regexNode
+	nextChild, result := 0, AnchorLoc(0)
+
+	curNode := tree.root
+
+	for {
+		switch curNode.t {
+		case ntConcatenate:
+			if len(curNode.children) > 0 {
+				concatNode = curNode
+				nextChild = 0
+			}
+
+		case ntGreedy, ntCapture:
+			curNode = curNode.children[0]
+			concatNode = nil
+			continue
+
+		case ntBol, ntEol, ntBoundary, ntECMABoundary, ntBeginning,
+			ntStart, ntEndZ, ntEnd:
+			return result | anchorFromType(curNode.t)
+
+		case ntEmpty, ntRequire, ntPrevent:
+
+		default:
+			return result
+		}
+
+		if concatNode == nil || nextChild >= len(concatNode.children) {
+			return result
+		}
+
+		curNode = concatNode.children[nextChild]
+		nextChild++
+	}
+}
+
+func anchorFromType(t nodeType) AnchorLoc {
+	switch t {
+	case ntBol:
+		return AnchorBol
+	case ntEol:
+		return AnchorEol
+	case ntBoundary:
+		return AnchorBoundary
+	case ntECMABoundary:
+		return AnchorECMABoundary
+	case ntBeginning:
+		return AnchorBeginning
+	case ntStart:
+		return AnchorStart
+	case ntEndZ:
+		return AnchorEndZ
+	case ntEnd:
+		return AnchorEnd
+	default:
+		return 0
+	}
+}
+
+// anchorDescription returns a human-readable description of the anchors
+func (anchors AnchorLoc) String() string {
+	buf := &bytes.Buffer{}
+
+	if 0 != (anchors & AnchorBeginning) {
+		buf.WriteString(", Beginning")
+	}
+	if 0 != (anchors & AnchorStart) {
+		buf.WriteString(", Start")
+	}
+	if 0 != (anchors & AnchorBol) {
+		buf.WriteString(", Bol")
+	}
+	if 0 != (anchors & AnchorBoundary) {
+		buf.WriteString(", Boundary")
+	}
+	if 0 != (anchors & AnchorECMABoundary) {
+		buf.WriteString(", ECMABoundary")
+	}
+	if 0 != (anchors & AnchorEol) {
+		buf.WriteString(", Eol")
+	}
+	if 0 != (anchors & AnchorEnd) {
+		buf.WriteString(", End")
+	}
+	if 0 != (anchors & AnchorEndZ) {
+		buf.WriteString(", EndZ")
+	}
+
+	// trim off comma
+	if buf.Len() >= 2 {
+		return buf.String()[2:]
+	}
+	return "None"
+}

--- a/vendor/github.com/dlclark/regexp2/syntax/replacerdata.go
+++ b/vendor/github.com/dlclark/regexp2/syntax/replacerdata.go
@@ -1,0 +1,87 @@
+package syntax
+
+import (
+	"bytes"
+	"errors"
+)
+
+type ReplacerData struct {
+	Rep     string
+	Strings []string
+	Rules   []int
+}
+
+const (
+	replaceSpecials     = 4
+	replaceLeftPortion  = -1
+	replaceRightPortion = -2
+	replaceLastGroup    = -3
+	replaceWholeString  = -4
+)
+
+//ErrReplacementError is a general error during parsing the replacement text
+var ErrReplacementError = errors.New("Replacement pattern error.")
+
+// NewReplacerData will populate a reusable replacer data struct based on the given replacement string
+// and the capture group data from a regexp
+func NewReplacerData(rep string, caps map[int]int, capsize int, capnames map[string]int, op RegexOptions) (*ReplacerData, error) {
+	p := parser{
+		options:  op,
+		caps:     caps,
+		capsize:  capsize,
+		capnames: capnames,
+	}
+	p.setPattern(rep)
+	concat, err := p.scanReplacement()
+	if err != nil {
+		return nil, err
+	}
+
+	if concat.t != ntConcatenate {
+		panic(ErrReplacementError)
+	}
+
+	sb := &bytes.Buffer{}
+	var (
+		strings []string
+		rules   []int
+	)
+
+	for _, child := range concat.children {
+		switch child.t {
+		case ntMulti:
+			child.writeStrToBuf(sb)
+
+		case ntOne:
+			sb.WriteRune(child.ch)
+
+		case ntRef:
+			if sb.Len() > 0 {
+				rules = append(rules, len(strings))
+				strings = append(strings, sb.String())
+				sb.Reset()
+			}
+			slot := child.m
+
+			if len(caps) > 0 && slot >= 0 {
+				slot = caps[slot]
+			}
+
+			rules = append(rules, -replaceSpecials-1-slot)
+
+		default:
+			panic(ErrReplacementError)
+		}
+	}
+
+	if sb.Len() > 0 {
+		rules = append(rules, len(strings))
+		strings = append(strings, sb.String())
+	}
+
+	return &ReplacerData{
+		Rep:     rep,
+		Strings: strings,
+		Rules:   rules,
+	}, nil
+}

--- a/vendor/github.com/dlclark/regexp2/syntax/tree.go
+++ b/vendor/github.com/dlclark/regexp2/syntax/tree.go
@@ -1,0 +1,654 @@
+package syntax
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"strconv"
+)
+
+type RegexTree struct {
+	root       *regexNode
+	caps       map[int]int
+	capnumlist []int
+	captop     int
+	Capnames   map[string]int
+	Caplist    []string
+	options    RegexOptions
+}
+
+// It is built into a parsed tree for a regular expression.
+
+// Implementation notes:
+//
+// Since the node tree is a temporary data structure only used
+// during compilation of the regexp to integer codes, it's
+// designed for clarity and convenience rather than
+// space efficiency.
+//
+// RegexNodes are built into a tree, linked by the n.children list.
+// Each node also has a n.parent and n.ichild member indicating
+// its parent and which child # it is in its parent's list.
+//
+// RegexNodes come in as many types as there are constructs in
+// a regular expression, for example, "concatenate", "alternate",
+// "one", "rept", "group". There are also node types for basic
+// peephole optimizations, e.g., "onerep", "notsetrep", etc.
+//
+// Because perl 5 allows "lookback" groups that scan backwards,
+// each node also gets a "direction". Normally the value of
+// boolean n.backward = false.
+//
+// During parsing, top-level nodes are also stacked onto a parse
+// stack (a stack of trees). For this purpose we have a n.next
+// pointer. [Note that to save a few bytes, we could overload the
+// n.parent pointer instead.]
+//
+// On the parse stack, each tree has a "role" - basically, the
+// nonterminal in the grammar that the parser has currently
+// assigned to the tree. That code is stored in n.role.
+//
+// Finally, some of the different kinds of nodes have data.
+// Two integers (for the looping constructs) are stored in
+// n.operands, an an object (either a string or a set)
+// is stored in n.data
+type regexNode struct {
+	t        nodeType
+	children []*regexNode
+	str      []rune
+	set      *CharSet
+	ch       rune
+	m        int
+	n        int
+	options  RegexOptions
+	next     *regexNode
+}
+
+type nodeType int32
+
+const (
+	// The following are leaves, and correspond to primitive operations
+
+	ntOnerep      nodeType = 0  // lef,back char,min,max    a {n}
+	ntNotonerep            = 1  // lef,back char,min,max    .{n}
+	ntSetrep               = 2  // lef,back set,min,max     [\d]{n}
+	ntOneloop              = 3  // lef,back char,min,max    a {,n}
+	ntNotoneloop           = 4  // lef,back char,min,max    .{,n}
+	ntSetloop              = 5  // lef,back set,min,max     [\d]{,n}
+	ntOnelazy              = 6  // lef,back char,min,max    a {,n}?
+	ntNotonelazy           = 7  // lef,back char,min,max    .{,n}?
+	ntSetlazy              = 8  // lef,back set,min,max     [\d]{,n}?
+	ntOne                  = 9  // lef      char            a
+	ntNotone               = 10 // lef      char            [^a]
+	ntSet                  = 11 // lef      set             [a-z\s]  \w \s \d
+	ntMulti                = 12 // lef      string          abcd
+	ntRef                  = 13 // lef      group           \#
+	ntBol                  = 14 //                          ^
+	ntEol                  = 15 //                          $
+	ntBoundary             = 16 //                          \b
+	ntNonboundary          = 17 //                          \B
+	ntBeginning            = 18 //                          \A
+	ntStart                = 19 //                          \G
+	ntEndZ                 = 20 //                          \Z
+	ntEnd                  = 21 //                          \Z
+
+	// Interior nodes do not correspond to primitive operations, but
+	// control structures compositing other operations
+
+	// Concat and alternate take n children, and can run forward or backwards
+
+	ntNothing     = 22 //          []
+	ntEmpty       = 23 //          ()
+	ntAlternate   = 24 //          a|b
+	ntConcatenate = 25 //          ab
+	ntLoop        = 26 // m,x      * + ? {,}
+	ntLazyloop    = 27 // m,x      *? +? ?? {,}?
+	ntCapture     = 28 // n        ()
+	ntGroup       = 29 //          (?:)
+	ntRequire     = 30 //          (?=) (?<=)
+	ntPrevent     = 31 //          (?!) (?<!)
+	ntGreedy      = 32 //          (?>) (?<)
+	ntTestref     = 33 //          (?(n) | )
+	ntTestgroup   = 34 //          (?(...) | )
+
+	ntECMABoundary    = 41 //                          \b
+	ntNonECMABoundary = 42 //                          \B
+)
+
+func newRegexNode(t nodeType, opt RegexOptions) *regexNode {
+	return &regexNode{
+		t:       t,
+		options: opt,
+	}
+}
+
+func newRegexNodeCh(t nodeType, opt RegexOptions, ch rune) *regexNode {
+	return &regexNode{
+		t:       t,
+		options: opt,
+		ch:      ch,
+	}
+}
+
+func newRegexNodeStr(t nodeType, opt RegexOptions, str []rune) *regexNode {
+	return &regexNode{
+		t:       t,
+		options: opt,
+		str:     str,
+	}
+}
+
+func newRegexNodeSet(t nodeType, opt RegexOptions, set *CharSet) *regexNode {
+	return &regexNode{
+		t:       t,
+		options: opt,
+		set:     set,
+	}
+}
+
+func newRegexNodeM(t nodeType, opt RegexOptions, m int) *regexNode {
+	return &regexNode{
+		t:       t,
+		options: opt,
+		m:       m,
+	}
+}
+func newRegexNodeMN(t nodeType, opt RegexOptions, m, n int) *regexNode {
+	return &regexNode{
+		t:       t,
+		options: opt,
+		m:       m,
+		n:       n,
+	}
+}
+
+func (n *regexNode) writeStrToBuf(buf *bytes.Buffer) {
+	for i := 0; i < len(n.str); i++ {
+		buf.WriteRune(n.str[i])
+	}
+}
+
+func (n *regexNode) addChild(child *regexNode) {
+	reduced := child.reduce()
+	n.children = append(n.children, reduced)
+	reduced.next = n
+}
+
+func (n *regexNode) insertChildren(afterIndex int, nodes []*regexNode) {
+	newChildren := make([]*regexNode, 0, len(n.children)+len(nodes))
+	n.children = append(append(append(newChildren, n.children[:afterIndex]...), nodes...), n.children[afterIndex:]...)
+}
+
+// removes children including the start but not the end index
+func (n *regexNode) removeChildren(startIndex, endIndex int) {
+	n.children = append(n.children[:startIndex], n.children[endIndex:]...)
+}
+
+// Pass type as OneLazy or OneLoop
+func (n *regexNode) makeRep(t nodeType, min, max int) {
+	n.t += (t - ntOne)
+	n.m = min
+	n.n = max
+}
+
+func (n *regexNode) reduce() *regexNode {
+	switch n.t {
+	case ntAlternate:
+		return n.reduceAlternation()
+
+	case ntConcatenate:
+		return n.reduceConcatenation()
+
+	case ntLoop, ntLazyloop:
+		return n.reduceRep()
+
+	case ntGroup:
+		return n.reduceGroup()
+
+	case ntSet, ntSetloop:
+		return n.reduceSet()
+
+	default:
+		return n
+	}
+}
+
+// Basic optimization. Single-letter alternations can be replaced
+// by faster set specifications, and nested alternations with no
+// intervening operators can be flattened:
+//
+// a|b|c|def|g|h -> [a-c]|def|[gh]
+// apple|(?:orange|pear)|grape -> apple|orange|pear|grape
+func (n *regexNode) reduceAlternation() *regexNode {
+	if len(n.children) == 0 {
+		return newRegexNode(ntNothing, n.options)
+	}
+
+	wasLastSet := false
+	lastNodeCannotMerge := false
+	var optionsLast RegexOptions
+	var i, j int
+
+	for i, j = 0, 0; i < len(n.children); i, j = i+1, j+1 {
+		at := n.children[i]
+
+		if j < i {
+			n.children[j] = at
+		}
+
+		for {
+			if at.t == ntAlternate {
+				for k := 0; k < len(at.children); k++ {
+					at.children[k].next = n
+				}
+				n.insertChildren(i+1, at.children)
+
+				j--
+			} else if at.t == ntSet || at.t == ntOne {
+				// Cannot merge sets if L or I options differ, or if either are negated.
+				optionsAt := at.options & (RightToLeft | IgnoreCase)
+
+				if at.t == ntSet {
+					if !wasLastSet || optionsLast != optionsAt || lastNodeCannotMerge || !at.set.IsMergeable() {
+						wasLastSet = true
+						lastNodeCannotMerge = !at.set.IsMergeable()
+						optionsLast = optionsAt
+						break
+					}
+				} else if !wasLastSet || optionsLast != optionsAt || lastNodeCannotMerge {
+					wasLastSet = true
+					lastNodeCannotMerge = false
+					optionsLast = optionsAt
+					break
+				}
+
+				// The last node was a Set or a One, we're a Set or One and our options are the same.
+				// Merge the two nodes.
+				j--
+				prev := n.children[j]
+
+				var prevCharClass *CharSet
+				if prev.t == ntOne {
+					prevCharClass = &CharSet{}
+					prevCharClass.addChar(prev.ch)
+				} else {
+					prevCharClass = prev.set
+				}
+
+				if at.t == ntOne {
+					prevCharClass.addChar(at.ch)
+				} else {
+					prevCharClass.addSet(*at.set)
+				}
+
+				prev.t = ntSet
+				prev.set = prevCharClass
+			} else if at.t == ntNothing {
+				j--
+			} else {
+				wasLastSet = false
+				lastNodeCannotMerge = false
+			}
+			break
+		}
+	}
+
+	if j < i {
+		n.removeChildren(j, i)
+	}
+
+	return n.stripEnation(ntNothing)
+}
+
+// Basic optimization. Adjacent strings can be concatenated.
+//
+// (?:abc)(?:def) -> abcdef
+func (n *regexNode) reduceConcatenation() *regexNode {
+	// Eliminate empties and concat adjacent strings/chars
+
+	var optionsLast RegexOptions
+	var optionsAt RegexOptions
+	var i, j int
+
+	if len(n.children) == 0 {
+		return newRegexNode(ntEmpty, n.options)
+	}
+
+	wasLastString := false
+
+	for i, j = 0, 0; i < len(n.children); i, j = i+1, j+1 {
+		var at, prev *regexNode
+
+		at = n.children[i]
+
+		if j < i {
+			n.children[j] = at
+		}
+
+		if at.t == ntConcatenate &&
+			((at.options & RightToLeft) == (n.options & RightToLeft)) {
+			for k := 0; k < len(at.children); k++ {
+				at.children[k].next = n
+			}
+
+			//insert at.children at i+1 index in n.children
+			n.insertChildren(i+1, at.children)
+
+			j--
+		} else if at.t == ntMulti || at.t == ntOne {
+			// Cannot merge strings if L or I options differ
+			optionsAt = at.options & (RightToLeft | IgnoreCase)
+
+			if !wasLastString || optionsLast != optionsAt {
+				wasLastString = true
+				optionsLast = optionsAt
+				continue
+			}
+
+			j--
+			prev = n.children[j]
+
+			if prev.t == ntOne {
+				prev.t = ntMulti
+				prev.str = []rune{prev.ch}
+			}
+
+			if (optionsAt & RightToLeft) == 0 {
+				if at.t == ntOne {
+					prev.str = append(prev.str, at.ch)
+				} else {
+					prev.str = append(prev.str, at.str...)
+				}
+			} else {
+				if at.t == ntOne {
+					// insert at the front by expanding our slice, copying the data over, and then setting the value
+					prev.str = append(prev.str, 0)
+					copy(prev.str[1:], prev.str)
+					prev.str[0] = at.ch
+				} else {
+					//insert at the front...this one we'll make a new slice and copy both into it
+					merge := make([]rune, len(prev.str)+len(at.str))
+					copy(merge, at.str)
+					copy(merge[len(at.str):], prev.str)
+					prev.str = merge
+				}
+			}
+		} else if at.t == ntEmpty {
+			j--
+		} else {
+			wasLastString = false
+		}
+	}
+
+	if j < i {
+		// remove indices j through i from the children
+		n.removeChildren(j, i)
+	}
+
+	return n.stripEnation(ntEmpty)
+}
+
+// Nested repeaters just get multiplied with each other if they're not
+// too lumpy
+func (n *regexNode) reduceRep() *regexNode {
+
+	u := n
+	t := n.t
+	min := n.m
+	max := n.n
+
+	for {
+		if len(u.children) == 0 {
+			break
+		}
+
+		child := u.children[0]
+
+		// multiply reps of the same type only
+		if child.t != t {
+			childType := child.t
+
+			if !(childType >= ntOneloop && childType <= ntSetloop && t == ntLoop ||
+				childType >= ntOnelazy && childType <= ntSetlazy && t == ntLazyloop) {
+				break
+			}
+		}
+
+		// child can be too lumpy to blur, e.g., (a {100,105}) {3} or (a {2,})?
+		// [but things like (a {2,})+ are not too lumpy...]
+		if u.m == 0 && child.m > 1 || child.n < child.m*2 {
+			break
+		}
+
+		u = child
+		if u.m > 0 {
+			if (math.MaxInt32-1)/u.m < min {
+				u.m = math.MaxInt32
+			} else {
+				u.m = u.m * min
+			}
+		}
+		if u.n > 0 {
+			if (math.MaxInt32-1)/u.n < max {
+				u.n = math.MaxInt32
+			} else {
+				u.n = u.n * max
+			}
+		}
+	}
+
+	if math.MaxInt32 == min {
+		return newRegexNode(ntNothing, n.options)
+	}
+	return u
+
+}
+
+// Simple optimization. If a concatenation or alternation has only
+// one child strip out the intermediate node. If it has zero children,
+// turn it into an empty.
+func (n *regexNode) stripEnation(emptyType nodeType) *regexNode {
+	switch len(n.children) {
+	case 0:
+		return newRegexNode(emptyType, n.options)
+	case 1:
+		return n.children[0]
+	default:
+		return n
+	}
+}
+
+func (n *regexNode) reduceGroup() *regexNode {
+	u := n
+
+	for u.t == ntGroup {
+		u = u.children[0]
+	}
+
+	return u
+}
+
+// Simple optimization. If a set is a singleton, an inverse singleton,
+// or empty, it's transformed accordingly.
+func (n *regexNode) reduceSet() *regexNode {
+	// Extract empty-set, one and not-one case as special
+
+	if n.set == nil {
+		n.t = ntNothing
+	} else if n.set.IsSingleton() {
+		n.ch = n.set.SingletonChar()
+		n.set = nil
+		n.t += (ntOne - ntSet)
+	} else if n.set.IsSingletonInverse() {
+		n.ch = n.set.SingletonChar()
+		n.set = nil
+		n.t += (ntNotone - ntSet)
+	}
+
+	return n
+}
+
+func (n *regexNode) reverseLeft() *regexNode {
+	if n.options&RightToLeft != 0 && n.t == ntConcatenate && len(n.children) > 0 {
+		//reverse children order
+		for left, right := 0, len(n.children)-1; left < right; left, right = left+1, right-1 {
+			n.children[left], n.children[right] = n.children[right], n.children[left]
+		}
+	}
+
+	return n
+}
+
+func (n *regexNode) makeQuantifier(lazy bool, min, max int) *regexNode {
+	if min == 0 && max == 0 {
+		return newRegexNode(ntEmpty, n.options)
+	}
+
+	if min == 1 && max == 1 {
+		return n
+	}
+
+	switch n.t {
+	case ntOne, ntNotone, ntSet:
+		if lazy {
+			n.makeRep(Onelazy, min, max)
+		} else {
+			n.makeRep(Oneloop, min, max)
+		}
+		return n
+
+	default:
+		var t nodeType
+		if lazy {
+			t = ntLazyloop
+		} else {
+			t = ntLoop
+		}
+		result := newRegexNodeMN(t, n.options, min, max)
+		result.addChild(n)
+		return result
+	}
+}
+
+// debug functions
+
+var typeStr = []string{
+	"Onerep", "Notonerep", "Setrep",
+	"Oneloop", "Notoneloop", "Setloop",
+	"Onelazy", "Notonelazy", "Setlazy",
+	"One", "Notone", "Set",
+	"Multi", "Ref",
+	"Bol", "Eol", "Boundary", "Nonboundary",
+	"Beginning", "Start", "EndZ", "End",
+	"Nothing", "Empty",
+	"Alternate", "Concatenate",
+	"Loop", "Lazyloop",
+	"Capture", "Group", "Require", "Prevent", "Greedy",
+	"Testref", "Testgroup",
+	"Unknown", "Unknown", "Unknown",
+	"Unknown", "Unknown", "Unknown",
+	"ECMABoundary", "NonECMABoundary",
+}
+
+func (n *regexNode) description() string {
+	buf := &bytes.Buffer{}
+
+	buf.WriteString(typeStr[n.t])
+
+	if (n.options & ExplicitCapture) != 0 {
+		buf.WriteString("-C")
+	}
+	if (n.options & IgnoreCase) != 0 {
+		buf.WriteString("-I")
+	}
+	if (n.options & RightToLeft) != 0 {
+		buf.WriteString("-L")
+	}
+	if (n.options & Multiline) != 0 {
+		buf.WriteString("-M")
+	}
+	if (n.options & Singleline) != 0 {
+		buf.WriteString("-S")
+	}
+	if (n.options & IgnorePatternWhitespace) != 0 {
+		buf.WriteString("-X")
+	}
+	if (n.options & ECMAScript) != 0 {
+		buf.WriteString("-E")
+	}
+
+	switch n.t {
+	case ntOneloop, ntNotoneloop, ntOnelazy, ntNotonelazy, ntOne, ntNotone:
+		buf.WriteString("(Ch = " + CharDescription(n.ch) + ")")
+		break
+	case ntCapture:
+		buf.WriteString("(index = " + strconv.Itoa(n.m) + ", unindex = " + strconv.Itoa(n.n) + ")")
+		break
+	case ntRef, ntTestref:
+		buf.WriteString("(index = " + strconv.Itoa(n.m) + ")")
+		break
+	case ntMulti:
+		fmt.Fprintf(buf, "(String = %s)", string(n.str))
+		break
+	case ntSet, ntSetloop, ntSetlazy:
+		buf.WriteString("(Set = " + n.set.String() + ")")
+		break
+	}
+
+	switch n.t {
+	case ntOneloop, ntNotoneloop, ntOnelazy, ntNotonelazy, ntSetloop, ntSetlazy, ntLoop, ntLazyloop:
+		buf.WriteString("(Min = ")
+		buf.WriteString(strconv.Itoa(n.m))
+		buf.WriteString(", Max = ")
+		if n.n == math.MaxInt32 {
+			buf.WriteString("inf")
+		} else {
+			buf.WriteString(strconv.Itoa(n.n))
+		}
+		buf.WriteString(")")
+
+		break
+	}
+
+	return buf.String()
+}
+
+var padSpace = []byte("                                ")
+
+func (t *RegexTree) Dump() string {
+	return t.root.dump()
+}
+
+func (n *regexNode) dump() string {
+	var stack []int
+	CurNode := n
+	CurChild := 0
+
+	buf := bytes.NewBufferString(CurNode.description())
+	buf.WriteRune('\n')
+
+	for {
+		if CurNode.children != nil && CurChild < len(CurNode.children) {
+			stack = append(stack, CurChild+1)
+			CurNode = CurNode.children[CurChild]
+			CurChild = 0
+
+			Depth := len(stack)
+			if Depth > 32 {
+				Depth = 32
+			}
+			buf.Write(padSpace[:Depth])
+			buf.WriteString(CurNode.description())
+			buf.WriteRune('\n')
+		} else {
+			if len(stack) == 0 {
+				break
+			}
+
+			CurChild = stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			CurNode = CurNode.next
+		}
+	}
+	return buf.String()
+}

--- a/vendor/github.com/dlclark/regexp2/syntax/writer.go
+++ b/vendor/github.com/dlclark/regexp2/syntax/writer.go
@@ -1,0 +1,500 @@
+package syntax
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"os"
+)
+
+func Write(tree *RegexTree) (*Code, error) {
+	w := writer{
+		intStack:   make([]int, 0, 32),
+		emitted:    make([]int, 2),
+		stringhash: make(map[string]int),
+		sethash:    make(map[string]int),
+	}
+
+	code, err := w.codeFromTree(tree)
+
+	if tree.options&Debug > 0 && code != nil {
+		os.Stdout.WriteString(code.Dump())
+		os.Stdout.WriteString("\n")
+	}
+
+	return code, err
+}
+
+type writer struct {
+	emitted []int
+
+	intStack    []int
+	curpos      int
+	stringhash  map[string]int
+	stringtable [][]rune
+	sethash     map[string]int
+	settable    []*CharSet
+	counting    bool
+	count       int
+	trackcount  int
+	caps        map[int]int
+}
+
+const (
+	beforeChild nodeType = 64
+	afterChild           = 128
+	//MaxPrefixSize is the largest number of runes we'll use for a BoyerMoyer prefix
+	MaxPrefixSize = 50
+)
+
+// The top level RegexCode generator. It does a depth-first walk
+// through the tree and calls EmitFragment to emits code before
+// and after each child of an interior node, and at each leaf.
+//
+// It runs two passes, first to count the size of the generated
+// code, and second to generate the code.
+//
+// We should time it against the alternative, which is
+// to just generate the code and grow the array as we go.
+func (w *writer) codeFromTree(tree *RegexTree) (*Code, error) {
+	var (
+		curNode  *regexNode
+		curChild int
+		capsize  int
+	)
+	// construct sparse capnum mapping if some numbers are unused
+
+	if tree.capnumlist == nil || tree.captop == len(tree.capnumlist) {
+		capsize = tree.captop
+		w.caps = nil
+	} else {
+		capsize = len(tree.capnumlist)
+		w.caps = tree.caps
+		for i := 0; i < len(tree.capnumlist); i++ {
+			w.caps[tree.capnumlist[i]] = i
+		}
+	}
+
+	w.counting = true
+
+	for {
+		if !w.counting {
+			w.emitted = make([]int, w.count)
+		}
+
+		curNode = tree.root
+		curChild = 0
+
+		w.emit1(Lazybranch, 0)
+
+		for {
+			if len(curNode.children) == 0 {
+				w.emitFragment(curNode.t, curNode, 0)
+			} else if curChild < len(curNode.children) {
+				w.emitFragment(curNode.t|beforeChild, curNode, curChild)
+
+				curNode = curNode.children[curChild]
+
+				w.pushInt(curChild)
+				curChild = 0
+				continue
+			}
+
+			if w.emptyStack() {
+				break
+			}
+
+			curChild = w.popInt()
+			curNode = curNode.next
+
+			w.emitFragment(curNode.t|afterChild, curNode, curChild)
+			curChild++
+		}
+
+		w.patchJump(0, w.curPos())
+		w.emit(Stop)
+
+		if !w.counting {
+			break
+		}
+
+		w.counting = false
+	}
+
+	fcPrefix := getFirstCharsPrefix(tree)
+	prefix := getPrefix(tree)
+	rtl := (tree.options & RightToLeft) != 0
+
+	var bmPrefix *BmPrefix
+	//TODO: benchmark string prefixes
+	if prefix != nil && len(prefix.PrefixStr) > 0 && MaxPrefixSize > 0 {
+		if len(prefix.PrefixStr) > MaxPrefixSize {
+			// limit prefix changes to 10k
+			prefix.PrefixStr = prefix.PrefixStr[:MaxPrefixSize]
+		}
+		bmPrefix = newBmPrefix(prefix.PrefixStr, prefix.CaseInsensitive, rtl)
+	} else {
+		bmPrefix = nil
+	}
+
+	return &Code{
+		Codes:       w.emitted,
+		Strings:     w.stringtable,
+		Sets:        w.settable,
+		TrackCount:  w.trackcount,
+		Caps:        w.caps,
+		Capsize:     capsize,
+		FcPrefix:    fcPrefix,
+		BmPrefix:    bmPrefix,
+		Anchors:     getAnchors(tree),
+		RightToLeft: rtl,
+	}, nil
+}
+
+// The main RegexCode generator. It does a depth-first walk
+// through the tree and calls EmitFragment to emits code before
+// and after each child of an interior node, and at each leaf.
+func (w *writer) emitFragment(nodetype nodeType, node *regexNode, curIndex int) error {
+	bits := InstOp(0)
+
+	if nodetype <= ntRef {
+		if (node.options & RightToLeft) != 0 {
+			bits |= Rtl
+		}
+		if (node.options & IgnoreCase) != 0 {
+			bits |= Ci
+		}
+	}
+	ntBits := nodeType(bits)
+
+	switch nodetype {
+	case ntConcatenate | beforeChild, ntConcatenate | afterChild, ntEmpty:
+		break
+
+	case ntAlternate | beforeChild:
+		if curIndex < len(node.children)-1 {
+			w.pushInt(w.curPos())
+			w.emit1(Lazybranch, 0)
+		}
+
+	case ntAlternate | afterChild:
+		if curIndex < len(node.children)-1 {
+			lbPos := w.popInt()
+			w.pushInt(w.curPos())
+			w.emit1(Goto, 0)
+			w.patchJump(lbPos, w.curPos())
+		} else {
+			for i := 0; i < curIndex; i++ {
+				w.patchJump(w.popInt(), w.curPos())
+			}
+		}
+		break
+
+	case ntTestref | beforeChild:
+		if curIndex == 0 {
+			w.emit(Setjump)
+			w.pushInt(w.curPos())
+			w.emit1(Lazybranch, 0)
+			w.emit1(Testref, w.mapCapnum(node.m))
+			w.emit(Forejump)
+		}
+
+	case ntTestref | afterChild:
+		if curIndex == 0 {
+			branchpos := w.popInt()
+			w.pushInt(w.curPos())
+			w.emit1(Goto, 0)
+			w.patchJump(branchpos, w.curPos())
+			w.emit(Forejump)
+			if len(node.children) <= 1 {
+				w.patchJump(w.popInt(), w.curPos())
+			}
+		} else if curIndex == 1 {
+			w.patchJump(w.popInt(), w.curPos())
+		}
+
+	case ntTestgroup | beforeChild:
+		if curIndex == 0 {
+			w.emit(Setjump)
+			w.emit(Setmark)
+			w.pushInt(w.curPos())
+			w.emit1(Lazybranch, 0)
+		}
+
+	case ntTestgroup | afterChild:
+		if curIndex == 0 {
+			w.emit(Getmark)
+			w.emit(Forejump)
+		} else if curIndex == 1 {
+			Branchpos := w.popInt()
+			w.pushInt(w.curPos())
+			w.emit1(Goto, 0)
+			w.patchJump(Branchpos, w.curPos())
+			w.emit(Getmark)
+			w.emit(Forejump)
+			if len(node.children) <= 2 {
+				w.patchJump(w.popInt(), w.curPos())
+			}
+		} else if curIndex == 2 {
+			w.patchJump(w.popInt(), w.curPos())
+		}
+
+	case ntLoop | beforeChild, ntLazyloop | beforeChild:
+
+		if node.n < math.MaxInt32 || node.m > 1 {
+			if node.m == 0 {
+				w.emit1(Nullcount, 0)
+			} else {
+				w.emit1(Setcount, 1-node.m)
+			}
+		} else if node.m == 0 {
+			w.emit(Nullmark)
+		} else {
+			w.emit(Setmark)
+		}
+
+		if node.m == 0 {
+			w.pushInt(w.curPos())
+			w.emit1(Goto, 0)
+		}
+		w.pushInt(w.curPos())
+
+	case ntLoop | afterChild, ntLazyloop | afterChild:
+
+		startJumpPos := w.curPos()
+		lazy := (nodetype - (ntLoop | afterChild))
+
+		if node.n < math.MaxInt32 || node.m > 1 {
+			if node.n == math.MaxInt32 {
+				w.emit2(InstOp(Branchcount+lazy), w.popInt(), math.MaxInt32)
+			} else {
+				w.emit2(InstOp(Branchcount+lazy), w.popInt(), node.n-node.m)
+			}
+		} else {
+			w.emit1(InstOp(Branchmark+lazy), w.popInt())
+		}
+
+		if node.m == 0 {
+			w.patchJump(w.popInt(), startJumpPos)
+		}
+
+	case ntGroup | beforeChild, ntGroup | afterChild:
+
+	case ntCapture | beforeChild:
+		w.emit(Setmark)
+
+	case ntCapture | afterChild:
+		w.emit2(Capturemark, w.mapCapnum(node.m), w.mapCapnum(node.n))
+
+	case ntRequire | beforeChild:
+		// NOTE: the following line causes lookahead/lookbehind to be
+		// NON-BACKTRACKING. It can be commented out with (*)
+		w.emit(Setjump)
+
+		w.emit(Setmark)
+
+	case ntRequire | afterChild:
+		w.emit(Getmark)
+
+		// NOTE: the following line causes lookahead/lookbehind to be
+		// NON-BACKTRACKING. It can be commented out with (*)
+		w.emit(Forejump)
+
+	case ntPrevent | beforeChild:
+		w.emit(Setjump)
+		w.pushInt(w.curPos())
+		w.emit1(Lazybranch, 0)
+
+	case ntPrevent | afterChild:
+		w.emit(Backjump)
+		w.patchJump(w.popInt(), w.curPos())
+		w.emit(Forejump)
+
+	case ntGreedy | beforeChild:
+		w.emit(Setjump)
+
+	case ntGreedy | afterChild:
+		w.emit(Forejump)
+
+	case ntOne, ntNotone:
+		w.emit1(InstOp(node.t|ntBits), int(node.ch))
+
+	case ntNotoneloop, ntNotonelazy, ntOneloop, ntOnelazy:
+		if node.m > 0 {
+			if node.t == ntOneloop || node.t == ntOnelazy {
+				w.emit2(Onerep|bits, int(node.ch), node.m)
+			} else {
+				w.emit2(Notonerep|bits, int(node.ch), node.m)
+			}
+		}
+		if node.n > node.m {
+			if node.n == math.MaxInt32 {
+				w.emit2(InstOp(node.t|ntBits), int(node.ch), math.MaxInt32)
+			} else {
+				w.emit2(InstOp(node.t|ntBits), int(node.ch), node.n-node.m)
+			}
+		}
+
+	case ntSetloop, ntSetlazy:
+		if node.m > 0 {
+			w.emit2(Setrep|bits, w.setCode(node.set), node.m)
+		}
+		if node.n > node.m {
+			if node.n == math.MaxInt32 {
+				w.emit2(InstOp(node.t|ntBits), w.setCode(node.set), math.MaxInt32)
+			} else {
+				w.emit2(InstOp(node.t|ntBits), w.setCode(node.set), node.n-node.m)
+			}
+		}
+
+	case ntMulti:
+		w.emit1(InstOp(node.t|ntBits), w.stringCode(node.str))
+
+	case ntSet:
+		w.emit1(InstOp(node.t|ntBits), w.setCode(node.set))
+
+	case ntRef:
+		w.emit1(InstOp(node.t|ntBits), w.mapCapnum(node.m))
+
+	case ntNothing, ntBol, ntEol, ntBoundary, ntNonboundary, ntECMABoundary, ntNonECMABoundary, ntBeginning, ntStart, ntEndZ, ntEnd:
+		w.emit(InstOp(node.t))
+
+	default:
+		return fmt.Errorf("unexpected opcode in regular expression generation: %v", nodetype)
+	}
+
+	return nil
+}
+
+// To avoid recursion, we use a simple integer stack.
+// This is the push.
+func (w *writer) pushInt(i int) {
+	w.intStack = append(w.intStack, i)
+}
+
+// Returns true if the stack is empty.
+func (w *writer) emptyStack() bool {
+	return len(w.intStack) == 0
+}
+
+// This is the pop.
+func (w *writer) popInt() int {
+	//get our item
+	idx := len(w.intStack) - 1
+	i := w.intStack[idx]
+	//trim our slice
+	w.intStack = w.intStack[:idx]
+	return i
+}
+
+// Returns the current position in the emitted code.
+func (w *writer) curPos() int {
+	return w.curpos
+}
+
+// Fixes up a jump instruction at the specified offset
+// so that it jumps to the specified jumpDest.
+func (w *writer) patchJump(offset, jumpDest int) {
+	w.emitted[offset+1] = jumpDest
+}
+
+// Returns an index in the set table for a charset
+// uses a map to eliminate duplicates.
+func (w *writer) setCode(set *CharSet) int {
+	if w.counting {
+		return 0
+	}
+
+	buf := &bytes.Buffer{}
+
+	set.mapHashFill(buf)
+	hash := buf.String()
+	i, ok := w.sethash[hash]
+	if !ok {
+		i = len(w.sethash)
+		w.sethash[hash] = i
+		w.settable = append(w.settable, set)
+	}
+	return i
+}
+
+// Returns an index in the string table for a string.
+// uses a map to eliminate duplicates.
+func (w *writer) stringCode(str []rune) int {
+	if w.counting {
+		return 0
+	}
+
+	hash := string(str)
+	i, ok := w.stringhash[hash]
+	if !ok {
+		i = len(w.stringhash)
+		w.stringhash[hash] = i
+		w.stringtable = append(w.stringtable, str)
+	}
+
+	return i
+}
+
+// When generating code on a regex that uses a sparse set
+// of capture slots, we hash them to a dense set of indices
+// for an array of capture slots. Instead of doing the hash
+// at match time, it's done at compile time, here.
+func (w *writer) mapCapnum(capnum int) int {
+	if capnum == -1 {
+		return -1
+	}
+
+	if w.caps != nil {
+		return w.caps[capnum]
+	}
+
+	return capnum
+}
+
+// Emits a zero-argument operation. Note that the emit
+// functions all run in two modes: they can emit code, or
+// they can just count the size of the code.
+func (w *writer) emit(op InstOp) {
+	if w.counting {
+		w.count++
+		if opcodeBacktracks(op) {
+			w.trackcount++
+		}
+		return
+	}
+	w.emitted[w.curpos] = int(op)
+	w.curpos++
+}
+
+// Emits a one-argument operation.
+func (w *writer) emit1(op InstOp, opd1 int) {
+	if w.counting {
+		w.count += 2
+		if opcodeBacktracks(op) {
+			w.trackcount++
+		}
+		return
+	}
+	w.emitted[w.curpos] = int(op)
+	w.curpos++
+	w.emitted[w.curpos] = opd1
+	w.curpos++
+}
+
+// Emits a two-argument operation.
+func (w *writer) emit2(op InstOp, opd1, opd2 int) {
+	if w.counting {
+		w.count += 3
+		if opcodeBacktracks(op) {
+			w.trackcount++
+		}
+		return
+	}
+	w.emitted[w.curpos] = int(op)
+	w.curpos++
+	w.emitted[w.curpos] = opd1
+	w.curpos++
+	w.emitted[w.curpos] = opd2
+	w.curpos++
+}

--- a/vendor/github.com/dlclark/regexp2/testoutput1
+++ b/vendor/github.com/dlclark/regexp2/testoutput1
@@ -1,0 +1,7061 @@
+# This set of tests is for features that are compatible with all versions of
+# Perl >= 5.10, in non-UTF mode. It should run clean for the 8-bit, 16-bit, and
+# 32-bit PCRE libraries, and also using the perltest.pl script.
+    
+#forbid_utf
+#newline_default lf any anycrlf
+#perltest
+
+/the quick brown fox/
+    the quick brown fox
+ 0: the quick brown fox
+    What do you know about the quick brown fox?
+ 0: the quick brown fox
+\= Expect no match
+    The quick brown FOX
+No match
+    What do you know about THE QUICK BROWN FOX?
+No match
+
+/The quick brown fox/i
+    the quick brown fox
+ 0: the quick brown fox
+    The quick brown FOX
+ 0: The quick brown FOX
+    What do you know about the quick brown fox?
+ 0: the quick brown fox
+    What do you know about THE QUICK BROWN FOX?
+ 0: THE QUICK BROWN FOX
+
+/abcd\t\n\r\f\a\e\071\x3b\$\\\?caxyz/
+    abcd\t\n\r\f\a\e9;\$\\?caxyz
+ 0: abcd\x09\x0a\x0d\x0c\x07\x1b9;$\?caxyz
+
+/a*abc?xyz+pqr{3}ab{2,}xy{4,5}pq{0,6}AB{0,}zz/
+    abxyzpqrrrabbxyyyypqAzz
+ 0: abxyzpqrrrabbxyyyypqAzz
+    abxyzpqrrrabbxyyyypqAzz
+ 0: abxyzpqrrrabbxyyyypqAzz
+    aabxyzpqrrrabbxyyyypqAzz
+ 0: aabxyzpqrrrabbxyyyypqAzz
+    aaabxyzpqrrrabbxyyyypqAzz
+ 0: aaabxyzpqrrrabbxyyyypqAzz
+    aaaabxyzpqrrrabbxyyyypqAzz
+ 0: aaaabxyzpqrrrabbxyyyypqAzz
+    abcxyzpqrrrabbxyyyypqAzz
+ 0: abcxyzpqrrrabbxyyyypqAzz
+    aabcxyzpqrrrabbxyyyypqAzz
+ 0: aabcxyzpqrrrabbxyyyypqAzz
+    aaabcxyzpqrrrabbxyyyypAzz
+ 0: aaabcxyzpqrrrabbxyyyypAzz
+    aaabcxyzpqrrrabbxyyyypqAzz
+ 0: aaabcxyzpqrrrabbxyyyypqAzz
+    aaabcxyzpqrrrabbxyyyypqqAzz
+ 0: aaabcxyzpqrrrabbxyyyypqqAzz
+    aaabcxyzpqrrrabbxyyyypqqqAzz
+ 0: aaabcxyzpqrrrabbxyyyypqqqAzz
+    aaabcxyzpqrrrabbxyyyypqqqqAzz
+ 0: aaabcxyzpqrrrabbxyyyypqqqqAzz
+    aaabcxyzpqrrrabbxyyyypqqqqqAzz
+ 0: aaabcxyzpqrrrabbxyyyypqqqqqAzz
+    aaabcxyzpqrrrabbxyyyypqqqqqqAzz
+ 0: aaabcxyzpqrrrabbxyyyypqqqqqqAzz
+    aaaabcxyzpqrrrabbxyyyypqAzz
+ 0: aaaabcxyzpqrrrabbxyyyypqAzz
+    abxyzzpqrrrabbxyyyypqAzz
+ 0: abxyzzpqrrrabbxyyyypqAzz
+    aabxyzzzpqrrrabbxyyyypqAzz
+ 0: aabxyzzzpqrrrabbxyyyypqAzz
+    aaabxyzzzzpqrrrabbxyyyypqAzz
+ 0: aaabxyzzzzpqrrrabbxyyyypqAzz
+    aaaabxyzzzzpqrrrabbxyyyypqAzz
+ 0: aaaabxyzzzzpqrrrabbxyyyypqAzz
+    abcxyzzpqrrrabbxyyyypqAzz
+ 0: abcxyzzpqrrrabbxyyyypqAzz
+    aabcxyzzzpqrrrabbxyyyypqAzz
+ 0: aabcxyzzzpqrrrabbxyyyypqAzz
+    aaabcxyzzzzpqrrrabbxyyyypqAzz
+ 0: aaabcxyzzzzpqrrrabbxyyyypqAzz
+    aaaabcxyzzzzpqrrrabbxyyyypqAzz
+ 0: aaaabcxyzzzzpqrrrabbxyyyypqAzz
+    aaaabcxyzzzzpqrrrabbbxyyyypqAzz
+ 0: aaaabcxyzzzzpqrrrabbbxyyyypqAzz
+    aaaabcxyzzzzpqrrrabbbxyyyyypqAzz
+ 0: aaaabcxyzzzzpqrrrabbbxyyyyypqAzz
+    aaabcxyzpqrrrabbxyyyypABzz
+ 0: aaabcxyzpqrrrabbxyyyypABzz
+    aaabcxyzpqrrrabbxyyyypABBzz
+ 0: aaabcxyzpqrrrabbxyyyypABBzz
+    >>>aaabxyzpqrrrabbxyyyypqAzz
+ 0: aaabxyzpqrrrabbxyyyypqAzz
+    >aaaabxyzpqrrrabbxyyyypqAzz
+ 0: aaaabxyzpqrrrabbxyyyypqAzz
+    >>>>abcxyzpqrrrabbxyyyypqAzz
+ 0: abcxyzpqrrrabbxyyyypqAzz
+\= Expect no match
+    abxyzpqrrabbxyyyypqAzz
+No match
+    abxyzpqrrrrabbxyyyypqAzz
+No match
+    abxyzpqrrrabxyyyypqAzz
+No match
+    aaaabcxyzzzzpqrrrabbbxyyyyyypqAzz
+No match
+    aaaabcxyzzzzpqrrrabbbxyyypqAzz
+No match
+    aaabcxyzpqrrrabbxyyyypqqqqqqqAzz
+No match
+
+/^(abc){1,2}zz/
+    abczz
+ 0: abczz
+ 1: abc
+    abcabczz
+ 0: abcabczz
+ 1: abc
+\= Expect no match
+    zz
+No match
+    abcabcabczz
+No match
+    >>abczz
+No match
+
+/^(b+?|a){1,2}?c/
+    bc
+ 0: bc
+ 1: b
+    bbc
+ 0: bbc
+ 1: b
+    bbbc
+ 0: bbbc
+ 1: bb
+    bac
+ 0: bac
+ 1: a
+    bbac
+ 0: bbac
+ 1: a
+    aac
+ 0: aac
+ 1: a
+    abbbbbbbbbbbc
+ 0: abbbbbbbbbbbc
+ 1: bbbbbbbbbbb
+    bbbbbbbbbbbac
+ 0: bbbbbbbbbbbac
+ 1: a
+\= Expect no match
+    aaac
+No match
+    abbbbbbbbbbbac
+No match
+
+/^(b+|a){1,2}c/
+    bc
+ 0: bc
+ 1: b
+    bbc
+ 0: bbc
+ 1: bb
+    bbbc
+ 0: bbbc
+ 1: bbb
+    bac
+ 0: bac
+ 1: a
+    bbac
+ 0: bbac
+ 1: a
+    aac
+ 0: aac
+ 1: a
+    abbbbbbbbbbbc
+ 0: abbbbbbbbbbbc
+ 1: bbbbbbbbbbb
+    bbbbbbbbbbbac
+ 0: bbbbbbbbbbbac
+ 1: a
+\= Expect no match
+    aaac
+No match
+    abbbbbbbbbbbac
+No match
+
+/^(b+|a){1,2}?bc/
+    bbc
+ 0: bbc
+ 1: b
+
+/^(b*|ba){1,2}?bc/
+    babc
+ 0: babc
+ 1: ba
+    bbabc
+ 0: bbabc
+ 1: ba
+    bababc
+ 0: bababc
+ 1: ba
+\= Expect no match
+    bababbc
+No match
+    babababc
+No match
+
+/^(ba|b*){1,2}?bc/
+    babc
+ 0: babc
+ 1: ba
+    bbabc
+ 0: bbabc
+ 1: ba
+    bababc
+ 0: bababc
+ 1: ba
+\= Expect no match
+    bababbc
+No match
+    babababc
+No match
+
+#/^\ca\cA\c[;\c:/
+#    \x01\x01\e;z
+# 0: \x01\x01\x1b;z
+
+/^[ab\]cde]/
+    athing
+ 0: a
+    bthing
+ 0: b
+    ]thing
+ 0: ]
+    cthing
+ 0: c
+    dthing
+ 0: d
+    ething
+ 0: e
+\= Expect no match
+    fthing
+No match
+    [thing
+No match
+    \\thing
+No match
+
+/^[]cde]/
+    ]thing
+ 0: ]
+    cthing
+ 0: c
+    dthing
+ 0: d
+    ething
+ 0: e
+\= Expect no match
+    athing
+No match
+    fthing
+No match
+
+/^[^ab\]cde]/
+    fthing
+ 0: f
+    [thing
+ 0: [
+    \\thing
+ 0: \
+\= Expect no match
+    athing
+No match
+    bthing
+No match
+    ]thing
+No match
+    cthing
+No match
+    dthing
+No match
+    ething
+No match
+
+/^[^]cde]/
+    athing
+ 0: a
+    fthing
+ 0: f
+\= Expect no match
+    ]thing
+No match
+    cthing
+No match
+    dthing
+No match
+    ething
+No match
+
+# DLC - I don't get this one
+#/^\/
+#    
+# 0: \x81
+
+#updated to handle 16-bits utf8
+/^ÿ/
+    ÿ
+ 0: \xc3\xbf
+
+/^[0-9]+$/
+    0
+ 0: 0
+    1
+ 0: 1
+    2
+ 0: 2
+    3
+ 0: 3
+    4
+ 0: 4
+    5
+ 0: 5
+    6
+ 0: 6
+    7
+ 0: 7
+    8
+ 0: 8
+    9
+ 0: 9
+    10
+ 0: 10
+    100
+ 0: 100
+\= Expect no match
+    abc
+No match
+
+/^.*nter/
+    enter
+ 0: enter
+    inter
+ 0: inter
+    uponter
+ 0: uponter
+
+/^xxx[0-9]+$/
+    xxx0
+ 0: xxx0
+    xxx1234
+ 0: xxx1234
+\= Expect no match
+    xxx
+No match
+
+/^.+[0-9][0-9][0-9]$/
+    x123
+ 0: x123
+    x1234
+ 0: x1234
+    xx123
+ 0: xx123
+    123456
+ 0: 123456
+\= Expect no match
+    123
+No match
+
+/^.+?[0-9][0-9][0-9]$/
+    x123
+ 0: x123
+    x1234
+ 0: x1234
+    xx123
+ 0: xx123
+    123456
+ 0: 123456
+\= Expect no match
+    123
+No match
+
+/^([^!]+)!(.+)=apquxz\.ixr\.zzz\.ac\.uk$/
+    abc!pqr=apquxz.ixr.zzz.ac.uk
+ 0: abc!pqr=apquxz.ixr.zzz.ac.uk
+ 1: abc
+ 2: pqr
+\= Expect no match
+    !pqr=apquxz.ixr.zzz.ac.uk
+No match
+    abc!=apquxz.ixr.zzz.ac.uk
+No match
+    abc!pqr=apquxz:ixr.zzz.ac.uk
+No match
+    abc!pqr=apquxz.ixr.zzz.ac.ukk
+No match
+
+/:/
+    Well, we need a colon: somewhere
+ 0: :
+\= Expect no match
+    Fail without a colon
+No match
+
+/([\da-f:]+)$/i
+    0abc
+ 0: 0abc
+ 1: 0abc
+    abc
+ 0: abc
+ 1: abc
+    fed
+ 0: fed
+ 1: fed
+    E
+ 0: E
+ 1: E
+    ::
+ 0: ::
+ 1: ::
+    5f03:12C0::932e
+ 0: 5f03:12C0::932e
+ 1: 5f03:12C0::932e
+    fed def
+ 0: def
+ 1: def
+    Any old stuff
+ 0: ff
+ 1: ff
+\= Expect no match
+    0zzz
+No match
+    gzzz
+No match
+    fed\x20
+No match
+    Any old rubbish
+No match
+
+/^.*\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/
+    .1.2.3
+ 0: .1.2.3
+ 1: 1
+ 2: 2
+ 3: 3
+    A.12.123.0
+ 0: A.12.123.0
+ 1: 12
+ 2: 123
+ 3: 0
+\= Expect no match
+    .1.2.3333
+No match
+    1.2.3
+No match
+    1234.2.3
+No match
+
+/^(\d+)\s+IN\s+SOA\s+(\S+)\s+(\S+)\s*\(\s*$/
+    1 IN SOA non-sp1 non-sp2(
+ 0: 1 IN SOA non-sp1 non-sp2(
+ 1: 1
+ 2: non-sp1
+ 3: non-sp2
+    1    IN    SOA    non-sp1    non-sp2   (
+ 0: 1    IN    SOA    non-sp1    non-sp2   (
+ 1: 1
+ 2: non-sp1
+ 3: non-sp2
+\= Expect no match
+    1IN SOA non-sp1 non-sp2(
+No match
+
+/^[a-zA-Z\d][a-zA-Z\d\-]*(\.[a-zA-Z\d][a-zA-z\d\-]*)*\.$/
+    a.
+ 0: a.
+    Z.
+ 0: Z.
+    2.
+ 0: 2.
+    ab-c.pq-r.
+ 0: ab-c.pq-r.
+ 1: .pq-r
+    sxk.zzz.ac.uk.
+ 0: sxk.zzz.ac.uk.
+ 1: .uk
+    x-.y-.
+ 0: x-.y-.
+ 1: .y-
+\= Expect no match
+    -abc.peq.
+No match
+
+/^\*\.[a-z]([a-z\-\d]*[a-z\d]+)?(\.[a-z]([a-z\-\d]*[a-z\d]+)?)*$/
+    *.a
+ 0: *.a
+    *.b0-a
+ 0: *.b0-a
+ 1: 0-a
+    *.c3-b.c
+ 0: *.c3-b.c
+ 1: 3-b
+ 2: .c
+    *.c-a.b-c
+ 0: *.c-a.b-c
+ 1: -a
+ 2: .b-c
+ 3: -c
+\= Expect no match
+    *.0
+No match
+    *.a-
+No match
+    *.a-b.c-
+No match
+    *.c-a.0-c
+No match
+
+/^(?=ab(de))(abd)(e)/
+    abde
+ 0: abde
+ 1: de
+ 2: abd
+ 3: e
+
+/^(?!(ab)de|x)(abd)(f)/
+    abdf
+ 0: abdf
+ 1: <unset>
+ 2: abd
+ 3: f
+
+/^(?=(ab(cd)))(ab)/
+    abcd
+ 0: ab
+ 1: abcd
+ 2: cd
+ 3: ab
+
+/^[\da-f](\.[\da-f])*$/i
+    a.b.c.d
+ 0: a.b.c.d
+ 1: .d
+    A.B.C.D
+ 0: A.B.C.D
+ 1: .D
+    a.b.c.1.2.3.C
+ 0: a.b.c.1.2.3.C
+ 1: .C
+
+/^\".*\"\s*(;.*)?$/
+    \"1234\"
+ 0: "1234"
+    \"abcd\" ;
+ 0: "abcd" ;
+ 1: ;
+    \"\" ; rhubarb
+ 0: "" ; rhubarb
+ 1: ; rhubarb
+\= Expect no match
+    \"1234\" : things
+No match
+
+/^$/
+    \
+ 0: 
+\= Expect no match
+    A non-empty line
+No match
+
+/   ^    a   (?# begins with a)  b\sc (?# then b c) $ (?# then end)/x
+    ab c
+ 0: ab c
+\= Expect no match
+    abc
+No match
+    ab cde
+No match
+
+/(?x)   ^    a   (?# begins with a)  b\sc (?# then b c) $ (?# then end)/
+    ab c
+ 0: ab c
+\= Expect no match
+    abc
+No match
+    ab cde
+No match
+
+/^   a\ b[c ]d       $/x
+    a bcd
+ 0: a bcd
+    a b d
+ 0: a b d
+\= Expect no match
+    abcd
+No match
+    ab d
+No match
+
+/^(a(b(c)))(d(e(f)))(h(i(j)))(k(l(m)))$/
+    abcdefhijklm
+ 0: abcdefhijklm
+ 1: abc
+ 2: bc
+ 3: c
+ 4: def
+ 5: ef
+ 6: f
+ 7: hij
+ 8: ij
+ 9: j
+10: klm
+11: lm
+12: m
+
+/^(?:a(b(c)))(?:d(e(f)))(?:h(i(j)))(?:k(l(m)))$/
+    abcdefhijklm
+ 0: abcdefhijklm
+ 1: bc
+ 2: c
+ 3: ef
+ 4: f
+ 5: ij
+ 6: j
+ 7: lm
+ 8: m
+
+#/^[\w][\W][\s][\S][\d][\D][\b][\n][\c]][\022]/
+#    a+ Z0+\x08\n\x1d\x12
+# 0: a+ Z0+\x08\x0a\x1d\x12
+
+/^[.^$|()*+?{,}]+/
+    .^\$(*+)|{?,?}
+ 0: .^$(*+)|{?,?}
+
+/^a*\w/
+    z
+ 0: z
+    az
+ 0: az
+    aaaz
+ 0: aaaz
+    a
+ 0: a
+    aa
+ 0: aa
+    aaaa
+ 0: aaaa
+    a+
+ 0: a
+    aa+
+ 0: aa
+
+/^a*?\w/
+    z
+ 0: z
+    az
+ 0: a
+    aaaz
+ 0: a
+    a
+ 0: a
+    aa
+ 0: a
+    aaaa
+ 0: a
+    a+
+ 0: a
+    aa+
+ 0: a
+
+/^a+\w/
+    az
+ 0: az
+    aaaz
+ 0: aaaz
+    aa
+ 0: aa
+    aaaa
+ 0: aaaa
+    aa+
+ 0: aa
+
+/^a+?\w/
+    az
+ 0: az
+    aaaz
+ 0: aa
+    aa
+ 0: aa
+    aaaa
+ 0: aa
+    aa+
+ 0: aa
+
+/^\d{8}\w{2,}/
+    1234567890
+ 0: 1234567890
+    12345678ab
+ 0: 12345678ab
+    12345678__
+ 0: 12345678__
+\= Expect no match
+    1234567
+No match
+
+/^[aeiou\d]{4,5}$/
+    uoie
+ 0: uoie
+    1234
+ 0: 1234
+    12345
+ 0: 12345
+    aaaaa
+ 0: aaaaa
+\= Expect no match
+    123456
+No match
+
+/^[aeiou\d]{4,5}?/
+    uoie
+ 0: uoie
+    1234
+ 0: 1234
+    12345
+ 0: 1234
+    aaaaa
+ 0: aaaa
+    123456
+ 0: 1234
+
+/\A(abc|def)=(\1){2,3}\Z/
+    abc=abcabc
+ 0: abc=abcabc
+ 1: abc
+ 2: abc
+    def=defdefdef
+ 0: def=defdefdef
+ 1: def
+ 2: def
+\= Expect no match
+    abc=defdef
+No match
+
+/^(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)\11*(\3\4)\1(?#)2$/
+    abcdefghijkcda2
+ 0: abcdefghijkcda2
+ 1: a
+ 2: b
+ 3: c
+ 4: d
+ 5: e
+ 6: f
+ 7: g
+ 8: h
+ 9: i
+10: j
+11: k
+12: cd
+    abcdefghijkkkkcda2
+ 0: abcdefghijkkkkcda2
+ 1: a
+ 2: b
+ 3: c
+ 4: d
+ 5: e
+ 6: f
+ 7: g
+ 8: h
+ 9: i
+10: j
+11: k
+12: cd
+
+/(cat(a(ract|tonic)|erpillar)) \1()2(3)/
+    cataract cataract23
+ 0: cataract cataract23
+ 1: cataract
+ 2: aract
+ 3: ract
+ 4: 
+ 5: 3
+    catatonic catatonic23
+ 0: catatonic catatonic23
+ 1: catatonic
+ 2: atonic
+ 3: tonic
+ 4: 
+ 5: 3
+    caterpillar caterpillar23
+ 0: caterpillar caterpillar23
+ 1: caterpillar
+ 2: erpillar
+ 3: <unset>
+ 4: 
+ 5: 3
+
+
+/^From +([^ ]+) +[a-zA-Z][a-zA-Z][a-zA-Z] +[a-zA-Z][a-zA-Z][a-zA-Z] +[0-9]?[0-9] +[0-9][0-9]:[0-9][0-9]/
+    From abcd  Mon Sep 01 12:33:02 1997
+ 0: From abcd  Mon Sep 01 12:33
+ 1: abcd
+
+/^From\s+\S+\s+([a-zA-Z]{3}\s+){2}\d{1,2}\s+\d\d:\d\d/
+    From abcd  Mon Sep 01 12:33:02 1997
+ 0: From abcd  Mon Sep 01 12:33
+ 1: Sep 
+    From abcd  Mon Sep  1 12:33:02 1997
+ 0: From abcd  Mon Sep  1 12:33
+ 1: Sep  
+\= Expect no match
+    From abcd  Sep 01 12:33:02 1997
+No match
+
+/^12.34/s
+    12\n34
+ 0: 12\x0a34
+    12\r34
+ 0: 12\x0d34
+
+/\w+(?=\t)/
+    the quick brown\t fox
+ 0: brown
+
+/foo(?!bar)(.*)/
+    foobar is foolish see?
+ 0: foolish see?
+ 1: lish see?
+
+/(?:(?!foo)...|^.{0,2})bar(.*)/
+    foobar crowbar etc
+ 0: rowbar etc
+ 1:  etc
+    barrel
+ 0: barrel
+ 1: rel
+    2barrel
+ 0: 2barrel
+ 1: rel
+    A barrel
+ 0: A barrel
+ 1: rel
+
+/^(\D*)(?=\d)(?!123)/
+    abc456
+ 0: abc
+ 1: abc
+\= Expect no match
+    abc123
+No match
+
+/^1234(?# test newlines
+  inside)/
+    1234
+ 0: 1234
+
+/^1234 #comment in extended re
+  /x
+    1234
+ 0: 1234
+
+/#rhubarb
+  abcd/x
+    abcd
+ 0: abcd
+
+/^abcd#rhubarb/x
+    abcd
+ 0: abcd
+
+/^(a)\1{2,3}(.)/
+    aaab
+ 0: aaab
+ 1: a
+ 2: b
+    aaaab
+ 0: aaaab
+ 1: a
+ 2: b
+    aaaaab
+ 0: aaaaa
+ 1: a
+ 2: a
+    aaaaaab
+ 0: aaaaa
+ 1: a
+ 2: a
+
+/(?!^)abc/
+    the abc
+ 0: abc
+\= Expect no match
+    abc
+No match
+
+/(?=^)abc/
+    abc
+ 0: abc
+\= Expect no match
+    the abc
+No match
+
+/^[ab]{1,3}(ab*|b)/
+    aabbbbb
+ 0: aabb
+ 1: b
+
+/^[ab]{1,3}?(ab*|b)/
+    aabbbbb
+ 0: aabbbbb
+ 1: abbbbb
+
+/^[ab]{1,3}?(ab*?|b)/
+    aabbbbb
+ 0: aa
+ 1: a
+
+/^[ab]{1,3}(ab*?|b)/
+    aabbbbb
+ 0: aabb
+ 1: b
+
+/  (?: [\040\t] |  \(
+(?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  |  \( (?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  )* \)  )*
+\)  )*                          # optional leading comment
+(?:    (?:
+[^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]+    # some number of atom characters...
+(?![^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]) # ..not followed by something that could be part of an atom
+|
+" (?:                      # opening quote...
+[^\\\x80-\xff\n\015"]                #   Anything except backslash and quote
+|                     #    or
+\\ [^\x80-\xff]           #   Escaped something (something != CR)
+)* "  # closing quote
+)                    # initial word
+(?:  (?: [\040\t] |  \(
+(?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  |  \( (?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  )* \)  )*
+\)  )*  \.  (?: [\040\t] |  \(
+(?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  |  \( (?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  )* \)  )*
+\)  )*   (?:
+[^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]+    # some number of atom characters...
+(?![^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]) # ..not followed by something that could be part of an atom
+|
+" (?:                      # opening quote...
+[^\\\x80-\xff\n\015"]                #   Anything except backslash and quote
+|                     #    or
+\\ [^\x80-\xff]           #   Escaped something (something != CR)
+)* "  # closing quote
+)  )* # further okay, if led by a period
+(?: [\040\t] |  \(
+(?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  |  \( (?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  )* \)  )*
+\)  )*  @  (?: [\040\t] |  \(
+(?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  |  \( (?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  )* \)  )*
+\)  )*    (?:
+[^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]+    # some number of atom characters...
+(?![^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]) # ..not followed by something that could be part of an atom
+|   \[                         # [
+(?: [^\\\x80-\xff\n\015\[\]] |  \\ [^\x80-\xff]  )*    #    stuff
+\]                        #           ]
+)                           # initial subdomain
+(?:                                  #
+(?: [\040\t] |  \(
+(?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  |  \( (?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  )* \)  )*
+\)  )*  \.                        # if led by a period...
+(?: [\040\t] |  \(
+(?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  |  \( (?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  )* \)  )*
+\)  )*   (?:
+[^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]+    # some number of atom characters...
+(?![^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]) # ..not followed by something that could be part of an atom
+|   \[                         # [
+(?: [^\\\x80-\xff\n\015\[\]] |  \\ [^\x80-\xff]  )*    #    stuff
+\]                        #           ]
+)                     #   ...further okay
+)*
+# address
+|                     #  or
+(?:
+[^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]+    # some number of atom characters...
+(?![^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]) # ..not followed by something that could be part of an atom
+|
+" (?:                      # opening quote...
+[^\\\x80-\xff\n\015"]                #   Anything except backslash and quote
+|                     #    or
+\\ [^\x80-\xff]           #   Escaped something (something != CR)
+)* "  # closing quote
+)             # one word, optionally followed by....
+(?:
+[^()<>@,;:".\\\[\]\x80-\xff\000-\010\012-\037]  |  # atom and space parts, or...
+\(
+(?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  |  \( (?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  )* \)  )*
+\)       |  # comments, or...
+
+" (?:                      # opening quote...
+[^\\\x80-\xff\n\015"]                #   Anything except backslash and quote
+|                     #    or
+\\ [^\x80-\xff]           #   Escaped something (something != CR)
+)* "  # closing quote
+# quoted strings
+)*
+<  (?: [\040\t] |  \(
+(?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  |  \( (?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  )* \)  )*
+\)  )*                     # leading <
+(?:  @  (?: [\040\t] |  \(
+(?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  |  \( (?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  )* \)  )*
+\)  )*    (?:
+[^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]+    # some number of atom characters...
+(?![^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]) # ..not followed by something that could be part of an atom
+|   \[                         # [
+(?: [^\\\x80-\xff\n\015\[\]] |  \\ [^\x80-\xff]  )*    #    stuff
+\]                        #           ]
+)                           # initial subdomain
+(?:                                  #
+(?: [\040\t] |  \(
+(?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  |  \( (?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  )* \)  )*
+\)  )*  \.                        # if led by a period...
+(?: [\040\t] |  \(
+(?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  |  \( (?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  )* \)  )*
+\)  )*   (?:
+[^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]+    # some number of atom characters...
+(?![^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]) # ..not followed by something that could be part of an atom
+|   \[                         # [
+(?: [^\\\x80-\xff\n\015\[\]] |  \\ [^\x80-\xff]  )*    #    stuff
+\]                        #           ]
+)                     #   ...further okay
+)*
+
+(?:  (?: [\040\t] |  \(
+(?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  |  \( (?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  )* \)  )*
+\)  )*  ,  (?: [\040\t] |  \(
+(?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  |  \( (?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  )* \)  )*
+\)  )*  @  (?: [\040\t] |  \(
+(?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  |  \( (?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  )* \)  )*
+\)  )*    (?:
+[^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]+    # some number of atom characters...
+(?![^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]) # ..not followed by something that could be part of an atom
+|   \[                         # [
+(?: [^\\\x80-\xff\n\015\[\]] |  \\ [^\x80-\xff]  )*    #    stuff
+\]                        #           ]
+)                           # initial subdomain
+(?:                                  #
+(?: [\040\t] |  \(
+(?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  |  \( (?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  )* \)  )*
+\)  )*  \.                        # if led by a period...
+(?: [\040\t] |  \(
+(?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  |  \( (?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  )* \)  )*
+\)  )*   (?:
+[^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]+    # some number of atom characters...
+(?![^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]) # ..not followed by something that could be part of an atom
+|   \[                         # [
+(?: [^\\\x80-\xff\n\015\[\]] |  \\ [^\x80-\xff]  )*    #    stuff
+\]                        #           ]
+)                     #   ...further okay
+)*
+)* # further okay, if led by comma
+:                                # closing colon
+(?: [\040\t] |  \(
+(?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  |  \( (?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  )* \)  )*
+\)  )*  )? #       optional route
+(?:
+[^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]+    # some number of atom characters...
+(?![^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]) # ..not followed by something that could be part of an atom
+|
+" (?:                      # opening quote...
+[^\\\x80-\xff\n\015"]                #   Anything except backslash and quote
+|                     #    or
+\\ [^\x80-\xff]           #   Escaped something (something != CR)
+)* "  # closing quote
+)                    # initial word
+(?:  (?: [\040\t] |  \(
+(?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  |  \( (?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  )* \)  )*
+\)  )*  \.  (?: [\040\t] |  \(
+(?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  |  \( (?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  )* \)  )*
+\)  )*   (?:
+[^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]+    # some number of atom characters...
+(?![^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]) # ..not followed by something that could be part of an atom
+|
+" (?:                      # opening quote...
+[^\\\x80-\xff\n\015"]                #   Anything except backslash and quote
+|                     #    or
+\\ [^\x80-\xff]           #   Escaped something (something != CR)
+)* "  # closing quote
+)  )* # further okay, if led by a period
+(?: [\040\t] |  \(
+(?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  |  \( (?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  )* \)  )*
+\)  )*  @  (?: [\040\t] |  \(
+(?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  |  \( (?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  )* \)  )*
+\)  )*    (?:
+[^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]+    # some number of atom characters...
+(?![^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]) # ..not followed by something that could be part of an atom
+|   \[                         # [
+(?: [^\\\x80-\xff\n\015\[\]] |  \\ [^\x80-\xff]  )*    #    stuff
+\]                        #           ]
+)                           # initial subdomain
+(?:                                  #
+(?: [\040\t] |  \(
+(?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  |  \( (?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  )* \)  )*
+\)  )*  \.                        # if led by a period...
+(?: [\040\t] |  \(
+(?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  |  \( (?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  )* \)  )*
+\)  )*   (?:
+[^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]+    # some number of atom characters...
+(?![^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]) # ..not followed by something that could be part of an atom
+|   \[                         # [
+(?: [^\\\x80-\xff\n\015\[\]] |  \\ [^\x80-\xff]  )*    #    stuff
+\]                        #           ]
+)                     #   ...further okay
+)*
+#       address spec
+(?: [\040\t] |  \(
+(?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  |  \( (?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  )* \)  )*
+\)  )*  > #                  trailing >
+# name and address
+)  (?: [\040\t] |  \(
+(?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  |  \( (?:  [^\\\x80-\xff\n\015()]  |  \\ [^\x80-\xff]  )* \)  )*
+\)  )*                       # optional trailing comment
+/x
+    Alan Other <user\@dom.ain>
+ 0: Alan Other <user@dom.ain>
+    <user\@dom.ain>
+ 0: user@dom.ain
+    user\@dom.ain
+ 0: user@dom.ain
+    \"A. Other\" <user.1234\@dom.ain> (a comment)
+ 0: "A. Other" <user.1234@dom.ain> (a comment)
+    A. Other <user.1234\@dom.ain> (a comment)
+ 0:  Other <user.1234@dom.ain> (a comment)
+    \"/s=user/ou=host/o=place/prmd=uu.yy/admd= /c=gb/\"\@x400-re.lay
+ 0: "/s=user/ou=host/o=place/prmd=uu.yy/admd= /c=gb/"@x400-re.lay
+    A missing angle <user\@some.where
+ 0: user@some.where
+\= Expect no match
+    The quick brown fox
+No match
+
+/[\040\t]*                    # Nab whitespace.
+(?:
+\(                              #  (
+[^\\\x80-\xff\n\015()] *                             #     normal*
+(?:                                 #       (
+(?:  \\ [^\x80-\xff]  |
+\(                            #  (
+[^\\\x80-\xff\n\015()] *                            #     normal*
+(?:  \\ [^\x80-\xff]   [^\\\x80-\xff\n\015()] * )*        #     (special normal*)*
+\)                           #                       )
+)    #         special
+[^\\\x80-\xff\n\015()] *                         #         normal*
+)*                                  #            )*
+\)                             #                )
+[\040\t]* )*    # If comment found, allow more spaces.
+# optional leading comment
+(?:
+(?:
+[^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]+    # some number of atom characters...
+(?![^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]) # ..not followed by something that could be part of an atom
+# Atom
+|                       #  or
+"                                     # "
+[^\\\x80-\xff\n\015"] *                            #   normal
+(?:  \\ [^\x80-\xff]  [^\\\x80-\xff\n\015"] * )*        #   ( special normal* )*
+"                                     #        "
+# Quoted string
+)
+[\040\t]*                    # Nab whitespace.
+(?:
+\(                              #  (
+[^\\\x80-\xff\n\015()] *                             #     normal*
+(?:                                 #       (
+(?:  \\ [^\x80-\xff]  |
+\(                            #  (
+[^\\\x80-\xff\n\015()] *                            #     normal*
+(?:  \\ [^\x80-\xff]   [^\\\x80-\xff\n\015()] * )*        #     (special normal*)*
+\)                           #                       )
+)    #         special
+[^\\\x80-\xff\n\015()] *                         #         normal*
+)*                                  #            )*
+\)                             #                )
+[\040\t]* )*    # If comment found, allow more spaces.
+(?:
+\.
+[\040\t]*                    # Nab whitespace.
+(?:
+\(                              #  (
+[^\\\x80-\xff\n\015()] *                             #     normal*
+(?:                                 #       (
+(?:  \\ [^\x80-\xff]  |
+\(                            #  (
+[^\\\x80-\xff\n\015()] *                            #     normal*
+(?:  \\ [^\x80-\xff]   [^\\\x80-\xff\n\015()] * )*        #     (special normal*)*
+\)                           #                       )
+)    #         special
+[^\\\x80-\xff\n\015()] *                         #         normal*
+)*                                  #            )*
+\)                             #                )
+[\040\t]* )*    # If comment found, allow more spaces.
+(?:
+[^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]+    # some number of atom characters...
+(?![^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]) # ..not followed by something that could be part of an atom
+# Atom
+|                       #  or
+"                                     # "
+[^\\\x80-\xff\n\015"] *                            #   normal
+(?:  \\ [^\x80-\xff]  [^\\\x80-\xff\n\015"] * )*        #   ( special normal* )*
+"                                     #        "
+# Quoted string
+)
+[\040\t]*                    # Nab whitespace.
+(?:
+\(                              #  (
+[^\\\x80-\xff\n\015()] *                             #     normal*
+(?:                                 #       (
+(?:  \\ [^\x80-\xff]  |
+\(                            #  (
+[^\\\x80-\xff\n\015()] *                            #     normal*
+(?:  \\ [^\x80-\xff]   [^\\\x80-\xff\n\015()] * )*        #     (special normal*)*
+\)                           #                       )
+)    #         special
+[^\\\x80-\xff\n\015()] *                         #         normal*
+)*                                  #            )*
+\)                             #                )
+[\040\t]* )*    # If comment found, allow more spaces.
+# additional words
+)*
+@
+[\040\t]*                    # Nab whitespace.
+(?:
+\(                              #  (
+[^\\\x80-\xff\n\015()] *                             #     normal*
+(?:                                 #       (
+(?:  \\ [^\x80-\xff]  |
+\(                            #  (
+[^\\\x80-\xff\n\015()] *                            #     normal*
+(?:  \\ [^\x80-\xff]   [^\\\x80-\xff\n\015()] * )*        #     (special normal*)*
+\)                           #                       )
+)    #         special
+[^\\\x80-\xff\n\015()] *                         #         normal*
+)*                                  #            )*
+\)                             #                )
+[\040\t]* )*    # If comment found, allow more spaces.
+(?:
+[^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]+    # some number of atom characters...
+(?![^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]) # ..not followed by something that could be part of an atom
+|
+\[                            # [
+(?: [^\\\x80-\xff\n\015\[\]] |  \\ [^\x80-\xff]  )*     #    stuff
+\]                           #           ]
+)
+[\040\t]*                    # Nab whitespace.
+(?:
+\(                              #  (
+[^\\\x80-\xff\n\015()] *                             #     normal*
+(?:                                 #       (
+(?:  \\ [^\x80-\xff]  |
+\(                            #  (
+[^\\\x80-\xff\n\015()] *                            #     normal*
+(?:  \\ [^\x80-\xff]   [^\\\x80-\xff\n\015()] * )*        #     (special normal*)*
+\)                           #                       )
+)    #         special
+[^\\\x80-\xff\n\015()] *                         #         normal*
+)*                                  #            )*
+\)                             #                )
+[\040\t]* )*    # If comment found, allow more spaces.
+# optional trailing comments
+(?:
+\.
+[\040\t]*                    # Nab whitespace.
+(?:
+\(                              #  (
+[^\\\x80-\xff\n\015()] *                             #     normal*
+(?:                                 #       (
+(?:  \\ [^\x80-\xff]  |
+\(                            #  (
+[^\\\x80-\xff\n\015()] *                            #     normal*
+(?:  \\ [^\x80-\xff]   [^\\\x80-\xff\n\015()] * )*        #     (special normal*)*
+\)                           #                       )
+)    #         special
+[^\\\x80-\xff\n\015()] *                         #         normal*
+)*                                  #            )*
+\)                             #                )
+[\040\t]* )*    # If comment found, allow more spaces.
+(?:
+[^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]+    # some number of atom characters...
+(?![^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]) # ..not followed by something that could be part of an atom
+|
+\[                            # [
+(?: [^\\\x80-\xff\n\015\[\]] |  \\ [^\x80-\xff]  )*     #    stuff
+\]                           #           ]
+)
+[\040\t]*                    # Nab whitespace.
+(?:
+\(                              #  (
+[^\\\x80-\xff\n\015()] *                             #     normal*
+(?:                                 #       (
+(?:  \\ [^\x80-\xff]  |
+\(                            #  (
+[^\\\x80-\xff\n\015()] *                            #     normal*
+(?:  \\ [^\x80-\xff]   [^\\\x80-\xff\n\015()] * )*        #     (special normal*)*
+\)                           #                       )
+)    #         special
+[^\\\x80-\xff\n\015()] *                         #         normal*
+)*                                  #            )*
+\)                             #                )
+[\040\t]* )*    # If comment found, allow more spaces.
+# optional trailing comments
+)*
+# address
+|                             #  or
+(?:
+[^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]+    # some number of atom characters...
+(?![^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]) # ..not followed by something that could be part of an atom
+# Atom
+|                       #  or
+"                                     # "
+[^\\\x80-\xff\n\015"] *                            #   normal
+(?:  \\ [^\x80-\xff]  [^\\\x80-\xff\n\015"] * )*        #   ( special normal* )*
+"                                     #        "
+# Quoted string
+)
+# leading word
+[^()<>@,;:".\\\[\]\x80-\xff\000-\010\012-\037] *               # "normal" atoms and or spaces
+(?:
+(?:
+\(                              #  (
+[^\\\x80-\xff\n\015()] *                             #     normal*
+(?:                                 #       (
+(?:  \\ [^\x80-\xff]  |
+\(                            #  (
+[^\\\x80-\xff\n\015()] *                            #     normal*
+(?:  \\ [^\x80-\xff]   [^\\\x80-\xff\n\015()] * )*        #     (special normal*)*
+\)                           #                       )
+)    #         special
+[^\\\x80-\xff\n\015()] *                         #         normal*
+)*                                  #            )*
+\)                             #                )
+|
+"                                     # "
+[^\\\x80-\xff\n\015"] *                            #   normal
+(?:  \\ [^\x80-\xff]  [^\\\x80-\xff\n\015"] * )*        #   ( special normal* )*
+"                                     #        "
+) # "special" comment or quoted string
+[^()<>@,;:".\\\[\]\x80-\xff\000-\010\012-\037] *            #  more "normal"
+)*
+<
+[\040\t]*                    # Nab whitespace.
+(?:
+\(                              #  (
+[^\\\x80-\xff\n\015()] *                             #     normal*
+(?:                                 #       (
+(?:  \\ [^\x80-\xff]  |
+\(                            #  (
+[^\\\x80-\xff\n\015()] *                            #     normal*
+(?:  \\ [^\x80-\xff]   [^\\\x80-\xff\n\015()] * )*        #     (special normal*)*
+\)                           #                       )
+)    #         special
+[^\\\x80-\xff\n\015()] *                         #         normal*
+)*                                  #            )*
+\)                             #                )
+[\040\t]* )*    # If comment found, allow more spaces.
+# <
+(?:
+@
+[\040\t]*                    # Nab whitespace.
+(?:
+\(                              #  (
+[^\\\x80-\xff\n\015()] *                             #     normal*
+(?:                                 #       (
+(?:  \\ [^\x80-\xff]  |
+\(                            #  (
+[^\\\x80-\xff\n\015()] *                            #     normal*
+(?:  \\ [^\x80-\xff]   [^\\\x80-\xff\n\015()] * )*        #     (special normal*)*
+\)                           #                       )
+)    #         special
+[^\\\x80-\xff\n\015()] *                         #         normal*
+)*                                  #            )*
+\)                             #                )
+[\040\t]* )*    # If comment found, allow more spaces.
+(?:
+[^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]+    # some number of atom characters...
+(?![^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]) # ..not followed by something that could be part of an atom
+|
+\[                            # [
+(?: [^\\\x80-\xff\n\015\[\]] |  \\ [^\x80-\xff]  )*     #    stuff
+\]                           #           ]
+)
+[\040\t]*                    # Nab whitespace.
+(?:
+\(                              #  (
+[^\\\x80-\xff\n\015()] *                             #     normal*
+(?:                                 #       (
+(?:  \\ [^\x80-\xff]  |
+\(                            #  (
+[^\\\x80-\xff\n\015()] *                            #     normal*
+(?:  \\ [^\x80-\xff]   [^\\\x80-\xff\n\015()] * )*        #     (special normal*)*
+\)                           #                       )
+)    #         special
+[^\\\x80-\xff\n\015()] *                         #         normal*
+)*                                  #            )*
+\)                             #                )
+[\040\t]* )*    # If comment found, allow more spaces.
+# optional trailing comments
+(?:
+\.
+[\040\t]*                    # Nab whitespace.
+(?:
+\(                              #  (
+[^\\\x80-\xff\n\015()] *                             #     normal*
+(?:                                 #       (
+(?:  \\ [^\x80-\xff]  |
+\(                            #  (
+[^\\\x80-\xff\n\015()] *                            #     normal*
+(?:  \\ [^\x80-\xff]   [^\\\x80-\xff\n\015()] * )*        #     (special normal*)*
+\)                           #                       )
+)    #         special
+[^\\\x80-\xff\n\015()] *                         #         normal*
+)*                                  #            )*
+\)                             #                )
+[\040\t]* )*    # If comment found, allow more spaces.
+(?:
+[^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]+    # some number of atom characters...
+(?![^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]) # ..not followed by something that could be part of an atom
+|
+\[                            # [
+(?: [^\\\x80-\xff\n\015\[\]] |  \\ [^\x80-\xff]  )*     #    stuff
+\]                           #           ]
+)
+[\040\t]*                    # Nab whitespace.
+(?:
+\(                              #  (
+[^\\\x80-\xff\n\015()] *                             #     normal*
+(?:                                 #       (
+(?:  \\ [^\x80-\xff]  |
+\(                            #  (
+[^\\\x80-\xff\n\015()] *                            #     normal*
+(?:  \\ [^\x80-\xff]   [^\\\x80-\xff\n\015()] * )*        #     (special normal*)*
+\)                           #                       )
+)    #         special
+[^\\\x80-\xff\n\015()] *                         #         normal*
+)*                                  #            )*
+\)                             #                )
+[\040\t]* )*    # If comment found, allow more spaces.
+# optional trailing comments
+)*
+(?: ,
+[\040\t]*                    # Nab whitespace.
+(?:
+\(                              #  (
+[^\\\x80-\xff\n\015()] *                             #     normal*
+(?:                                 #       (
+(?:  \\ [^\x80-\xff]  |
+\(                            #  (
+[^\\\x80-\xff\n\015()] *                            #     normal*
+(?:  \\ [^\x80-\xff]   [^\\\x80-\xff\n\015()] * )*        #     (special normal*)*
+\)                           #                       )
+)    #         special
+[^\\\x80-\xff\n\015()] *                         #         normal*
+)*                                  #            )*
+\)                             #                )
+[\040\t]* )*    # If comment found, allow more spaces.
+@
+[\040\t]*                    # Nab whitespace.
+(?:
+\(                              #  (
+[^\\\x80-\xff\n\015()] *                             #     normal*
+(?:                                 #       (
+(?:  \\ [^\x80-\xff]  |
+\(                            #  (
+[^\\\x80-\xff\n\015()] *                            #     normal*
+(?:  \\ [^\x80-\xff]   [^\\\x80-\xff\n\015()] * )*        #     (special normal*)*
+\)                           #                       )
+)    #         special
+[^\\\x80-\xff\n\015()] *                         #         normal*
+)*                                  #            )*
+\)                             #                )
+[\040\t]* )*    # If comment found, allow more spaces.
+(?:
+[^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]+    # some number of atom characters...
+(?![^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]) # ..not followed by something that could be part of an atom
+|
+\[                            # [
+(?: [^\\\x80-\xff\n\015\[\]] |  \\ [^\x80-\xff]  )*     #    stuff
+\]                           #           ]
+)
+[\040\t]*                    # Nab whitespace.
+(?:
+\(                              #  (
+[^\\\x80-\xff\n\015()] *                             #     normal*
+(?:                                 #       (
+(?:  \\ [^\x80-\xff]  |
+\(                            #  (
+[^\\\x80-\xff\n\015()] *                            #     normal*
+(?:  \\ [^\x80-\xff]   [^\\\x80-\xff\n\015()] * )*        #     (special normal*)*
+\)                           #                       )
+)    #         special
+[^\\\x80-\xff\n\015()] *                         #         normal*
+)*                                  #            )*
+\)                             #                )
+[\040\t]* )*    # If comment found, allow more spaces.
+# optional trailing comments
+(?:
+\.
+[\040\t]*                    # Nab whitespace.
+(?:
+\(                              #  (
+[^\\\x80-\xff\n\015()] *                             #     normal*
+(?:                                 #       (
+(?:  \\ [^\x80-\xff]  |
+\(                            #  (
+[^\\\x80-\xff\n\015()] *                            #     normal*
+(?:  \\ [^\x80-\xff]   [^\\\x80-\xff\n\015()] * )*        #     (special normal*)*
+\)                           #                       )
+)    #         special
+[^\\\x80-\xff\n\015()] *                         #         normal*
+)*                                  #            )*
+\)                             #                )
+[\040\t]* )*    # If comment found, allow more spaces.
+(?:
+[^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]+    # some number of atom characters...
+(?![^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]) # ..not followed by something that could be part of an atom
+|
+\[                            # [
+(?: [^\\\x80-\xff\n\015\[\]] |  \\ [^\x80-\xff]  )*     #    stuff
+\]                           #           ]
+)
+[\040\t]*                    # Nab whitespace.
+(?:
+\(                              #  (
+[^\\\x80-\xff\n\015()] *                             #     normal*
+(?:                                 #       (
+(?:  \\ [^\x80-\xff]  |
+\(                            #  (
+[^\\\x80-\xff\n\015()] *                            #     normal*
+(?:  \\ [^\x80-\xff]   [^\\\x80-\xff\n\015()] * )*        #     (special normal*)*
+\)                           #                       )
+)    #         special
+[^\\\x80-\xff\n\015()] *                         #         normal*
+)*                                  #            )*
+\)                             #                )
+[\040\t]* )*    # If comment found, allow more spaces.
+# optional trailing comments
+)*
+)*  # additional domains
+:
+[\040\t]*                    # Nab whitespace.
+(?:
+\(                              #  (
+[^\\\x80-\xff\n\015()] *                             #     normal*
+(?:                                 #       (
+(?:  \\ [^\x80-\xff]  |
+\(                            #  (
+[^\\\x80-\xff\n\015()] *                            #     normal*
+(?:  \\ [^\x80-\xff]   [^\\\x80-\xff\n\015()] * )*        #     (special normal*)*
+\)                           #                       )
+)    #         special
+[^\\\x80-\xff\n\015()] *                         #         normal*
+)*                                  #            )*
+\)                             #                )
+[\040\t]* )*    # If comment found, allow more spaces.
+# optional trailing comments
+)?     #       optional route
+(?:
+[^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]+    # some number of atom characters...
+(?![^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]) # ..not followed by something that could be part of an atom
+# Atom
+|                       #  or
+"                                     # "
+[^\\\x80-\xff\n\015"] *                            #   normal
+(?:  \\ [^\x80-\xff]  [^\\\x80-\xff\n\015"] * )*        #   ( special normal* )*
+"                                     #        "
+# Quoted string
+)
+[\040\t]*                    # Nab whitespace.
+(?:
+\(                              #  (
+[^\\\x80-\xff\n\015()] *                             #     normal*
+(?:                                 #       (
+(?:  \\ [^\x80-\xff]  |
+\(                            #  (
+[^\\\x80-\xff\n\015()] *                            #     normal*
+(?:  \\ [^\x80-\xff]   [^\\\x80-\xff\n\015()] * )*        #     (special normal*)*
+\)                           #                       )
+)    #         special
+[^\\\x80-\xff\n\015()] *                         #         normal*
+)*                                  #            )*
+\)                             #                )
+[\040\t]* )*    # If comment found, allow more spaces.
+(?:
+\.
+[\040\t]*                    # Nab whitespace.
+(?:
+\(                              #  (
+[^\\\x80-\xff\n\015()] *                             #     normal*
+(?:                                 #       (
+(?:  \\ [^\x80-\xff]  |
+\(                            #  (
+[^\\\x80-\xff\n\015()] *                            #     normal*
+(?:  \\ [^\x80-\xff]   [^\\\x80-\xff\n\015()] * )*        #     (special normal*)*
+\)                           #                       )
+)    #         special
+[^\\\x80-\xff\n\015()] *                         #         normal*
+)*                                  #            )*
+\)                             #                )
+[\040\t]* )*    # If comment found, allow more spaces.
+(?:
+[^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]+    # some number of atom characters...
+(?![^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]) # ..not followed by something that could be part of an atom
+# Atom
+|                       #  or
+"                                     # "
+[^\\\x80-\xff\n\015"] *                            #   normal
+(?:  \\ [^\x80-\xff]  [^\\\x80-\xff\n\015"] * )*        #   ( special normal* )*
+"                                     #        "
+# Quoted string
+)
+[\040\t]*                    # Nab whitespace.
+(?:
+\(                              #  (
+[^\\\x80-\xff\n\015()] *                             #     normal*
+(?:                                 #       (
+(?:  \\ [^\x80-\xff]  |
+\(                            #  (
+[^\\\x80-\xff\n\015()] *                            #     normal*
+(?:  \\ [^\x80-\xff]   [^\\\x80-\xff\n\015()] * )*        #     (special normal*)*
+\)                           #                       )
+)    #         special
+[^\\\x80-\xff\n\015()] *                         #         normal*
+)*                                  #            )*
+\)                             #                )
+[\040\t]* )*    # If comment found, allow more spaces.
+# additional words
+)*
+@
+[\040\t]*                    # Nab whitespace.
+(?:
+\(                              #  (
+[^\\\x80-\xff\n\015()] *                             #     normal*
+(?:                                 #       (
+(?:  \\ [^\x80-\xff]  |
+\(                            #  (
+[^\\\x80-\xff\n\015()] *                            #     normal*
+(?:  \\ [^\x80-\xff]   [^\\\x80-\xff\n\015()] * )*        #     (special normal*)*
+\)                           #                       )
+)    #         special
+[^\\\x80-\xff\n\015()] *                         #         normal*
+)*                                  #            )*
+\)                             #                )
+[\040\t]* )*    # If comment found, allow more spaces.
+(?:
+[^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]+    # some number of atom characters...
+(?![^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]) # ..not followed by something that could be part of an atom
+|
+\[                            # [
+(?: [^\\\x80-\xff\n\015\[\]] |  \\ [^\x80-\xff]  )*     #    stuff
+\]                           #           ]
+)
+[\040\t]*                    # Nab whitespace.
+(?:
+\(                              #  (
+[^\\\x80-\xff\n\015()] *                             #     normal*
+(?:                                 #       (
+(?:  \\ [^\x80-\xff]  |
+\(                            #  (
+[^\\\x80-\xff\n\015()] *                            #     normal*
+(?:  \\ [^\x80-\xff]   [^\\\x80-\xff\n\015()] * )*        #     (special normal*)*
+\)                           #                       )
+)    #         special
+[^\\\x80-\xff\n\015()] *                         #         normal*
+)*                                  #            )*
+\)                             #                )
+[\040\t]* )*    # If comment found, allow more spaces.
+# optional trailing comments
+(?:
+\.
+[\040\t]*                    # Nab whitespace.
+(?:
+\(                              #  (
+[^\\\x80-\xff\n\015()] *                             #     normal*
+(?:                                 #       (
+(?:  \\ [^\x80-\xff]  |
+\(                            #  (
+[^\\\x80-\xff\n\015()] *                            #     normal*
+(?:  \\ [^\x80-\xff]   [^\\\x80-\xff\n\015()] * )*        #     (special normal*)*
+\)                           #                       )
+)    #         special
+[^\\\x80-\xff\n\015()] *                         #         normal*
+)*                                  #            )*
+\)                             #                )
+[\040\t]* )*    # If comment found, allow more spaces.
+(?:
+[^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]+    # some number of atom characters...
+(?![^(\040)<>@,;:".\\\[\]\000-\037\x80-\xff]) # ..not followed by something that could be part of an atom
+|
+\[                            # [
+(?: [^\\\x80-\xff\n\015\[\]] |  \\ [^\x80-\xff]  )*     #    stuff
+\]                           #           ]
+)
+[\040\t]*                    # Nab whitespace.
+(?:
+\(                              #  (
+[^\\\x80-\xff\n\015()] *                             #     normal*
+(?:                                 #       (
+(?:  \\ [^\x80-\xff]  |
+\(                            #  (
+[^\\\x80-\xff\n\015()] *                            #     normal*
+(?:  \\ [^\x80-\xff]   [^\\\x80-\xff\n\015()] * )*        #     (special normal*)*
+\)                           #                       )
+)    #         special
+[^\\\x80-\xff\n\015()] *                         #         normal*
+)*                                  #            )*
+\)                             #                )
+[\040\t]* )*    # If comment found, allow more spaces.
+# optional trailing comments
+)*
+#       address spec
+>                    #                 >
+# name and address
+)
+/x
+    Alan Other <user\@dom.ain>
+ 0: Alan Other <user@dom.ain>
+    <user\@dom.ain>
+ 0: user@dom.ain
+    user\@dom.ain
+ 0: user@dom.ain
+    \"A. Other\" <user.1234\@dom.ain> (a comment)
+ 0: "A. Other" <user.1234@dom.ain>
+    A. Other <user.1234\@dom.ain> (a comment)
+ 0:  Other <user.1234@dom.ain>
+    \"/s=user/ou=host/o=place/prmd=uu.yy/admd= /c=gb/\"\@x400-re.lay
+ 0: "/s=user/ou=host/o=place/prmd=uu.yy/admd= /c=gb/"@x400-re.lay
+    A missing angle <user\@some.where
+ 0: user@some.where
+\= Expect no match
+    The quick brown fox
+No match
+
+/abc\0def\00pqr\000xyz\0000AB/
+    abc\0def\00pqr\000xyz\0000AB
+ 0: abc\x00def\x00pqr\x00xyz\x000AB
+    abc456 abc\0def\00pqr\000xyz\0000ABCDE
+ 0: abc\x00def\x00pqr\x00xyz\x000AB
+
+/abc\x0def\x00pqr\x000xyz\x0000AB/
+    abc\x0def\x00pqr\x000xyz\x0000AB
+ 0: abc\x0def\x00pqr\x000xyz\x0000AB
+    abc456 abc\x0def\x00pqr\x000xyz\x0000ABCDE
+ 0: abc\x0def\x00pqr\x000xyz\x0000AB
+
+/^[\000-\037]/
+    \0A
+ 0: \x00
+    \01B
+ 0: \x01
+    \037C
+ 0: \x1f
+
+#.NET doesn't do octal with 1 number
+
+/^(cow|)\1(bell)/
+    cowcowbell
+ 0: cowcowbell
+ 1: cow
+ 2: bell
+    bell
+ 0: bell
+ 1: 
+ 2: bell
+\= Expect no match
+    cowbell
+No match
+
+/^\s/
+    \040abc
+ 0:  
+    \x0cabc
+ 0: \x0c
+    \nabc
+ 0: \x0a
+    \rabc
+ 0: \x0d
+    \tabc
+ 0: \x09
+\= Expect no match
+    abc
+No match
+
+/^a	b
+      c/x
+    abc
+ 0: abc
+
+/^(a|)\1*b/
+    ab
+ 0: ab
+ 1: a
+    aaaab
+ 0: aaaab
+ 1: a
+    b
+ 0: b
+ 1: 
+\= Expect no match
+    acb
+No match
+
+/^(a|)\1+b/
+    aab
+ 0: aab
+ 1: a
+    aaaab
+ 0: aaaab
+ 1: a
+    b
+ 0: b
+ 1: 
+\= Expect no match
+    ab
+No match
+
+/^(a|)\1?b/
+    ab
+ 0: ab
+ 1: a
+    aab
+ 0: aab
+ 1: a
+    b
+ 0: b
+ 1: 
+\= Expect no match
+    acb
+No match
+
+/^(a|)\1{2}b/
+    aaab
+ 0: aaab
+ 1: a
+    b
+ 0: b
+ 1: 
+\= Expect no match
+    ab
+No match
+    aab
+No match
+    aaaab
+No match
+
+/^(a|)\1{2,3}b/
+    aaab
+ 0: aaab
+ 1: a
+    aaaab
+ 0: aaaab
+ 1: a
+    b
+ 0: b
+ 1: 
+\= Expect no match
+    ab
+No match
+    aab
+No match
+    aaaaab
+No match
+
+/ab{1,3}bc/
+    abbbbc
+ 0: abbbbc
+    abbbc
+ 0: abbbc
+    abbc
+ 0: abbc
+\= Expect no match
+    abc
+No match
+    abbbbbc
+No match
+
+/([^.]*)\.([^:]*):[T ]+(.*)/
+    track1.title:TBlah blah blah
+ 0: track1.title:TBlah blah blah
+ 1: track1
+ 2: title
+ 3: Blah blah blah
+
+/([^.]*)\.([^:]*):[T ]+(.*)/i
+    track1.title:TBlah blah blah
+ 0: track1.title:TBlah blah blah
+ 1: track1
+ 2: title
+ 3: Blah blah blah
+
+/([^.]*)\.([^:]*):[t ]+(.*)/i
+    track1.title:TBlah blah blah
+ 0: track1.title:TBlah blah blah
+ 1: track1
+ 2: title
+ 3: Blah blah blah
+
+/^[W-c]+$/
+    WXY_^abc
+ 0: WXY_^abc
+\= Expect no match
+    wxy
+No match
+
+/^[W-c]+$/i
+    WXY_^abc
+ 0: WXY_^abc
+    wxy_^ABC
+ 0: wxy_^ABC
+
+/^[\x3f-\x5F]+$/i
+    WXY_^abc
+ 0: WXY_^abc
+    wxy_^ABC
+ 0: wxy_^ABC
+
+/^abc$/m
+    abc
+ 0: abc
+    qqq\nabc
+ 0: abc
+    abc\nzzz
+ 0: abc
+    qqq\nabc\nzzz
+ 0: abc
+
+/^abc$/
+    abc
+ 0: abc
+\= Expect no match
+    qqq\nabc
+No match
+    abc\nzzz
+No match
+    qqq\nabc\nzzz
+No match
+
+/\Aabc\Z/m
+    abc
+ 0: abc
+    abc\n 
+ 0: abc
+\= Expect no match
+    qqq\nabc
+No match
+    abc\nzzz
+No match
+    qqq\nabc\nzzz
+No match
+    
+/\A(.)*\Z/s
+    abc\ndef
+ 0: abc\x0adef
+ 1: f
+
+/\A(.)*\Z/m
+\= Expect no match
+    abc\ndef
+No match
+
+/(?:b)|(?::+)/
+    b::c
+ 0: b
+    c::b
+ 0: ::
+
+/[-az]+/
+    az-
+ 0: az-
+\= Expect no match
+    b
+No match
+
+/[az-]+/
+    za-
+ 0: za-
+\= Expect no match
+    b
+No match
+
+/[a\-z]+/
+    a-z
+ 0: a-z
+\= Expect no match
+    b
+No match
+
+/[a-z]+/
+    abcdxyz
+ 0: abcdxyz
+
+/[\d-]+/
+    12-34
+ 0: 12-34
+\= Expect no match
+    aaa
+No match
+
+/[\d-z]+/
+    12-34z
+ 0: 12-34z
+\= Expect no match
+    aaa
+No match
+
+/\x5c/
+    \\
+ 0: \
+
+/\x20Z/
+    the Zoo
+ 0:  Z
+\= Expect no match
+    Zulu
+No match
+
+/(abc)\1/i
+    abcabc
+ 0: abcabc
+ 1: abc
+    ABCabc
+ 0: ABCabc
+ 1: ABC
+    abcABC
+ 0: abcABC
+ 1: abc
+
+/abc$/
+    abc
+ 0: abc
+    abc\n
+ 0: abc
+\= Expect no match
+    abc\ndef
+No match
+
+/(abc)\123/
+    abc\x53
+ 0: abcS
+ 1: abc
+
+/(abc)\100/
+    abc\x40
+ 0: abc@
+ 1: abc
+    abc\100
+ 0: abc@
+ 1: abc
+
+/(abc)\1000/
+    abc\x400
+ 0: abc@0
+ 1: abc
+    abc\x40\x30
+ 0: abc@0
+ 1: abc
+    abc\1000
+ 0: abc@0
+ 1: abc
+    abc\100\x30
+ 0: abc@0
+ 1: abc
+    abc\100\060
+ 0: abc@0
+ 1: abc
+    abc\100\60
+ 0: abc@0
+ 1: abc
+    
+/^(A)(B)(C)(D)(E)(F)(G)(H)(I)\8\9$/
+    ABCDEFGHIHI 
+ 0: ABCDEFGHIHI
+ 1: A
+ 2: B
+ 3: C
+ 4: D
+ 5: E
+ 6: F
+ 7: G
+ 8: H
+ 9: I
+
+/(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)\12\123/
+    abcdefghijkllS
+ 0: abcdefghijkllS
+ 1: a
+ 2: b
+ 3: c
+ 4: d
+ 5: e
+ 6: f
+ 7: g
+ 8: h
+ 9: i
+10: j
+11: k
+12: l
+
+/(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)\12\123/
+    abcdefghijk\12S
+ 0: abcdefghijk\x0aS
+ 1: a
+ 2: b
+ 3: c
+ 4: d
+ 5: e
+ 6: f
+ 7: g
+ 8: h
+ 9: i
+10: j
+11: k
+
+/a{0}bc/
+    bc
+ 0: bc
+
+/(a|(bc)){0,0}?xyz/
+    xyz
+ 0: xyz
+
+/abc[\10]de/
+    abc\010de
+ 0: abc\x08de
+
+/abc[\1]de/
+    abc\1de
+ 0: abc\x01de
+
+/(abc)[\1]de/
+    abc\1de
+ 0: abc\x01de
+ 1: abc
+
+/(?s)a.b/
+    a\nb
+ 0: a\x0ab
+
+/^([^a])([^\b])([^c]*)([^d]{3,4})/
+    baNOTccccd
+ 0: baNOTcccc
+ 1: b
+ 2: a
+ 3: NOT
+ 4: cccc
+    baNOTcccd
+ 0: baNOTccc
+ 1: b
+ 2: a
+ 3: NOT
+ 4: ccc
+    baNOTccd
+ 0: baNOTcc
+ 1: b
+ 2: a
+ 3: NO
+ 4: Tcc
+    bacccd
+ 0: baccc
+ 1: b
+ 2: a
+ 3: 
+ 4: ccc
+\= Expect no match
+    anything
+No match
+    b\bc   
+No match
+    baccd
+No match
+
+/[^a]/
+    Abc
+ 0: A
+  
+/[^a]/i
+    Abc 
+ 0: b
+
+/[^a]+/
+    AAAaAbc
+ 0: AAA
+  
+/[^a]+/i
+    AAAaAbc
+ 0: bc
+
+/[^a]+/
+    bbb\nccc
+ 0: bbb\x0accc
+   
+/[^k]$/
+    abc
+ 0: c
+\= Expect no match
+    abk
+No match
+   
+/[^k]{2,3}$/
+    abc
+ 0: abc
+    kbc
+ 0: bc
+    kabc
+ 0: abc
+\= Expect no match
+    abk
+No match
+    akb
+No match
+    akk
+No match
+
+/^\d{8,}\@.+[^k]$/
+    12345678\@a.b.c.d
+ 0: 12345678@a.b.c.d
+    123456789\@x.y.z
+ 0: 123456789@x.y.z
+\= Expect no match
+    12345678\@x.y.uk
+No match
+    1234567\@a.b.c.d       
+No match
+
+/(a)\1{8,}/
+    aaaaaaaaa
+ 0: aaaaaaaaa
+ 1: a
+    aaaaaaaaaa
+ 0: aaaaaaaaaa
+ 1: a
+\= Expect no match
+    aaaaaaa   
+No match
+
+/[^a]/
+    aaaabcd
+ 0: b
+    aaAabcd 
+ 0: A
+
+/[^a]/i
+    aaaabcd
+ 0: b
+    aaAabcd 
+ 0: b
+
+/[^az]/
+    aaaabcd
+ 0: b
+    aaAabcd 
+ 0: A
+
+/[^az]/i
+    aaaabcd
+ 0: b
+    aaAabcd 
+ 0: b
+
+# trimmed upper ascii since Go is UTF-8
+/\000\001\002\003\004\005\006\007\010\011\012\013\014\015\016\017\020\021\022\023\024\025\026\027\030\031\032\033\034\035\036\037\040\041\042\043\044\045\046\047\050\051\052\053\054\055\056\057\060\061\062\063\064\065\066\067\070\071\072\073\074\075\076\077\100\101\102\103\104\105\106\107\110\111\112\113\114\115\116\117\120\121\122\123\124\125\126\127\130\131\132\133\134\135\136\137\140\141\142\143\144\145\146\147\150\151\152\153\154\155\156\157\160\161\162\163\164\165\166\167\170\171\172\173\174\175\176\177/
+    \000\001\002\003\004\005\006\007\010\011\012\013\014\015\016\017\020\021\022\023\024\025\026\027\030\031\032\033\034\035\036\037\040\041\042\043\044\045\046\047\050\051\052\053\054\055\056\057\060\061\062\063\064\065\066\067\070\071\072\073\074\075\076\077\100\101\102\103\104\105\106\107\110\111\112\113\114\115\116\117\120\121\122\123\124\125\126\127\130\131\132\133\134\135\136\137\140\141\142\143\144\145\146\147\150\151\152\153\154\155\156\157\160\161\162\163\164\165\166\167\170\171\172\173\174\175\176\177
+ 0: \x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~\x7f
+
+/P[^*]TAIRE[^*]{1,6}?LL/
+    xxxxxxxxxxxPSTAIREISLLxxxxxxxxx
+ 0: PSTAIREISLL
+
+/P[^*]TAIRE[^*]{1,}?LL/
+    xxxxxxxxxxxPSTAIREISLLxxxxxxxxx
+ 0: PSTAIREISLL
+
+/(\.\d\d[1-9]?)\d+/
+    1.230003938
+ 0: .230003938
+ 1: .23
+    1.875000282   
+ 0: .875000282
+ 1: .875
+    1.235  
+ 0: .235
+ 1: .23
+                  
+/(\.\d\d((?=0)|\d(?=\d)))/
+    1.230003938      
+ 0: .23
+ 1: .23
+ 2: 
+    1.875000282
+ 0: .875
+ 1: .875
+ 2: 5
+\= Expect no match 
+    1.235 
+No match
+     
+/\b(foo)\s+(\w+)/i
+    Food is on the foo table
+ 0: foo table
+ 1: foo
+ 2: table
+    
+/foo(.*)bar/
+    The food is under the bar in the barn.
+ 0: food is under the bar in the bar
+ 1: d is under the bar in the 
+    
+/foo(.*?)bar/
+    The food is under the bar in the barn.
+ 0: food is under the bar
+ 1: d is under the 
+
+/(.*)(\d*)/
+    I have 2 numbers: 53147
+ 0: I have 2 numbers: 53147
+ 1: I have 2 numbers: 53147
+ 2: 
+    
+/(.*)(\d+)/
+    I have 2 numbers: 53147
+ 0: I have 2 numbers: 53147
+ 1: I have 2 numbers: 5314
+ 2: 7
+ 
+/(.*?)(\d*)/
+    I have 2 numbers: 53147
+ 0: 
+ 1: 
+ 2: 
+
+/(.*?)(\d+)/
+    I have 2 numbers: 53147
+ 0: I have 2
+ 1: I have 
+ 2: 2
+
+/(.*)(\d+)$/
+    I have 2 numbers: 53147
+ 0: I have 2 numbers: 53147
+ 1: I have 2 numbers: 5314
+ 2: 7
+
+/(.*?)(\d+)$/
+    I have 2 numbers: 53147
+ 0: I have 2 numbers: 53147
+ 1: I have 2 numbers: 
+ 2: 53147
+
+/(.*)\b(\d+)$/
+    I have 2 numbers: 53147
+ 0: I have 2 numbers: 53147
+ 1: I have 2 numbers: 
+ 2: 53147
+
+/(.*\D)(\d+)$/
+    I have 2 numbers: 53147
+ 0: I have 2 numbers: 53147
+ 1: I have 2 numbers: 
+ 2: 53147
+
+/^\D*(?!123)/
+    ABC123
+ 0: AB
+     
+/^(\D*)(?=\d)(?!123)/
+    ABC445
+ 0: ABC
+ 1: ABC
+\= Expect no match
+    ABC123
+No match
+    
+/^[W-]46]/
+    W46]789 
+ 0: W46]
+    -46]789
+ 0: -46]
+\= Expect no match
+    Wall
+No match
+    Zebra
+No match
+    42
+No match
+    [abcd] 
+No match
+    ]abcd[
+No match
+       
+/^[W-\]46]/
+    W46]789 
+ 0: W
+    Wall
+ 0: W
+    Zebra
+ 0: Z
+    Xylophone  
+ 0: X
+    42
+ 0: 4
+    [abcd] 
+ 0: [
+    ]abcd[
+ 0: ]
+    \\backslash 
+ 0: \
+\= Expect no match
+    -46]789
+No match
+    well
+No match
+    
+/\d\d\/\d\d\/\d\d\d\d/
+    01/01/2000
+ 0: 01/01/2000
+
+/word (?:[a-zA-Z0-9]+ ){0,10}otherword/
+    word cat dog elephant mussel cow horse canary baboon snake shark otherword
+ 0: word cat dog elephant mussel cow horse canary baboon snake shark otherword
+\= Expect no match
+    word cat dog elephant mussel cow horse canary baboon snake shark
+No match
+
+/word (?:[a-zA-Z0-9]+ ){0,300}otherword/
+\= Expect no match
+    word cat dog elephant mussel cow horse canary baboon snake shark the quick brown fox and the lazy dog and several other words getting close to thirty by now I hope
+No match
+
+/^(a){0,0}/
+    bcd
+ 0: 
+    abc
+ 0: 
+    aab     
+ 0: 
+
+/^(a){0,1}/
+    bcd
+ 0: 
+    abc
+ 0: a
+ 1: a
+    aab  
+ 0: a
+ 1: a
+
+/^(a){0,2}/
+    bcd
+ 0: 
+    abc
+ 0: a
+ 1: a
+    aab  
+ 0: aa
+ 1: a
+
+/^(a){0,3}/
+    bcd
+ 0: 
+    abc
+ 0: a
+ 1: a
+    aab
+ 0: aa
+ 1: a
+    aaa   
+ 0: aaa
+ 1: a
+
+/^(a){0,}/
+    bcd
+ 0: 
+    abc
+ 0: a
+ 1: a
+    aab
+ 0: aa
+ 1: a
+    aaa
+ 0: aaa
+ 1: a
+    aaaaaaaa    
+ 0: aaaaaaaa
+ 1: a
+
+/^(a){1,1}/
+    abc
+ 0: a
+ 1: a
+    aab  
+ 0: a
+ 1: a
+\= Expect no match
+    bcd
+No match
+
+/^(a){1,2}/
+    abc
+ 0: a
+ 1: a
+    aab  
+ 0: aa
+ 1: a
+\= Expect no match
+    bcd
+No match
+
+/^(a){1,3}/
+    abc
+ 0: a
+ 1: a
+    aab
+ 0: aa
+ 1: a
+    aaa   
+ 0: aaa
+ 1: a
+\= Expect no match
+    bcd
+No match
+
+/^(a){1,}/
+    abc
+ 0: a
+ 1: a
+    aab
+ 0: aa
+ 1: a
+    aaa
+ 0: aaa
+ 1: a
+    aaaaaaaa    
+ 0: aaaaaaaa
+ 1: a
+\= Expect no match
+    bcd
+No match
+
+/.*\.gif/
+    borfle\nbib.gif\nno
+ 0: bib.gif
+
+/.{0,}\.gif/
+    borfle\nbib.gif\nno
+ 0: bib.gif
+
+/.*\.gif/m
+    borfle\nbib.gif\nno
+ 0: bib.gif
+
+/.*\.gif/s
+    borfle\nbib.gif\nno
+ 0: borfle\x0abib.gif
+
+/.*\.gif/ms
+    borfle\nbib.gif\nno
+ 0: borfle\x0abib.gif
+    
+/.*$/
+    borfle\nbib.gif\nno
+ 0: no
+
+/.*$/m
+    borfle\nbib.gif\nno
+ 0: borfle
+
+/.*$/s
+    borfle\nbib.gif\nno
+ 0: borfle\x0abib.gif\x0ano
+
+/.*$/ms
+    borfle\nbib.gif\nno
+ 0: borfle\x0abib.gif\x0ano
+    
+/.*$/
+    borfle\nbib.gif\nno\n
+ 0: no
+
+/.*$/m
+    borfle\nbib.gif\nno\n
+ 0: borfle
+
+/.*$/s
+    borfle\nbib.gif\nno\n
+ 0: borfle\x0abib.gif\x0ano\x0a
+
+/.*$/ms
+    borfle\nbib.gif\nno\n
+ 0: borfle\x0abib.gif\x0ano\x0a
+    
+/(.*X|^B)/
+    abcde\n1234Xyz
+ 0: 1234X
+ 1: 1234X
+    BarFoo 
+ 0: B
+ 1: B
+\= Expect no match
+    abcde\nBar  
+No match
+
+/(.*X|^B)/m
+    abcde\n1234Xyz
+ 0: 1234X
+ 1: 1234X
+    BarFoo 
+ 0: B
+ 1: B
+    abcde\nBar  
+ 0: B
+ 1: B
+
+/(.*X|^B)/s
+    abcde\n1234Xyz
+ 0: abcde\x0a1234X
+ 1: abcde\x0a1234X
+    BarFoo 
+ 0: B
+ 1: B
+\= Expect no match
+    abcde\nBar  
+No match
+
+/(.*X|^B)/ms
+    abcde\n1234Xyz
+ 0: abcde\x0a1234X
+ 1: abcde\x0a1234X
+    BarFoo 
+ 0: B
+ 1: B
+    abcde\nBar  
+ 0: B
+ 1: B
+
+/(?s)(.*X|^B)/
+    abcde\n1234Xyz
+ 0: abcde\x0a1234X
+ 1: abcde\x0a1234X
+    BarFoo 
+ 0: B
+ 1: B
+\= Expect no match 
+    abcde\nBar  
+No match
+
+/(?s:.*X|^B)/
+    abcde\n1234Xyz
+ 0: abcde\x0a1234X
+    BarFoo 
+ 0: B
+\= Expect no match 
+    abcde\nBar  
+No match
+
+/^.*B/
+\= Expect no match
+    abc\nB
+No match
+     
+/(?s)^.*B/
+    abc\nB
+ 0: abc\x0aB
+
+/(?m)^.*B/
+    abc\nB
+ 0: B
+     
+/(?ms)^.*B/
+    abc\nB
+ 0: abc\x0aB
+
+/(?ms)^B/
+    abc\nB
+ 0: B
+
+/(?s)B$/
+    B\n
+ 0: B
+
+/^[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]/
+    123456654321
+ 0: 123456654321
+  
+/^\d\d\d\d\d\d\d\d\d\d\d\d/
+    123456654321 
+ 0: 123456654321
+
+/^[\d][\d][\d][\d][\d][\d][\d][\d][\d][\d][\d][\d]/
+    123456654321
+ 0: 123456654321
+  
+/^[abc]{12}/
+    abcabcabcabc
+ 0: abcabcabcabc
+    
+/^[a-c]{12}/
+    abcabcabcabc
+ 0: abcabcabcabc
+    
+/^(a|b|c){12}/
+    abcabcabcabc 
+ 0: abcabcabcabc
+ 1: c
+
+/^[abcdefghijklmnopqrstuvwxy0123456789]/
+    n
+ 0: n
+\= Expect no match 
+    z 
+No match
+
+/abcde{0,0}/
+    abcd
+ 0: abcd
+\= Expect no match
+    abce  
+No match
+
+/ab[cd]{0,0}e/
+    abe
+ 0: abe
+\= Expect no match
+    abcde 
+No match
+    
+/ab(c){0,0}d/
+    abd
+ 0: abd
+\= Expect no match
+    abcd   
+No match
+
+/a(b*)/
+    a
+ 0: a
+ 1: 
+    ab
+ 0: ab
+ 1: b
+    abbbb
+ 0: abbbb
+ 1: bbbb
+\= Expect no match
+    bbbbb    
+No match
+    
+/ab\d{0}e/
+    abe
+ 0: abe
+\= Expect no match
+    ab1e   
+No match
+    
+/"([^\\"]+|\\.)*"/
+    the \"quick\" brown fox
+ 0: "quick"
+ 1: quick
+    \"the \\\"quick\\\" brown fox\" 
+ 0: "the \"quick\" brown fox"
+ 1:  brown fox
+
+/<tr([\w\W\s\d][^<>]{0,})><TD([\w\W\s\d][^<>]{0,})>([\d]{0,}\.)(.*)((<BR>([\w\W\s\d][^<>]{0,})|[\s]{0,}))<\/a><\/TD><TD([\w\W\s\d][^<>]{0,})>([\w\W\s\d][^<>]{0,})<\/TD><TD([\w\W\s\d][^<>]{0,})>([\w\W\s\d][^<>]{0,})<\/TD><\/TR>/is
+    <TR BGCOLOR='#DBE9E9'><TD align=left valign=top>43.<a href='joblist.cfm?JobID=94 6735&Keyword='>Word Processor<BR>(N-1286)</a></TD><TD align=left valign=top>Lega lstaff.com</TD><TD align=left valign=top>CA - Statewide</TD></TR>
+ 0: <TR BGCOLOR='#DBE9E9'><TD align=left valign=top>43.<a href='joblist.cfm?JobID=94 6735&Keyword='>Word Processor<BR>(N-1286)</a></TD><TD align=left valign=top>Lega lstaff.com</TD><TD align=left valign=top>CA - Statewide</TD></TR>
+ 1:  BGCOLOR='#DBE9E9'
+ 2:  align=left valign=top
+ 3: 43.
+ 4: <a href='joblist.cfm?JobID=94 6735&Keyword='>Word Processor<BR>(N-1286)
+ 5: 
+ 6: 
+ 7: <unset>
+ 8:  align=left valign=top
+ 9: Lega lstaff.com
+10:  align=left valign=top
+11: CA - Statewide
+
+/a[^a]b/
+    acb
+ 0: acb
+    a\nb
+ 0: a\x0ab
+    
+/a.b/
+    acb
+ 0: acb
+\= Expect no match 
+    a\nb   
+No match
+    
+/a[^a]b/s
+    acb
+ 0: acb
+    a\nb  
+ 0: a\x0ab
+    
+/a.b/s
+    acb
+ 0: acb
+    a\nb  
+ 0: a\x0ab
+
+/^(b+?|a){1,2}?c/
+    bac
+ 0: bac
+ 1: a
+    bbac
+ 0: bbac
+ 1: a
+    bbbac
+ 0: bbbac
+ 1: a
+    bbbbac
+ 0: bbbbac
+ 1: a
+    bbbbbac 
+ 0: bbbbbac
+ 1: a
+
+/^(b+|a){1,2}?c/
+    bac
+ 0: bac
+ 1: a
+    bbac
+ 0: bbac
+ 1: a
+    bbbac
+ 0: bbbac
+ 1: a
+    bbbbac
+ 0: bbbbac
+ 1: a
+    bbbbbac 
+ 0: bbbbbac
+ 1: a
+    
+/(?!\A)x/m
+    a\bx\n
+ 0: x
+    a\nx\n
+ 0: x
+\= Expect no match     
+    x\nb\n
+No match
+    
+/(A|B)*?CD/
+    CD 
+ 0: CD
+    
+/(A|B)*CD/
+    CD 
+ 0: CD
+
+/(AB)*?\1/
+    ABABAB
+ 0: ABAB
+ 1: AB
+
+/(AB)*\1/
+    ABABAB
+ 0: ABABAB
+ 1: AB
+    
+/(?<!bar)foo/
+    foo
+ 0: foo
+    catfood
+ 0: foo
+    arfootle
+ 0: foo
+    rfoosh
+ 0: foo
+\= Expect no match
+    barfoo
+No match
+    towbarfoo
+No match
+
+/\w{3}(?<!bar)foo/
+    catfood
+ 0: catfoo
+\= Expect no match
+    foo
+No match
+    barfoo
+No match
+    towbarfoo
+No match
+
+/(?<=(foo)a)bar/
+    fooabar
+ 0: bar
+ 1: foo
+\= Expect no match
+    bar
+No match
+    foobbar
+No match
+      
+/\Aabc\z/m
+    abc
+ 0: abc
+\= Expect no match
+    abc\n   
+No match
+    qqq\nabc
+No match
+    abc\nzzz
+No match
+    qqq\nabc\nzzz
+No match
+
+"(?>.*/)foo"
+    /this/is/a/very/long/line/in/deed/with/very/many/slashes/in/and/foo
+ 0: /this/is/a/very/long/line/in/deed/with/very/many/slashes/in/and/foo
+\= Expect no match     
+    /this/is/a/very/long/line/in/deed/with/very/many/slashes/in/it/you/see/
+No match
+
+/(?>(\.\d\d[1-9]?))\d+/
+    1.230003938
+ 0: .230003938
+ 1: .23
+    1.875000282
+ 0: .875000282
+ 1: .875
+\= Expect no match 
+    1.235 
+No match
+
+/^((?>\w+)|(?>\s+))*$/
+    now is the time for all good men to come to the aid of the party
+ 0: now is the time for all good men to come to the aid of the party
+ 1: party
+\= Expect no match
+    this is not a line with only words and spaces!
+No match
+    
+/(\d+)(\w)/
+    12345a
+ 0: 12345a
+ 1: 12345
+ 2: a
+    12345+ 
+ 0: 12345
+ 1: 1234
+ 2: 5
+
+/((?>\d+))(\w)/
+    12345a
+ 0: 12345a
+ 1: 12345
+ 2: a
+\= Expect no match
+    12345+ 
+No match
+
+/(?>a+)b/
+    aaab
+ 0: aaab
+
+/((?>a+)b)/
+    aaab
+ 0: aaab
+ 1: aaab
+
+/(?>(a+))b/
+    aaab
+ 0: aaab
+ 1: aaa
+
+/(?>b)+/
+    aaabbbccc
+ 0: bbb
+
+/(?>a+|b+|c+)*c/
+    aaabbbbccccd
+ 0: aaabbbbc
+
+/((?>[^()]+)|\([^()]*\))+/
+    ((abc(ade)ufh()()x
+ 0: abc(ade)ufh()()x
+ 1: x
+    
+/\(((?>[^()]+)|\([^()]+\))+\)/
+    (abc)
+ 0: (abc)
+ 1: abc
+    (abc(def)xyz)
+ 0: (abc(def)xyz)
+ 1: xyz
+\= Expect no match
+    ((()aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa   
+No match
+
+/a(?-i)b/i
+    ab
+ 0: ab
+    Ab
+ 0: Ab
+\= Expect no match 
+    aB
+No match
+    AB
+No match
+        
+/(a (?x)b c)d e/
+    a bcd e
+ 0: a bcd e
+ 1: a bc
+\= Expect no match
+    a b cd e
+No match
+    abcd e   
+No match
+    a bcde 
+No match
+ 
+/(a b(?x)c d (?-x)e f)/
+    a bcde f
+ 0: a bcde f
+ 1: a bcde f
+\= Expect no match
+    abcdef  
+No match
+
+/(a(?i)b)c/
+    abc
+ 0: abc
+ 1: ab
+    aBc
+ 0: aBc
+ 1: aB
+\= Expect no match
+    abC
+No match
+    aBC  
+No match
+    Abc
+No match
+    ABc
+No match
+    ABC
+No match
+    AbC
+No match
+    
+/a(?i:b)c/
+    abc
+ 0: abc
+    aBc
+ 0: aBc
+\= Expect no match 
+    ABC
+No match
+    abC
+No match
+    aBC
+No match
+    
+/a(?i:b)*c/
+    aBc
+ 0: aBc
+    aBBc
+ 0: aBBc
+\= Expect no match 
+    aBC
+No match
+    aBBC
+No match
+    
+/a(?=b(?i)c)\w\wd/
+    abcd
+ 0: abcd
+    abCd
+ 0: abCd
+\= Expect no match
+    aBCd
+No match
+    abcD     
+No match
+    
+/(?s-i:more.*than).*million/i
+    more than million
+ 0: more than million
+    more than MILLION
+ 0: more than MILLION
+    more \n than Million 
+ 0: more \x0a than Million
+\= Expect no match
+    MORE THAN MILLION    
+No match
+    more \n than \n million 
+No match
+
+/(?:(?s-i)more.*than).*million/i
+    more than million
+ 0: more than million
+    more than MILLION
+ 0: more than MILLION
+    more \n than Million 
+ 0: more \x0a than Million
+\= Expect no match
+    MORE THAN MILLION    
+No match
+    more \n than \n million 
+No match
+    
+/(?>a(?i)b+)+c/
+    abc
+ 0: abc
+    aBbc
+ 0: aBbc
+    aBBc 
+ 0: aBBc
+\= Expect no match
+    Abc
+No match
+    abAb    
+No match
+    abbC 
+No match
+    
+/(?=a(?i)b)\w\wc/
+    abc
+ 0: abc
+    aBc
+ 0: aBc
+\= Expect no match
+    Ab 
+No match
+    abC
+No match
+    aBC     
+No match
+    
+/(?<=a(?i)b)(\w\w)c/
+    abxxc
+ 0: xxc
+ 1: xx
+    aBxxc
+ 0: xxc
+ 1: xx
+\= Expect no match
+    Abxxc
+No match
+    ABxxc
+No match
+    abxxC      
+No match
+
+/(?:(a)|b)(?(1)A|B)/
+    aA
+ 0: aA
+ 1: a
+    bB
+ 0: bB
+\= Expect no match
+    aB
+No match
+    bA    
+No match
+
+/^(a)?(?(1)a|b)+$/
+    aa
+ 0: aa
+ 1: a
+    b
+ 0: b
+    bb  
+ 0: bb
+\= Expect no match
+    ab   
+No match
+    
+# Perl gets this next one wrong if the pattern ends with $; in that case it
+# fails to match "12". 
+
+/^(?(?=abc)\w{3}:|\d\d)/
+    abc:
+ 0: abc:
+    12
+ 0: 12
+    123
+ 0: 12
+\= Expect no match
+    xyz    
+No match
+
+/^(?(?!abc)\d\d|\w{3}:)$/
+    abc:
+ 0: abc:
+    12
+ 0: 12
+\= Expect no match
+    123
+No match
+    xyz    
+No match
+    
+/(?(?<=foo)bar|cat)/
+    foobar
+ 0: bar
+    cat
+ 0: cat
+    fcat
+ 0: cat
+    focat   
+ 0: cat
+\= Expect no match
+    foocat  
+No match
+
+/(?(?<!foo)cat|bar)/
+    foobar
+ 0: bar
+    cat
+ 0: cat
+    fcat
+ 0: cat
+    focat   
+ 0: cat
+\= Expect no match
+    foocat  
+No match
+
+/( \( )? [^()]+ (?(1) \) |) /x
+    abcd
+ 0: abcd
+    (abcd)
+ 0: (abcd)
+ 1: (
+    the quick (abcd) fox
+ 0: the quick 
+    (abcd   
+ 0: abcd
+
+/( \( )? [^()]+ (?(1) \) ) /x
+    abcd
+ 0: abcd
+    (abcd)
+ 0: (abcd)
+ 1: (
+    the quick (abcd) fox
+ 0: the quick 
+    (abcd   
+ 0: abcd
+
+/^(?(2)a|(1)(2))+$/
+    12
+ 0: 12
+ 1: 1
+ 2: 2
+    12a
+ 0: 12a
+ 1: 1
+ 2: 2
+    12aa
+ 0: 12aa
+ 1: 1
+ 2: 2
+\= Expect no match
+    1234    
+No match
+
+/((?i)blah)\s+\1/
+    blah blah
+ 0: blah blah
+ 1: blah
+    BLAH BLAH
+ 0: BLAH BLAH
+ 1: BLAH
+    Blah Blah
+ 0: Blah Blah
+ 1: Blah
+    blaH blaH
+ 0: blaH blaH
+ 1: blaH
+\= Expect no match
+    blah BLAH
+No match
+    Blah blah      
+No match
+    blaH blah 
+No match
+
+/((?i)blah)\s+(?i:\1)/
+    blah blah
+ 0: blah blah
+ 1: blah
+    BLAH BLAH
+ 0: BLAH BLAH
+ 1: BLAH
+    Blah Blah
+ 0: Blah Blah
+ 1: Blah
+    blaH blaH
+ 0: blaH blaH
+ 1: blaH
+    blah BLAH
+ 0: blah BLAH
+ 1: blah
+    Blah blah      
+ 0: Blah blah
+ 1: Blah
+    blaH blah 
+ 0: blaH blah
+ 1: blaH
+
+/(?>a*)*/
+    a
+ 0: a
+    aa
+ 0: aa
+    aaaa
+ 0: aaaa
+    
+/(abc|)+/
+    abc
+ 0: abc
+ 1: 
+    abcabc
+ 0: abcabc
+ 1: 
+    abcabcabc
+ 0: abcabcabc
+ 1: 
+    xyz      
+ 0: 
+ 1: 
+
+/([a]*)*/
+    a
+ 0: a
+ 1: 
+    aaaaa 
+ 0: aaaaa
+ 1: 
+ 
+/([ab]*)*/
+    a
+ 0: a
+ 1: 
+    b
+ 0: b
+ 1: 
+    ababab
+ 0: ababab
+ 1: 
+    aaaabcde
+ 0: aaaab
+ 1: 
+    bbbb    
+ 0: bbbb
+ 1: 
+ 
+/([^a]*)*/
+    b
+ 0: b
+ 1: 
+    bbbb
+ 0: bbbb
+ 1: 
+    aaa   
+ 0: 
+ 1: 
+ 
+/([^ab]*)*/
+    cccc
+ 0: cccc
+ 1: 
+    abab  
+ 0: 
+ 1: 
+ 
+/([a]*?)*/
+    a
+ 0: 
+ 1: 
+    aaaa 
+ 0: 
+ 1: 
+ 
+/([ab]*?)*/
+    a
+ 0: 
+ 1: 
+    b
+ 0: 
+ 1: 
+    abab
+ 0: 
+ 1: 
+    baba   
+ 0: 
+ 1: 
+ 
+/([^a]*?)*/
+    b
+ 0: 
+ 1: 
+    bbbb
+ 0: 
+ 1: 
+    aaa   
+ 0: 
+ 1: 
+ 
+/([^ab]*?)*/
+    c
+ 0: 
+ 1: 
+    cccc
+ 0: 
+ 1: 
+    baba   
+ 0: 
+ 1: 
+ 
+/(?>a*)*/
+    a
+ 0: a
+    aaabcde 
+ 0: aaa
+ 
+/((?>a*))*/
+    aaaaa
+ 0: aaaaa
+ 1: 
+    aabbaa 
+ 0: aa
+ 1: 
+ 
+/((?>a*?))*/
+    aaaaa
+ 0: 
+ 1: 
+    aabbaa 
+ 0: 
+ 1: 
+
+/(?(?=[^a-z]+[a-z])  \d{2}-[a-z]{3}-\d{2}  |  \d{2}-\d{2}-\d{2} ) /x
+    12-sep-98
+ 0: 12-sep-98
+    12-09-98
+ 0: 12-09-98
+\= Expect no match
+    sep-12-98
+No match
+        
+/(?<=(foo))bar\1/
+    foobarfoo
+ 0: barfoo
+ 1: foo
+    foobarfootling 
+ 0: barfoo
+ 1: foo
+\= Expect no match
+    foobar
+No match
+    barfoo   
+No match
+
+/(?i:saturday|sunday)/
+    saturday
+ 0: saturday
+    sunday
+ 0: sunday
+    Saturday
+ 0: Saturday
+    Sunday
+ 0: Sunday
+    SATURDAY
+ 0: SATURDAY
+    SUNDAY
+ 0: SUNDAY
+    SunDay
+ 0: SunDay
+    
+/(a(?i)bc|BB)x/
+    abcx
+ 0: abcx
+ 1: abc
+    aBCx
+ 0: aBCx
+ 1: aBC
+    bbx
+ 0: bbx
+ 1: bb
+    BBx
+ 0: BBx
+ 1: BB
+\= Expect no match
+    abcX
+No match
+    aBCX
+No match
+    bbX
+No match
+    BBX               
+No match
+
+/^([ab](?i)[cd]|[ef])/
+    ac
+ 0: ac
+ 1: ac
+    aC
+ 0: aC
+ 1: aC
+    bD
+ 0: bD
+ 1: bD
+    elephant
+ 0: e
+ 1: e
+    Europe 
+ 0: E
+ 1: E
+    frog
+ 0: f
+ 1: f
+    France
+ 0: F
+ 1: F
+\= Expect no match
+    Africa     
+No match
+
+/^(ab|a(?i)[b-c](?m-i)d|x(?i)y|z)/
+    ab
+ 0: ab
+ 1: ab
+    aBd
+ 0: aBd
+ 1: aBd
+    xy
+ 0: xy
+ 1: xy
+    xY
+ 0: xY
+ 1: xY
+    zebra
+ 0: z
+ 1: z
+    Zambesi
+ 0: Z
+ 1: Z
+\= Expect no match
+    aCD  
+No match
+    XY  
+No match
+
+/(?<=foo\n)^bar/m
+    foo\nbar
+ 0: bar
+\= Expect no match
+    bar
+No match
+    baz\nbar   
+No match
+
+/(?<=(?<!foo)bar)baz/
+    barbaz
+ 0: baz
+    barbarbaz 
+ 0: baz
+    koobarbaz 
+ 0: baz
+\= Expect no match
+    baz
+No match
+    foobarbaz 
+No match
+
+# The cases of aaaa and aaaaaa are missed out below because Perl does things
+# differently. We know that odd, and maybe incorrect, things happen with
+# recursive references in Perl, as far as 5.11.3 - see some stuff in test #2.
+
+/^(a\1?){4}$/
+    aaaaa
+ 0: aaaaa
+ 1: a
+    aaaaaaa
+ 0: aaaaaaa
+ 1: a
+    aaaaaaaaaa
+ 0: aaaaaaaaaa
+ 1: aaaa
+\= Expect no match
+    a
+No match
+    aa
+No match
+    aaa
+No match
+    aaaaaaaa
+No match
+    aaaaaaaaa
+No match
+    aaaaaaaaaaa
+No match
+    aaaaaaaaaaaa
+No match
+    aaaaaaaaaaaaa
+No match
+    aaaaaaaaaaaaaa
+No match
+    aaaaaaaaaaaaaaa
+No match
+    aaaaaaaaaaaaaaaa
+No match
+
+/^(a\1?)(a\1?)(a\2?)(a\3?)$/
+    aaaa
+ 0: aaaa
+ 1: a
+ 2: a
+ 3: a
+ 4: a
+    aaaaa
+ 0: aaaaa
+ 1: a
+ 2: aa
+ 3: a
+ 4: a
+    aaaaaa
+ 0: aaaaaa
+ 1: a
+ 2: aa
+ 3: a
+ 4: aa
+    aaaaaaa
+ 0: aaaaaaa
+ 1: a
+ 2: aa
+ 3: aaa
+ 4: a
+    aaaaaaaaaa
+ 0: aaaaaaaaaa
+ 1: a
+ 2: aa
+ 3: aaa
+ 4: aaaa
+\= Expect no match
+    a
+No match
+    aa
+No match
+    aaa
+No match
+    aaaaaaaa
+No match
+    aaaaaaaaa
+No match
+    aaaaaaaaaaa
+No match
+    aaaaaaaaaaaa
+No match
+    aaaaaaaaaaaaa
+No match
+    aaaaaaaaaaaaaa
+No match
+    aaaaaaaaaaaaaaa
+No match
+    aaaaaaaaaaaaaaaa               
+No match
+
+# The following tests are taken from the Perl 5.005 test suite; some of them
+# are compatible with 5.004, but I'd rather not have to sort them out.
+
+/abc/
+    abc
+ 0: abc
+    xabcy
+ 0: abc
+    ababc
+ 0: abc
+\= Expect no match
+    xbc
+No match
+    axc
+No match
+    abx
+No match
+
+/ab*c/
+    abc
+ 0: abc
+
+/ab*bc/
+    abc
+ 0: abc
+    abbc
+ 0: abbc
+    abbbbc
+ 0: abbbbc
+
+/.{1}/
+    abbbbc
+ 0: a
+
+/.{3,4}/
+    abbbbc
+ 0: abbb
+
+/ab{0,}bc/
+    abbbbc
+ 0: abbbbc
+
+/ab+bc/
+    abbc
+ 0: abbc
+\= Expect no match
+    abc
+No match
+    abq
+No match
+
+/ab{1,}bc/
+
+/ab+bc/
+    abbbbc
+ 0: abbbbc
+
+/ab{1,}bc/
+    abbbbc
+ 0: abbbbc
+
+/ab{1,3}bc/
+    abbbbc
+ 0: abbbbc
+
+/ab{3,4}bc/
+    abbbbc
+ 0: abbbbc
+
+/ab{4,5}bc/
+\= Expect no match
+    abq
+No match
+    abbbbc
+No match
+
+/ab?bc/
+    abbc
+ 0: abbc
+    abc
+ 0: abc
+
+/ab{0,1}bc/
+    abc
+ 0: abc
+
+/ab?bc/
+
+/ab?c/
+    abc
+ 0: abc
+
+/ab{0,1}c/
+    abc
+ 0: abc
+
+/^abc$/
+    abc
+ 0: abc
+\= Expect no match
+    abbbbc
+No match
+    abcc
+No match
+
+/^abc/
+    abcc
+ 0: abc
+
+/^abc$/
+
+/abc$/
+    aabc
+ 0: abc
+\= Expect no match
+    aabcd
+No match
+
+/^/
+    abc
+ 0: 
+
+/$/
+    abc
+ 0: 
+
+/a.c/
+    abc
+ 0: abc
+    axc
+ 0: axc
+
+/a.*c/
+    axyzc
+ 0: axyzc
+
+/a[bc]d/
+    abd
+ 0: abd
+\= Expect no match
+    axyzd
+No match
+    abc
+No match
+
+/a[b-d]e/
+    ace
+ 0: ace
+
+/a[b-d]/
+    aac
+ 0: ac
+
+/a[-b]/
+    a-
+ 0: a-
+
+/a[b-]/
+    a-
+ 0: a-
+
+/a]/
+    a]
+ 0: a]
+
+/a[]]b/
+    a]b
+ 0: a]b
+
+/a[^bc]d/
+    aed
+ 0: aed
+\= Expect no match
+    abd
+No match
+    abd
+No match
+
+/a[^-b]c/
+    adc
+ 0: adc
+
+/a[^]b]c/
+    adc
+ 0: adc
+    a-c
+ 0: a-c
+\= Expect no match
+    a]c
+No match
+
+/\ba\b/
+    a-
+ 0: a
+    -a
+ 0: a
+    -a-
+ 0: a
+
+/\by\b/
+\= Expect no match
+    xy
+No match
+    yz
+No match
+    xyz
+No match
+
+/\Ba\B/
+\= Expect no match
+    a-
+No match
+    -a
+No match
+    -a-
+No match
+
+/\By\b/
+    xy
+ 0: y
+
+/\by\B/
+    yz
+ 0: y
+
+/\By\B/
+    xyz
+ 0: y
+
+/\w/
+    a
+ 0: a
+
+/\W/
+    -
+ 0: -
+\= Expect no match
+    a
+No match
+
+/a\sb/
+    a b
+ 0: a b
+
+/a\Sb/
+    a-b
+ 0: a-b
+\= Expect no match
+    a b
+No match
+
+/\d/
+    1
+ 0: 1
+
+/\D/
+    -
+ 0: -
+\= Expect no match
+    1
+No match
+
+/[\w]/
+    a
+ 0: a
+
+/[\W]/
+    -
+ 0: -
+\= Expect no match
+    a
+No match
+
+/a[\s]b/
+    a b
+ 0: a b
+
+/a[\S]b/
+    a-b
+ 0: a-b
+\= Expect no match
+    a b
+No match
+
+/[\d]/
+    1
+ 0: 1
+
+/[\D]/
+    -
+ 0: -
+\= Expect no match
+    1
+No match
+
+/ab|cd/
+    abc
+ 0: ab
+    abcd
+ 0: ab
+
+/()ef/
+    def
+ 0: ef
+ 1: 
+
+/$b/
+
+/a\(b/
+    a(b
+ 0: a(b
+
+/a\(*b/
+    ab
+ 0: ab
+    a((b
+ 0: a((b
+
+/a\\b/
+    a\\b
+ 0: a\b
+
+/((a))/
+    abc
+ 0: a
+ 1: a
+ 2: a
+
+/(a)b(c)/
+    abc
+ 0: abc
+ 1: a
+ 2: c
+
+/a+b+c/
+    aabbabc
+ 0: abc
+
+/a{1,}b{1,}c/
+    aabbabc
+ 0: abc
+
+/a.+?c/
+    abcabc
+ 0: abc
+
+/(a+|b)*/
+    ab
+ 0: ab
+ 1: b
+
+/(a+|b){0,}/
+    ab
+ 0: ab
+ 1: b
+
+/(a+|b)+/
+    ab
+ 0: ab
+ 1: b
+
+/(a+|b){1,}/
+    ab
+ 0: ab
+ 1: b
+
+/(a+|b)?/
+    ab
+ 0: a
+ 1: a
+
+/(a+|b){0,1}/
+    ab
+ 0: a
+ 1: a
+
+/[^ab]*/
+    cde
+ 0: cde
+
+/abc/
+\= Expect no match
+    b
+No match
+
+/a*/
+    \
+ 0: 
+
+/([abc])*d/
+    abbbcd
+ 0: abbbcd
+ 1: c
+
+/([abc])*bcd/
+    abcd
+ 0: abcd
+ 1: a
+
+/a|b|c|d|e/
+    e
+ 0: e
+
+/(a|b|c|d|e)f/
+    ef
+ 0: ef
+ 1: e
+
+/abcd*efg/
+    abcdefg
+ 0: abcdefg
+
+/ab*/
+    xabyabbbz
+ 0: ab
+    xayabbbz
+ 0: a
+
+/(ab|cd)e/
+    abcde
+ 0: cde
+ 1: cd
+
+/[abhgefdc]ij/
+    hij
+ 0: hij
+
+/^(ab|cd)e/
+
+/(abc|)ef/
+    abcdef
+ 0: ef
+ 1: 
+
+/(a|b)c*d/
+    abcd
+ 0: bcd
+ 1: b
+
+/(ab|ab*)bc/
+    abc
+ 0: abc
+ 1: a
+
+/a([bc]*)c*/
+    abc
+ 0: abc
+ 1: bc
+
+/a([bc]*)(c*d)/
+    abcd
+ 0: abcd
+ 1: bc
+ 2: d
+
+/a([bc]+)(c*d)/
+    abcd
+ 0: abcd
+ 1: bc
+ 2: d
+
+/a([bc]*)(c+d)/
+    abcd
+ 0: abcd
+ 1: b
+ 2: cd
+
+/a[bcd]*dcdcde/
+    adcdcde
+ 0: adcdcde
+
+/a[bcd]+dcdcde/
+\= Expect no match
+    abcde
+No match
+    adcdcde
+No match
+
+/(ab|a)b*c/
+    abc
+ 0: abc
+ 1: ab
+
+/((a)(b)c)(d)/
+    abcd
+ 0: abcd
+ 1: abc
+ 2: a
+ 3: b
+ 4: d
+
+/[a-zA-Z_][a-zA-Z0-9_]*/
+    alpha
+ 0: alpha
+
+/^a(bc+|b[eh])g|.h$/
+    abh
+ 0: bh
+
+/(bc+d$|ef*g.|h?i(j|k))/
+    effgz
+ 0: effgz
+ 1: effgz
+    ij
+ 0: ij
+ 1: ij
+ 2: j
+    reffgz
+ 0: effgz
+ 1: effgz
+\= Expect no match
+    effg
+No match
+    bcdd
+No match
+
+/((((((((((a))))))))))/
+    a
+ 0: a
+ 1: a
+ 2: a
+ 3: a
+ 4: a
+ 5: a
+ 6: a
+ 7: a
+ 8: a
+ 9: a
+10: a
+
+/((((((((((a))))))))))\10/
+    aa
+ 0: aa
+ 1: a
+ 2: a
+ 3: a
+ 4: a
+ 5: a
+ 6: a
+ 7: a
+ 8: a
+ 9: a
+10: a
+
+/(((((((((a)))))))))/
+    a
+ 0: a
+ 1: a
+ 2: a
+ 3: a
+ 4: a
+ 5: a
+ 6: a
+ 7: a
+ 8: a
+ 9: a
+
+/multiple words of text/
+\= Expect no match
+    aa
+No match
+    uh-uh
+No match
+
+/multiple words/
+    multiple words, yeah
+ 0: multiple words
+
+/(.*)c(.*)/
+    abcde
+ 0: abcde
+ 1: ab
+ 2: de
+
+/\((.*), (.*)\)/
+    (a, b)
+ 0: (a, b)
+ 1: a
+ 2: b
+
+/[k]/
+
+/abcd/
+    abcd
+ 0: abcd
+
+/a(bc)d/
+    abcd
+ 0: abcd
+ 1: bc
+
+/a[-]?c/
+    ac
+ 0: ac
+
+/(abc)\1/
+    abcabc
+ 0: abcabc
+ 1: abc
+
+/([a-c]*)\1/
+    abcabc
+ 0: abcabc
+ 1: abc
+
+/(a)|\1/
+    a
+ 0: a
+ 1: a
+    ab
+ 0: a
+ 1: a
+\= Expect no match
+    x
+No match
+
+/(([a-c])b*?\2)*/
+    ababbbcbc
+ 0: ababb
+ 1: bb
+ 2: b
+
+/(([a-c])b*?\2){3}/
+    ababbbcbc
+ 0: ababbbcbc
+ 1: cbc
+ 2: c
+
+/((\3|b)\2(a)x)+/
+    aaaxabaxbaaxbbax
+ 0: bbax
+ 1: bbax
+ 2: b
+ 3: a
+
+/((\3|b)\2(a)){2,}/
+    bbaababbabaaaaabbaaaabba
+ 0: bbaaaabba
+ 1: bba
+ 2: b
+ 3: a
+
+/abc/i
+    ABC
+ 0: ABC
+    XABCY
+ 0: ABC
+    ABABC
+ 0: ABC
+\= Expect no match
+    aaxabxbaxbbx
+No match
+    XBC
+No match
+    AXC
+No match
+    ABX
+No match
+
+/ab*c/i
+    ABC
+ 0: ABC
+
+/ab*bc/i
+    ABC
+ 0: ABC
+    ABBC
+ 0: ABBC
+
+/ab*?bc/i
+    ABBBBC
+ 0: ABBBBC
+
+/ab{0,}?bc/i
+    ABBBBC
+ 0: ABBBBC
+
+/ab+?bc/i
+    ABBC
+ 0: ABBC
+
+/ab+bc/i
+\= Expect no match
+    ABC
+No match
+    ABQ
+No match
+
+/ab{1,}bc/i
+
+/ab+bc/i
+    ABBBBC
+ 0: ABBBBC
+
+/ab{1,}?bc/i
+    ABBBBC
+ 0: ABBBBC
+
+/ab{1,3}?bc/i
+    ABBBBC
+ 0: ABBBBC
+
+/ab{3,4}?bc/i
+    ABBBBC
+ 0: ABBBBC
+
+/ab{4,5}?bc/i
+\= Expect no match
+    ABQ
+No match
+    ABBBBC
+No match
+
+/ab??bc/i
+    ABBC
+ 0: ABBC
+    ABC
+ 0: ABC
+
+/ab{0,1}?bc/i
+    ABC
+ 0: ABC
+
+/ab??bc/i
+
+/ab??c/i
+    ABC
+ 0: ABC
+
+/ab{0,1}?c/i
+    ABC
+ 0: ABC
+
+/^abc$/i
+    ABC
+ 0: ABC
+\= Expect no match
+    ABBBBC
+No match
+    ABCC
+No match
+
+/^abc/i
+    ABCC
+ 0: ABC
+
+/^abc$/i
+
+/abc$/i
+    AABC
+ 0: ABC
+
+/^/i
+    ABC
+ 0: 
+
+/$/i
+    ABC
+ 0: 
+
+/a.c/i
+    ABC
+ 0: ABC
+    AXC
+ 0: AXC
+
+/a.*?c/i
+    AXYZC
+ 0: AXYZC
+
+/a.*c/i
+    AABC
+ 0: AABC
+\= Expect no match
+    AXYZD
+No match
+
+/a[bc]d/i
+    ABD
+ 0: ABD
+
+/a[b-d]e/i
+    ACE
+ 0: ACE
+\= Expect no match
+    ABC
+No match
+    ABD
+No match
+
+/a[b-d]/i
+    AAC
+ 0: AC
+
+/a[-b]/i
+    A-
+ 0: A-
+
+/a[b-]/i
+    A-
+ 0: A-
+
+/a]/i
+    A]
+ 0: A]
+
+/a[]]b/i
+    A]B
+ 0: A]B
+
+/a[^bc]d/i
+    AED
+ 0: AED
+
+/a[^-b]c/i
+    ADC
+ 0: ADC
+\= Expect no match
+    ABD
+No match
+    A-C
+No match
+
+/a[^]b]c/i
+    ADC
+ 0: ADC
+
+/ab|cd/i
+    ABC
+ 0: AB
+    ABCD
+ 0: AB
+
+/()ef/i
+    DEF
+ 0: EF
+ 1: 
+
+/$b/i
+\= Expect no match
+    A]C
+No match
+    B
+No match
+
+/a\(b/i
+    A(B
+ 0: A(B
+
+/a\(*b/i
+    AB
+ 0: AB
+    A((B
+ 0: A((B
+
+/a\\b/i
+    A\\b
+ 0: A\b
+    a\\B 
+ 0: a\B
+
+/((a))/i
+    ABC
+ 0: A
+ 1: A
+ 2: A
+
+/(a)b(c)/i
+    ABC
+ 0: ABC
+ 1: A
+ 2: C
+
+/a+b+c/i
+    AABBABC
+ 0: ABC
+
+/a{1,}b{1,}c/i
+    AABBABC
+ 0: ABC
+
+/a.+?c/i
+    ABCABC
+ 0: ABC
+
+/a.*?c/i
+    ABCABC
+ 0: ABC
+
+/a.{0,5}?c/i
+    ABCABC
+ 0: ABC
+
+/(a+|b)*/i
+    AB
+ 0: AB
+ 1: B
+
+/(a+|b){0,}/i
+    AB
+ 0: AB
+ 1: B
+
+/(a+|b)+/i
+    AB
+ 0: AB
+ 1: B
+
+/(a+|b){1,}/i
+    AB
+ 0: AB
+ 1: B
+
+/(a+|b)?/i
+    AB
+ 0: A
+ 1: A
+
+/(a+|b){0,1}/i
+    AB
+ 0: A
+ 1: A
+
+/(a+|b){0,1}?/i
+    AB
+ 0: 
+
+/[^ab]*/i
+    CDE
+ 0: CDE
+
+/([abc])*d/i
+    ABBBCD
+ 0: ABBBCD
+ 1: C
+
+/([abc])*bcd/i
+    ABCD
+ 0: ABCD
+ 1: A
+
+/a|b|c|d|e/i
+    E
+ 0: E
+
+/(a|b|c|d|e)f/i
+    EF
+ 0: EF
+ 1: E
+
+/abcd*efg/i
+    ABCDEFG
+ 0: ABCDEFG
+
+/ab*/i
+    XABYABBBZ
+ 0: AB
+    XAYABBBZ
+ 0: A
+
+/(ab|cd)e/i
+    ABCDE
+ 0: CDE
+ 1: CD
+
+/[abhgefdc]ij/i
+    HIJ
+ 0: HIJ
+
+/^(ab|cd)e/i
+\= Expect no match
+    ABCDE
+No match
+
+/(abc|)ef/i
+    ABCDEF
+ 0: EF
+ 1: 
+
+/(a|b)c*d/i
+    ABCD
+ 0: BCD
+ 1: B
+
+/(ab|ab*)bc/i
+    ABC
+ 0: ABC
+ 1: A
+
+/a([bc]*)c*/i
+    ABC
+ 0: ABC
+ 1: BC
+
+/a([bc]*)(c*d)/i
+    ABCD
+ 0: ABCD
+ 1: BC
+ 2: D
+
+/a([bc]+)(c*d)/i
+    ABCD
+ 0: ABCD
+ 1: BC
+ 2: D
+
+/a([bc]*)(c+d)/i
+    ABCD
+ 0: ABCD
+ 1: B
+ 2: CD
+
+/a[bcd]*dcdcde/i
+    ADCDCDE
+ 0: ADCDCDE
+
+/a[bcd]+dcdcde/i
+
+/(ab|a)b*c/i
+    ABC
+ 0: ABC
+ 1: AB
+
+/((a)(b)c)(d)/i
+    ABCD
+ 0: ABCD
+ 1: ABC
+ 2: A
+ 3: B
+ 4: D
+
+/[a-zA-Z_][a-zA-Z0-9_]*/i
+    ALPHA
+ 0: ALPHA
+
+/^a(bc+|b[eh])g|.h$/i
+    ABH
+ 0: BH
+
+/(bc+d$|ef*g.|h?i(j|k))/i
+    EFFGZ
+ 0: EFFGZ
+ 1: EFFGZ
+    IJ
+ 0: IJ
+ 1: IJ
+ 2: J
+    REFFGZ
+ 0: EFFGZ
+ 1: EFFGZ
+\= Expect no match
+    ADCDCDE
+No match
+    EFFG
+No match
+    BCDD
+No match
+
+/((((((((((a))))))))))/i
+    A
+ 0: A
+ 1: A
+ 2: A
+ 3: A
+ 4: A
+ 5: A
+ 6: A
+ 7: A
+ 8: A
+ 9: A
+10: A
+
+/((((((((((a))))))))))\10/i
+    AA
+ 0: AA
+ 1: A
+ 2: A
+ 3: A
+ 4: A
+ 5: A
+ 6: A
+ 7: A
+ 8: A
+ 9: A
+10: A
+
+/(((((((((a)))))))))/i
+    A
+ 0: A
+ 1: A
+ 2: A
+ 3: A
+ 4: A
+ 5: A
+ 6: A
+ 7: A
+ 8: A
+ 9: A
+
+/(?:(?:(?:(?:(?:(?:(?:(?:(?:(a))))))))))/i
+    A
+ 0: A
+ 1: A
+
+/(?:(?:(?:(?:(?:(?:(?:(?:(?:(a|b|c))))))))))/i
+    C
+ 0: C
+ 1: C
+
+/multiple words of text/i
+\= Expect no match
+    AA
+No match
+    UH-UH
+No match
+
+/multiple words/i
+    MULTIPLE WORDS, YEAH
+ 0: MULTIPLE WORDS
+
+/(.*)c(.*)/i
+    ABCDE
+ 0: ABCDE
+ 1: AB
+ 2: DE
+
+/\((.*), (.*)\)/i
+    (A, B)
+ 0: (A, B)
+ 1: A
+ 2: B
+
+/[k]/i
+
+/abcd/i
+    ABCD
+ 0: ABCD
+
+/a(bc)d/i
+    ABCD
+ 0: ABCD
+ 1: BC
+
+/a[-]?c/i
+    AC
+ 0: AC
+
+/(abc)\1/i
+    ABCABC
+ 0: ABCABC
+ 1: ABC
+
+/([a-c]*)\1/i
+    ABCABC
+ 0: ABCABC
+ 1: ABC
+
+/a(?!b)./
+    abad
+ 0: ad
+
+/a(?=d)./
+    abad
+ 0: ad
+
+/a(?=c|d)./
+    abad
+ 0: ad
+
+/a(?:b|c|d)(.)/
+    ace
+ 0: ace
+ 1: e
+
+/a(?:b|c|d)*(.)/
+    ace
+ 0: ace
+ 1: e
+
+/a(?:b|c|d)+?(.)/
+    ace
+ 0: ace
+ 1: e
+    acdbcdbe
+ 0: acd
+ 1: d
+
+/a(?:b|c|d)+(.)/
+    acdbcdbe
+ 0: acdbcdbe
+ 1: e
+
+/a(?:b|c|d){2}(.)/
+    acdbcdbe
+ 0: acdb
+ 1: b
+
+/a(?:b|c|d){4,5}(.)/
+    acdbcdbe
+ 0: acdbcdb
+ 1: b
+
+/a(?:b|c|d){4,5}?(.)/
+    acdbcdbe
+ 0: acdbcd
+ 1: d
+
+/((foo)|(bar))*/
+    foobar
+ 0: foobar
+ 1: bar
+ 2: foo
+ 3: bar
+
+/a(?:b|c|d){6,7}(.)/
+    acdbcdbe
+ 0: acdbcdbe
+ 1: e
+
+/a(?:b|c|d){6,7}?(.)/
+    acdbcdbe
+ 0: acdbcdbe
+ 1: e
+
+/a(?:b|c|d){5,6}(.)/
+    acdbcdbe
+ 0: acdbcdbe
+ 1: e
+
+/a(?:b|c|d){5,6}?(.)/
+    acdbcdbe
+ 0: acdbcdb
+ 1: b
+
+/a(?:b|c|d){5,7}(.)/
+    acdbcdbe
+ 0: acdbcdbe
+ 1: e
+
+/a(?:b|c|d){5,7}?(.)/
+    acdbcdbe
+ 0: acdbcdb
+ 1: b
+
+/a(?:b|(c|e){1,2}?|d)+?(.)/
+    ace
+ 0: ace
+ 1: c
+ 2: e
+
+/^(.+)?B/
+    AB
+ 0: AB
+ 1: A
+
+/^([^a-z])|(\^)$/
+    .
+ 0: .
+ 1: .
+
+/^[<>]&/
+    <&OUT
+ 0: <&
+
+/^(a\1?){4}$/
+    aaaaaaaaaa
+ 0: aaaaaaaaaa
+ 1: aaaa
+\= Expect no match
+    AB
+No match
+    aaaaaaaaa
+No match
+    aaaaaaaaaaa
+No match
+
+/^(a(?(1)\1)){4}$/
+    aaaaaaaaaa
+ 0: aaaaaaaaaa
+ 1: aaaa
+\= Expect no match
+    aaaaaaaaa
+No match
+    aaaaaaaaaaa
+No match
+
+/(?:(f)(o)(o)|(b)(a)(r))*/
+    foobar
+ 0: foobar
+ 1: f
+ 2: o
+ 3: o
+ 4: b
+ 5: a
+ 6: r
+
+/(?<=a)b/
+    ab
+ 0: b
+\= Expect no match
+    cb
+No match
+    b
+No match
+
+/(?<!c)b/
+    ab
+ 0: b
+    b
+ 0: b
+    b
+ 0: b
+
+/(?:..)*a/
+    aba
+ 0: aba
+
+/(?:..)*?a/
+    aba
+ 0: a
+
+/^(?:b|a(?=(.)))*\1/
+    abc
+ 0: ab
+ 1: b
+
+/^(){3,5}/
+    abc
+ 0: 
+ 1: 
+
+/^(a+)*ax/
+    aax
+ 0: aax
+ 1: a
+
+/^((a|b)+)*ax/
+    aax
+ 0: aax
+ 1: a
+ 2: a
+
+/^((a|bc)+)*ax/
+    aax
+ 0: aax
+ 1: a
+ 2: a
+
+/(a|x)*ab/
+    cab
+ 0: ab
+
+/(a)*ab/
+    cab
+ 0: ab
+
+/(?:(?i)a)b/
+    ab
+ 0: ab
+
+/((?i)a)b/
+    ab
+ 0: ab
+ 1: a
+
+/(?:(?i)a)b/
+    Ab
+ 0: Ab
+
+/((?i)a)b/
+    Ab
+ 0: Ab
+ 1: A
+
+/(?:(?i)a)b/
+\= Expect no match
+    cb
+No match
+    aB
+No match
+
+/((?i)a)b/
+
+/(?i:a)b/
+    ab
+ 0: ab
+
+/((?i:a))b/
+    ab
+ 0: ab
+ 1: a
+
+/(?i:a)b/
+    Ab
+ 0: Ab
+
+/((?i:a))b/
+    Ab
+ 0: Ab
+ 1: A
+
+/(?i:a)b/
+\= Expect no match
+    aB
+No match
+    aB
+No match
+
+/((?i:a))b/
+
+/(?:(?-i)a)b/i
+    ab
+ 0: ab
+
+/((?-i)a)b/i
+    ab
+ 0: ab
+ 1: a
+
+/(?:(?-i)a)b/i
+    aB
+ 0: aB
+
+/((?-i)a)b/i
+    aB
+ 0: aB
+ 1: a
+
+/(?:(?-i)a)b/i
+    aB
+ 0: aB
+\= Expect no match
+    Ab
+No match
+    AB
+No match
+
+/(?-i:a)b/i
+    ab
+ 0: ab
+
+/((?-i:a))b/i
+    ab
+ 0: ab
+ 1: a
+
+/(?-i:a)b/i
+    aB
+ 0: aB
+
+/((?-i:a))b/i
+    aB
+ 0: aB
+ 1: a
+
+/(?-i:a)b/i
+\= Expect no match
+    AB
+No match
+    Ab
+No match
+
+/((?-i:a))b/i
+
+/(?-i:a)b/i
+    aB
+ 0: aB
+
+/((?-i:a))b/i
+    aB
+ 0: aB
+ 1: a
+
+/(?-i:a)b/i
+\= Expect no match
+    Ab
+No match
+    AB
+No match
+
+/((?-i:a))b/i
+
+/((?-i:a.))b/i
+\= Expect no match
+    AB
+No match
+    a\nB
+No match
+
+/((?s-i:a.))b/i
+    a\nB
+ 0: a\x0aB
+ 1: a\x0a
+
+/(?:c|d)(?:)(?:a(?:)(?:b)(?:b(?:))(?:b(?:)(?:b)))/
+    cabbbb
+ 0: cabbbb
+
+/(?:c|d)(?:)(?:aaaaaaaa(?:)(?:bbbbbbbb)(?:bbbbbbbb(?:))(?:bbbbbbbb(?:)(?:bbbbbbbb)))/
+    caaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+ 0: caaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+
+/(ab)\d\1/i
+    Ab4ab
+ 0: Ab4ab
+ 1: Ab
+    ab4Ab
+ 0: ab4Ab
+ 1: ab
+
+/foo\w*\d{4}baz/
+    foobar1234baz
+ 0: foobar1234baz
+
+/x(~~)*(?:(?:F)?)?/
+    x~~
+ 0: x~~
+ 1: ~~
+
+/^a(?#xxx){3}c/
+    aaac
+ 0: aaac
+
+/^a (?#xxx) (?#yyy) {3}c/x
+    aaac
+ 0: aaac
+
+/(?<![cd])b/
+\= Expect no match
+    B\nB
+No match
+    dbcb
+No match
+
+/(?<![cd])[ab]/
+    dbaacb
+ 0: a
+
+/(?<!(c|d))b/
+
+/(?<!(c|d))[ab]/
+    dbaacb
+ 0: a
+
+/(?<!cd)[ab]/
+    cdaccb
+ 0: b
+
+/^(?:a?b?)*$/
+    \
+ 0: 
+    a
+ 0: a
+    ab
+ 0: ab
+    aaa   
+ 0: aaa
+\= Expect no match
+    dbcb
+No match
+    a--
+No match
+    aa-- 
+No match
+
+/((?s)^a(.))((?m)^b$)/
+    a\nb\nc\n
+ 0: a\x0ab
+ 1: a\x0a
+ 2: \x0a
+ 3: b
+
+/((?m)^b$)/
+    a\nb\nc\n
+ 0: b
+ 1: b
+
+/(?m)^b/
+    a\nb\n
+ 0: b
+
+/(?m)^(b)/
+    a\nb\n
+ 0: b
+ 1: b
+
+/((?m)^b)/
+    a\nb\n
+ 0: b
+ 1: b
+
+/\n((?m)^b)/
+    a\nb\n
+ 0: \x0ab
+ 1: b
+
+/((?s).)c(?!.)/
+    a\nb\nc\n
+ 0: \x0ac
+ 1: \x0a
+    a\nb\nc\n
+ 0: \x0ac
+ 1: \x0a
+
+/((?s)b.)c(?!.)/
+    a\nb\nc\n
+ 0: b\x0ac
+ 1: b\x0a
+    a\nb\nc\n
+ 0: b\x0ac
+ 1: b\x0a
+
+/^b/
+
+/()^b/
+\= Expect no match
+    a\nb\nc\n
+No match
+    a\nb\nc\n
+No match
+
+/((?m)^b)/
+    a\nb\nc\n
+ 0: b
+ 1: b
+
+/(x)?(?(1)a|b)/
+\= Expect no match
+    a
+No match
+    a
+No match
+
+/(x)?(?(1)b|a)/
+    a
+ 0: a
+
+/()?(?(1)b|a)/
+    a
+ 0: a
+
+/()(?(1)b|a)/
+
+/()?(?(1)a|b)/
+    a
+ 0: a
+ 1: 
+
+/^(\()?blah(?(1)(\)))$/
+    (blah)
+ 0: (blah)
+ 1: (
+ 2: )
+    blah
+ 0: blah
+\= Expect no match
+    a
+No match
+    blah)
+No match
+    (blah
+No match
+
+/^(\(+)?blah(?(1)(\)))$/
+    (blah)
+ 0: (blah)
+ 1: (
+ 2: )
+    blah
+ 0: blah
+\= Expect no match
+    blah)
+No match
+    (blah
+No match
+
+/(?(?!a)a|b)/
+
+/(?(?!a)b|a)/
+    a
+ 0: a
+
+/(?(?=a)b|a)/
+\= Expect no match
+    a
+No match
+    a
+No match
+
+/(?(?=a)a|b)/
+    a
+ 0: a
+
+/(?=(a+?))(\1ab)/
+    aaab
+ 0: aab
+ 1: a
+ 2: aab
+
+/^(?=(a+?))\1ab/
+
+/(\w+:)+/
+    one:
+ 0: one:
+ 1: one:
+
+/$(?<=^(a))/
+    a
+ 0: 
+ 1: a
+
+/(?=(a+?))(\1ab)/
+    aaab
+ 0: aab
+ 1: a
+ 2: aab
+
+/^(?=(a+?))\1ab/
+\= Expect no match
+    aaab
+No match
+    aaab
+No match
+
+/([\w:]+::)?(\w+)$/
+    abcd
+ 0: abcd
+ 1: <unset>
+ 2: abcd
+    xy:z:::abcd
+ 0: xy:z:::abcd
+ 1: xy:z:::
+ 2: abcd
+
+/^[^bcd]*(c+)/
+    aexycd
+ 0: aexyc
+ 1: c
+
+/(a*)b+/
+    caab
+ 0: aab
+ 1: aa
+
+/([\w:]+::)?(\w+)$/
+    abcd
+ 0: abcd
+ 1: <unset>
+ 2: abcd
+    xy:z:::abcd
+ 0: xy:z:::abcd
+ 1: xy:z:::
+ 2: abcd
+\= Expect no match
+    abcd:
+No match
+    abcd:
+No match
+
+/^[^bcd]*(c+)/
+    aexycd
+ 0: aexyc
+ 1: c
+
+/(>a+)ab/
+
+/(?>a+)b/
+    aaab
+ 0: aaab
+
+/([[:]+)/
+    a:[b]:
+ 0: :[
+ 1: :[
+
+/([[=]+)/
+    a=[b]=
+ 0: =[
+ 1: =[
+
+/([[.]+)/
+    a.[b].
+ 0: .[
+ 1: .[
+
+/((?>a+)b)/
+    aaab
+ 0: aaab
+ 1: aaab
+
+/(?>(a+))b/
+    aaab
+ 0: aaab
+ 1: aaa
+
+/((?>[^()]+)|\([^()]*\))+/
+    ((abc(ade)ufh()()x
+ 0: abc(ade)ufh()()x
+ 1: x
+
+/a\Z/
+\= Expect no match
+    aaab
+No match
+    a\nb\n
+No match
+
+/b\Z/
+    a\nb\n
+ 0: b
+
+/b\z/
+
+/b\Z/
+    a\nb
+ 0: b
+
+/b\z/
+    a\nb
+ 0: b
+    
+/^(?>(?(1)\.|())[^\W_](?>[a-z0-9-]*[^\W_])?)+$/
+    a
+ 0: a
+ 1: 
+    abc
+ 0: abc
+ 1: 
+    a-b
+ 0: a-b
+ 1: 
+    0-9
+ 0: 0-9
+ 1: 
+    a.b
+ 0: a.b
+ 1: 
+    5.6.7
+ 0: 5.6.7
+ 1: 
+    the.quick.brown.fox
+ 0: the.quick.brown.fox
+ 1: 
+    a100.b200.300c
+ 0: a100.b200.300c
+ 1: 
+    12-ab.1245
+ 0: 12-ab.1245
+ 1: 
+\= Expect no match
+    \
+No match
+    .a
+No match
+    -a
+No match
+    a-
+No match
+    a.
+No match
+    a_b
+No match
+    a.-
+No match
+    a..
+No match
+    ab..bc
+No match
+    the.quick.brown.fox-
+No match
+    the.quick.brown.fox.
+No match
+    the.quick.brown.fox_
+No match
+    the.quick.brown.fox+
+No match
+
+/(?>.*)(?<=(abcd|wxyz))/
+    alphabetabcd
+ 0: alphabetabcd
+ 1: abcd
+    endingwxyz
+ 0: endingwxyz
+ 1: wxyz
+\= Expect no match
+    a rather long string that doesn't end with one of them
+No match
+
+/word (?>(?:(?!otherword)[a-zA-Z0-9]+ ){0,30})otherword/
+    word cat dog elephant mussel cow horse canary baboon snake shark otherword
+ 0: word cat dog elephant mussel cow horse canary baboon snake shark otherword
+\= Expect no match
+    word cat dog elephant mussel cow horse canary baboon snake shark
+No match
+  
+/word (?>[a-zA-Z0-9]+ ){0,30}otherword/
+\= Expect no match
+    word cat dog elephant mussel cow horse canary baboon snake shark the quick brown fox and the lazy dog and several other words getting close to thirty by now I hope
+No match
+
+/(?<=\d{3}(?!999))foo/
+    999foo
+ 0: foo
+    123999foo 
+ 0: foo
+\= Expect no match
+    123abcfoo
+No match
+    
+/(?<=(?!...999)\d{3})foo/
+    999foo
+ 0: foo
+    123999foo 
+ 0: foo
+\= Expect no match
+    123abcfoo
+No match
+
+/(?<=\d{3}(?!999)...)foo/
+    123abcfoo
+ 0: foo
+    123456foo 
+ 0: foo
+\= Expect no match
+    123999foo  
+No match
+    
+/(?<=\d{3}...)(?<!999)foo/
+    123abcfoo   
+ 0: foo
+    123456foo 
+ 0: foo
+\= Expect no match
+    123999foo  
+No match
+
+/<a[\s]+href[\s]*=[\s]*          # find <a href=
+ ([\"\'])?                       # find single or double quote
+ (?(1) (.*?)\1 | ([^\s]+))       # if quote found, match up to next matching
+                                 # quote, otherwise match up to next space
+/isx
+    <a href=abcd xyz
+ 0: <a href=abcd
+ 1: <unset>
+ 2: <unset>
+ 3: abcd
+    <a href=\"abcd xyz pqr\" cats
+ 0: <a href="abcd xyz pqr"
+ 1: "
+ 2: abcd xyz pqr
+    <a href=\'abcd xyz pqr\' cats
+ 0: <a href='abcd xyz pqr'
+ 1: '
+ 2: abcd xyz pqr
+
+/<a\s+href\s*=\s*                # find <a href=
+ (["'])?                         # find single or double quote
+ (?(1) (.*?)\1 | (\S+))          # if quote found, match up to next matching
+                                 # quote, otherwise match up to next space
+/isx
+    <a href=abcd xyz
+ 0: <a href=abcd
+ 1: <unset>
+ 2: <unset>
+ 3: abcd
+    <a href=\"abcd xyz pqr\" cats
+ 0: <a href="abcd xyz pqr"
+ 1: "
+ 2: abcd xyz pqr
+    <a href       =       \'abcd xyz pqr\' cats
+ 0: <a href       =       'abcd xyz pqr'
+ 1: '
+ 2: abcd xyz pqr
+
+/<a\s+href(?>\s*)=(?>\s*)        # find <a href=
+ (["'])?                         # find single or double quote
+ (?(1) (.*?)\1 | (\S+))          # if quote found, match up to next matching
+                                 # quote, otherwise match up to next space
+/isx
+    <a href=abcd xyz
+ 0: <a href=abcd
+ 1: <unset>
+ 2: <unset>
+ 3: abcd
+    <a href=\"abcd xyz pqr\" cats
+ 0: <a href="abcd xyz pqr"
+ 1: "
+ 2: abcd xyz pqr
+    <a href       =       \'abcd xyz pqr\' cats
+ 0: <a href       =       'abcd xyz pqr'
+ 1: '
+ 2: abcd xyz pqr
+
+/((Z)+|A)*/
+    ZABCDEFG
+ 0: ZA
+ 1: A
+ 2: Z
+
+/(Z()|A)*/
+    ZABCDEFG
+ 0: ZA
+ 1: A
+ 2: 
+
+/(Z(())|A)*/
+    ZABCDEFG
+ 0: ZA
+ 1: A
+ 2: 
+ 3: 
+
+/((?>Z)+|A)*/
+    ZABCDEFG
+ 0: ZA
+ 1: A
+
+/((?>)+|A)*/
+    ZABCDEFG
+ 0: 
+ 1: 
+
+/^[\d-a]/
+    abcde
+ 0: a
+    -things
+ 0: -
+    0digit
+ 0: 0
+\= Expect no match
+    bcdef    
+No match
+    
+/[\s]+/
+    > \x09\x0a\x0c\x0d\x0b<
+ 0:  \x09\x0a\x0c\x0d\x0b
+     
+/\s+/
+    > \x09\x0a\x0c\x0d\x0b<
+ 0:  \x09\x0a\x0c\x0d\x0b
+     
+/ab/x
+    ab
+ 0: ab
+
+/(?!\A)x/m
+    a\nxb\n
+ 0: x
+
+/(?!^)x/m
+\= Expect no match
+    a\nxb\n
+No match
+
+#/abc\Qabc\Eabc/
+#    abcabcabc
+# 0: abcabcabc
+    
+#/abc\Q(*+|\Eabc/
+#    abc(*+|abc 
+# 0: abc(*+|abc
+
+#/   abc\Q abc\Eabc/x
+#    abc abcabc
+# 0: abc abcabc
+#\= Expect no match
+#    abcabcabc  
+#No match
+    
+#/abc#comment
+#    \Q#not comment
+#    literal\E/x
+#    abc#not comment\n    literal     
+# 0: abc#not comment\x0a    literal
+
+#/abc#comment
+#    \Q#not comment
+#    literal/x
+#    abc#not comment\n    literal     
+# 0: abc#not comment\x0a    literal
+
+#/abc#comment
+#    \Q#not comment
+#    literal\E #more comment
+#    /x
+#    abc#not comment\n    literal     
+# 0: abc#not comment\x0a    literal
+
+#/abc#comment
+#    \Q#not comment
+#    literal\E #more comment/x
+#    abc#not comment\n    literal     
+# 0: abc#not comment\x0a    literal
+
+#/\Qabc\$xyz\E/
+#    abc\\\$xyz
+# 0: abc\$xyz
+
+#/\Qabc\E\$\Qxyz\E/
+#    abc\$xyz
+# 0: abc$xyz
+
+/\Gabc/
+    abc
+ 0: abc
+\= Expect no match
+    xyzabc  
+No match
+
+/a(?x: b c )d/
+    XabcdY
+ 0: abcd
+\= Expect no match 
+    Xa b c d Y 
+No match
+
+/((?x)x y z | a b c)/
+    XabcY
+ 0: abc
+ 1: abc
+    AxyzB 
+ 0: xyz
+ 1: xyz
+
+/(?i)AB(?-i)C/
+    XabCY
+ 0: abC
+\= Expect no match
+    XabcY  
+No match
+
+/((?i)AB(?-i)C|D)E/
+    abCE
+ 0: abCE
+ 1: abC
+    DE
+ 0: DE
+ 1: D
+\= Expect no match
+    abcE
+No match
+    abCe  
+No match
+    dE
+No match
+    De    
+No match
+
+/(.*)\d+\1/
+    abc123abc
+ 0: abc123abc
+ 1: abc
+    abc123bc 
+ 0: bc123bc
+ 1: bc
+
+/(.*)\d+\1/s
+    abc123abc
+ 0: abc123abc
+ 1: abc
+    abc123bc 
+ 0: bc123bc
+ 1: bc
+    
+/((.*))\d+\1/
+    abc123abc
+ 0: abc123abc
+ 1: abc
+ 2: abc
+    abc123bc  
+ 0: bc123bc
+ 1: bc
+ 2: bc
+
+# This tests for an IPv6 address in the form where it can have up to
+# eight components, one and only one of which is empty. This must be
+# an internal component. 
+
+/^(?!:)                       # colon disallowed at start
+  (?:                         # start of item
+    (?: [0-9a-f]{1,4} |       # 1-4 hex digits or
+    (?(1)0 | () ) )           # if null previously matched, fail; else null
+    :                         # followed by colon
+  ){1,7}                      # end item; 1-7 of them required               
+  [0-9a-f]{1,4} $             # final hex number at end of string
+  (?(1)|.)                    # check that there was an empty component
+  /ix
+    a123::a123
+ 0: a123::a123
+ 1: 
+    a123:b342::abcd
+ 0: a123:b342::abcd
+ 1: 
+    a123:b342::324e:abcd
+ 0: a123:b342::324e:abcd
+ 1: 
+    a123:ddde:b342::324e:abcd
+ 0: a123:ddde:b342::324e:abcd
+ 1: 
+    a123:ddde:b342::324e:dcba:abcd
+ 0: a123:ddde:b342::324e:dcba:abcd
+ 1: 
+    a123:ddde:9999:b342::324e:dcba:abcd
+ 0: a123:ddde:9999:b342::324e:dcba:abcd
+ 1: 
+\= Expect no match
+    1:2:3:4:5:6:7:8
+No match
+    a123:bce:ddde:9999:b342::324e:dcba:abcd
+No match
+    a123::9999:b342::324e:dcba:abcd
+No match
+    abcde:2:3:4:5:6:7:8
+No match
+    ::1
+No match
+    abcd:fee0:123::   
+No match
+    :1
+No match
+    1:  
+No match
+
+#/[z\Qa-d]\E]/
+#    z
+# 0: z
+#    a
+# 0: a
+#    -
+# 0: -
+#    d
+# 0: d
+#    ] 
+# 0: ]
+#\= Expect no match
+#    b     
+#No match
+
+#TODO: PCRE has an optimization to make this workable, .NET does not
+#/(a+)*b/
+#\= Expect no match
+#    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 
+#No match
+
+# All these had to be updated because we understand unicode
+# and this looks like it's expecting single byte matches
+
+# .NET generates \xe4...not sure what's up, might just be different code pages
+/(?i)reg(?:ul(?:[aä]|ae)r|ex)/
+    REGular
+ 0: REGular
+    regulaer
+ 0: regulaer
+    Regex  
+ 0: Regex
+    regulär 
+ 0: regul\xc3\xa4r
+
+#/Åæåä[à-ÿÀ-ß]+/
+#    Åæåäà
+# 0: \xc5\xe6\xe5\xe4\xe0
+#    Åæåäÿ
+# 0: \xc5\xe6\xe5\xe4\xff
+#    ÅæåäÀ
+# 0: \xc5\xe6\xe5\xe4\xc0
+#    Åæåäß
+# 0: \xc5\xe6\xe5\xe4\xdf
+
+/(?<=Z)X./
+    \x84XAZXB
+ 0: XB
+
+/ab cd (?x) de fg/
+    ab cd defg
+ 0: ab cd defg
+
+/ab cd(?x) de fg/
+    ab cddefg
+ 0: ab cddefg
+\= Expect no match 
+    abcddefg
+No match
+
+/(?<![^f]oo)(bar)/
+    foobarX 
+ 0: bar
+ 1: bar
+\= Expect no match 
+    boobarX
+No match
+
+/(?<![^f])X/
+    offX
+ 0: X
+\= Expect no match
+    onyX  
+No match
+
+/(?<=[^f])X/
+    onyX
+ 0: X
+\= Expect no match
+    offX 
+No match
+
+/(?:(?(1)a|b)(X))+/
+    bXaX
+ 0: bXaX
+ 1: X
+
+/(?:(?(1)\1a|b)(X|Y))+/
+    bXXaYYaY
+ 0: bXXaYYaY
+ 1: Y
+    bXYaXXaX  
+ 0: bX
+ 1: X
+
+# TODO: I think this is a difference caused by the 
+# collision of group numbers, but not sure 
+#/()()()()()()()()()(?:(?(10)\10a|b)(X|Y))+/
+#    bXXaYYaY
+# 0: bX
+# 1: 
+# 2: 
+# 3: 
+# 4: 
+# 5: 
+# 6: 
+# 7: 
+# 8: 
+# 9: 
+#10: X
+
+/[[,abc,]+]/
+    abc]
+ 0: abc]
+    a,b]
+ 0: a,b]
+    [a,b,c]  
+ 0: [a,b,c]
+
+/(?-x: )/x
+    A\x20B
+ 0:  
+    
+"(?x)(?-x: \s*#\s*)"
+    A # B
+ 0:  # 
+\= Expect no match
+    #  
+No match
+
+"(?x-is)(?:(?-ixs) \s*#\s*) include"
+    A #include
+ 0:  #include
+\= Expect no match
+    A#include  
+No match
+    A #Include
+No match
+
+/a*b*\w/
+    aaabbbb
+ 0: aaabbbb
+    aaaa
+ 0: aaaa
+    a
+ 0: a
+
+/a*b?\w/
+    aaabbbb
+ 0: aaabb
+    aaaa
+ 0: aaaa
+    a
+ 0: a
+
+/a*b{0,4}\w/
+    aaabbbb
+ 0: aaabbbb
+    aaaa
+ 0: aaaa
+    a
+ 0: a
+
+/a*b{0,}\w/
+    aaabbbb
+ 0: aaabbbb
+    aaaa
+ 0: aaaa
+    a
+ 0: a
+    
+/a*\d*\w/
+    0a
+ 0: 0a
+    a 
+ 0: a
+    
+/a*b *\w/x
+    a 
+ 0: a
+
+/a*b#comment
+  *\w/x
+    a 
+ 0: a
+
+/a* b *\w/x
+    a 
+ 0: a
+
+/^\w+=.*(\\\n.*)*/
+    abc=xyz\\\npqr
+ 0: abc=xyz\
+
+/(?=(\w+))\1:/
+    abcd:
+ 0: abcd:
+ 1: abcd
+
+/^(?=(\w+))\1:/
+    abcd:
+ 0: abcd:
+ 1: abcd
+
+#/^\Eabc/
+#    abc
+# 0: abc
+    
+#/^[\Eabc]/
+#    a
+# 0: a
+#\= Expect no match 
+#    E 
+#No match
+    
+#/^[a-\Ec]/
+#    b
+# 0: b
+#\= Expect no match
+#    -
+#No match
+#    E    
+#No match
+
+#/^[a\E\E-\Ec]/
+#    b
+# 0: b
+#\= Expect no match
+#    -
+#No match
+#    E    
+#No match
+
+#/^[\E\Qa\E-\Qz\E]+/
+#    b
+# 0: b
+#\= Expect no match
+#    -  
+#No match
+    
+#/^[a\Q]bc\E]/
+#    a
+# 0: a
+#    ]
+# 0: ]
+#    c
+# 0: c
+    
+#/^[a-\Q\E]/
+#    a
+# 0: a
+#    -     
+# 0: -
+
+/^(a()*)*/
+    aaaa
+ 0: aaaa
+ 1: a
+ 2: 
+
+/^(?:a(?:(?:))*)*/
+    aaaa
+ 0: aaaa
+
+/^(a()+)+/
+    aaaa
+ 0: aaaa
+ 1: a
+ 2: 
+
+/^(?:a(?:(?:))+)+/
+    aaaa
+ 0: aaaa
+
+/(a){0,3}(?(1)b|(c|))*D/
+    abbD
+ 0: abbD
+ 1: a
+    ccccD
+ 0: ccccD
+ 1: <unset>
+ 2: 
+    D  
+ 0: D
+ 1: <unset>
+ 2: 
+
+# this is really long with debug -- removing for now
+#/(a|)*\d/
+#    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa4
+# 0: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa4
+# 1: 
+#\= Expect no match
+#    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+#No match
+
+/(?>a|)*\d/
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa4
+ 0: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa4
+\= Expect no match
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+No match
+
+/(?:a|)*\d/
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa4
+ 0: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa4
+\= Expect no match
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+No match
+
+/^(?s)(?>.*)(?<!\n)/
+    abc
+ 0: abc
+\= Expect no match
+    abc\n  
+No match
+
+/^(?![^\n]*\n\z)/
+    abc
+ 0: 
+\= Expect no match
+    abc\n 
+No match
+  
+/\z(?<!\n)/
+    abc
+ 0: 
+\= Expect no match
+    abc\n  
+No match
+
+/(.*(.)?)*/
+    abcd
+ 0: abcd
+ 1: 
+
+/( (A | (?(1)0|) )*   )/x
+    abcd
+ 0: 
+ 1: 
+ 2: 
+
+/( ( (?(1)0|) )*   )/x
+    abcd
+ 0: 
+ 1: 
+ 2: 
+
+/(  (?(1)0|)*   )/x
+    abcd
+ 0: 
+ 1: 
+
+/[[:abcd:xyz]]/
+    a]
+ 0: a]
+    :] 
+ 0: :]
+    
+/[abc[:x\]pqr]/
+    a
+ 0: a
+    [
+ 0: [
+    :
+ 0: :
+    ]
+ 0: ]
+    p    
+ 0: p
+
+/.*[op][xyz]/
+\= Expect no match
+    fooabcfoo
+No match
+
+/(?(?=.*b)b|^)/
+    adc
+ 0: 
+    abc 
+ 0: b
+
+/(?(?=^.*b)b|^)/
+    adc
+ 0: 
+\= Expect no match
+    abc 
+No match
+
+/(?(?=.*b)b|^)*/
+    adc
+ 0: 
+    abc 
+ 0: 
+
+/(?(?=.*b)b|^)+/
+    adc
+ 0: 
+    abc 
+ 0: b
+
+/(?(?=b).*b|^d)/
+    abc
+ 0: b
+
+/(?(?=.*b).*b|^d)/
+    abc
+ 0: ab
+
+/^%((?(?=[a])[^%])|b)*%$/
+    %ab%
+ 0: %ab%
+ 1: 
+
+/(?i)a(?-i)b|c/
+    XabX
+ 0: ab
+    XAbX
+ 0: Ab
+    CcC 
+ 0: c
+\= Expect no match
+    XABX   
+No match
+
+/[\x00-\xff\s]+/
+    \x0a\x0b\x0c\x0d
+ 0: \x0a\x0b\x0c\x0d
+
+/(abc)\1/i
+\= Expect no match
+    abc
+No match
+
+/(abc)\1/
+\= Expect no match
+    abc
+No match
+
+/[^a]*/i
+    12abc
+ 0: 12
+    12ABC
+ 0: 12
+
+#Posses
+/[^a]*/i
+    12abc
+ 0: 12
+    12ABC
+ 0: 12
+
+/[^a]*?X/i
+\= Expect no match
+    12abc
+No match
+    12ABC
+No match
+    
+/[^a]+?X/i
+\= Expect no match
+    12abc
+No match
+    12ABC
+No match
+
+/[^a]?X/i
+    12aXbcX
+ 0: X
+    12AXBCX
+ 0: X
+    BCX 
+ 0: CX
+
+/[^a]??X/i
+    12aXbcX
+ 0: X
+    12AXBCX
+ 0: X
+    BCX
+ 0: CX
+
+/[^a]{2,3}/i
+    abcdef
+ 0: bcd
+    ABCDEF  
+ 0: BCD
+
+/[^a]{2,3}?/i
+    abcdef
+ 0: bc
+    ABCDEF  
+ 0: BC
+
+/((a|)+)+Z/
+    Z
+ 0: Z
+ 1: 
+ 2: 
+
+/(a)b|(a)c/
+    ac
+ 0: ac
+ 1: <unset>
+ 2: a
+
+/(?>(a))b|(a)c/
+    ac
+ 0: ac
+ 1: <unset>
+ 2: a
+
+/(?=(a))ab|(a)c/
+    ac
+ 0: ac
+ 1: <unset>
+ 2: a
+
+/((?>(a))b|(a)c)/
+    ac
+ 0: ac
+ 1: ac
+ 2: <unset>
+ 3: a
+
+/(?=(?>(a))b|(a)c)(..)/
+    ac
+ 0: ac
+ 1: <unset>
+ 2: a
+ 3: ac
+
+/(?>(?>(a))b|(a)c)/
+    ac
+ 0: ac
+ 1: <unset>
+ 2: a
+
+/((?>(a+)b)+(aabab))/
+    aaaabaaabaabab
+ 0: aaaabaaabaabab
+ 1: aaaabaaabaabab
+ 2: aaa
+ 3: aabab
+
+/(?>a+|ab)+?c/
+\= Expect no match
+    aabc
+No match
+
+/(?>a+|ab)+c/
+\= Expect no match
+    aabc
+No match
+
+/(?:a+|ab)+c/
+    aabc
+ 0: aabc
+
+/^(?:a|ab)+c/
+    aaaabc
+ 0: aaaabc
+
+/(?=abc){0}xyz/
+    xyz 
+ 0: xyz
+
+/(?=abc){1}xyz/
+\= Expect no match
+    xyz 
+No match
+    
+/(?=(a))?./
+    ab
+ 0: a
+ 1: a
+    bc
+ 0: b
+      
+/(?=(a))??./
+    ab
+ 0: a
+    bc
+ 0: b
+
+/^(?!a){0}\w+/
+    aaaaa
+ 0: aaaaa
+
+/(?<=(abc))?xyz/
+    abcxyz
+ 0: xyz
+ 1: abc
+    pqrxyz 
+ 0: xyz
+
+/^[g<a>]+/
+    ggg<<<aaa>>>
+ 0: ggg<<<aaa>>>
+\= Expect no match
+    \\ga  
+No match
+    
+/^[ga]+/
+    gggagagaxyz 
+ 0: gggagaga
+   
+/[:a]xxx[b:]/
+     :xxx:
+ 0: :xxx:
+     
+/(?<=a{2})b/i
+    xaabc
+ 0: b
+\= Expect no match
+    xabc  
+No match
+
+/(?<!a{2})b/i
+    xabc
+ 0: b
+\= Expect no match
+    xaabc  
+No match
+    
+/(?<=[^a]{2})b/
+    axxbc
+ 0: b
+    aAAbc 
+ 0: b
+\= Expect no match
+    xaabc    
+No match
+
+/(?<=[^a]{2})b/i
+    axxbc  
+ 0: b
+\= Expect no match
+    aAAbc 
+No match
+    xaabc    
+No match
+
+#/(?|(abc)|(xyz))\1/
+#    abcabc
+# 0: abcabc
+# 1: abc
+#    xyzxyz 
+# 0: xyzxyz
+# 1: xyz
+#\= Expect no match
+#    abcxyz
+#No match
+#    xyzabc   
+#No match
+    
+#/(?|(abc)|(xyz))(?1)/
+#    abcabc
+# 0: abcabc
+# 1: abc
+#    xyzabc 
+# 0: xyzabc
+# 1: xyz
+#\= Expect no match 
+#    xyzxyz 
+#No match
+ 
+#/^X(?5)(a)(?|(b)|(q))(c)(d)(Y)/
+#    XYabcdY
+# 0: XYabcdY
+# 1: a
+# 2: b
+# 3: c
+# 4: d
+# 5: Y
+
+#/^X(?7)(a)(?|(b|(r)(s))|(q))(c)(d)(Y)/
+#    XYabcdY
+# 0: XYabcdY
+# 1: a
+# 2: b
+# 3: <unset>
+# 4: <unset>
+# 5: c
+# 6: d
+# 7: Y
+
+#/^X(?7)(a)(?|(b|(?|(r)|(t))(s))|(q))(c)(d)(Y)/
+#    XYabcdY
+# 0: XYabcdY
+# 1: a
+# 2: b
+# 3: <unset>
+# 4: <unset>
+# 5: c
+# 6: d
+# 7: Y
+
+/(?'abc'\w+):\k<abc>{2}/
+    a:aaxyz
+ 0: a:aa
+ 1: a
+    ab:ababxyz
+ 0: ab:abab
+ 1: ab
+\= Expect no match
+    a:axyz
+No match
+    ab:abxyz
+No match
+
+/^(?<ab>a)? (?(ab)b|c) (?(ab)d|e)/x
+    abd
+ 0: abd
+ 1: a
+    ce
+ 0: ce
+    
+# .NET has more consistent grouping numbers with these dupe groups for the two options
+/(?:a(?<quote> (?<apostrophe>')|(?<realquote>")) |b(?<quote> (?<apostrophe>')|(?<realquote>")) ) (?(quote)[a-z]+|[0-9]+)/x,dupnames
+    a\"aaaaa
+ 0: a"aaaaa
+ 1: "
+ 2: <unset>
+ 3: "
+    b\"aaaaa
+ 0: b"aaaaa
+ 1: "
+ 2: <unset>
+ 3: "
+\= Expect no match 
+    b\"11111
+No match
+
+#/(?P<L1>(?P<L2>0)(?P>L1)|(?P>L2))/
+#    0
+# 0: 0
+# 1: 0
+#    00
+# 0: 00
+# 1: 00
+# 2: 0
+#    0000  
+# 0: 0000
+# 1: 0000
+# 2: 0
+
+#/(?P<L1>(?P<L2>0)|(?P>L2)(?P>L1))/
+#    0
+# 0: 0
+# 1: 0
+# 2: 0
+#    00
+# 0: 0
+# 1: 0
+# 2: 0
+#    0000  
+# 0: 0
+# 1: 0
+# 2: 0
+
+# Check the use of names for failure
+
+# Check opening parens in comment when seeking forward reference.
+
+#/(?P<abn>(?P=abn)xxx|)+/
+#    xxx
+# 0: 
+# 1: 
+
+#Posses
+/^(a)?(\w)/
+    aaaaX
+ 0: aa
+ 1: a
+ 2: a
+    YZ 
+ 0: Y
+ 1: <unset>
+ 2: Y
+
+#Posses
+/^(?:a)?(\w)/
+    aaaaX
+ 0: aa
+ 1: a
+    YZ 
+ 0: Y
+ 1: Y
+
+/\A.*?(a|bc)/
+    ba
+ 0: ba
+ 1: a
+
+/\A.*?(?:a|bc|d)/
+    ba
+ 0: ba
+
+# --------------------------
+
+/(another)?(\1?)test/
+    hello world test
+ 0: test
+ 1: <unset>
+ 2: 
+
+/(another)?(\1+)test/
+\= Expect no match
+    hello world test
+No match
+
+/((?:a?)*)*c/
+    aac   
+ 0: aac
+ 1: 
+
+/((?>a?)*)*c/
+    aac   
+ 0: aac
+ 1: 
+
+/(?>.*?a)(?<=ba)/
+    aba
+ 0: ba
+
+/(?:.*?a)(?<=ba)/
+    aba
+ 0: aba
+
+/(?>.*?a)b/s
+    aab
+ 0: ab
+
+/(?>.*?a)b/
+    aab
+ 0: ab
+
+/(?>^a)b/s
+\= Expect no match
+    aab
+No match
+
+/(?>.*?)(?<=(abcd)|(wxyz))/
+    alphabetabcd
+ 0: 
+ 1: abcd
+    endingwxyz 
+ 0: 
+ 1: <unset>
+ 2: wxyz
+
+/(?>.*)(?<=(abcd)|(wxyz))/
+    alphabetabcd
+ 0: alphabetabcd
+ 1: abcd
+    endingwxyz
+ 0: endingwxyz
+ 1: <unset>
+ 2: wxyz
+
+"(?>.*)foo"
+\= Expect no match
+    abcdfooxyz
+No match
+    
+"(?>.*?)foo"
+    abcdfooxyz
+ 0: foo
+
+# Tests that try to figure out how Perl works. My hypothesis is that the first
+# verb that is backtracked onto is the one that acts. This seems to be the case
+# almost all the time, but there is one exception that is perhaps a bug.
+ 
+/a(?=bc).|abd/
+    abd
+ 0: abd
+    abc 
+ 0: ab
+  
+/a(?>bc)d|abd/
+    abceabd 
+ 0: abd
+
+# These tests were formerly in test 2, but changes in PCRE and Perl have
+# made them compatible. 
+    
+/^(a)?(?(1)a|b)+$/
+\= Expect no match
+    a
+No match
+
+# ----
+
+/^\d*\w{4}/
+    1234
+ 0: 1234
+\= Expect no match
+    123 
+No match
+
+/^[^b]*\w{4}/
+    aaaa
+ 0: aaaa
+\= Expect no match
+    aaa     
+No match
+
+/^[^b]*\w{4}/i
+    aaaa
+ 0: aaaa
+\= Expect no match
+    aaa     
+No match
+
+/^a*\w{4}/
+    aaaa
+ 0: aaaa
+\= Expect no match
+    aaa     
+No match
+
+/^a*\w{4}/i
+    aaaa
+ 0: aaaa
+\= Expect no match
+    aaa     
+No match
+
+/(?:(?<n>foo)|(?<n>bar))\k<n>/dupnames
+    foofoo
+ 0: foofoo
+ 1: foo
+    barbar
+ 0: barbar
+ 1: bar
+
+# A notable difference between PCRE and .NET.  According to
+# the PCRE docs:
+# If you make a subroutine call to a non-unique named 
+# subpattern, the one that corresponds  to  the first 
+# occurrence of the name is used. In the absence of 
+# duplicate numbers (see the previous section) this is 
+# the one with the lowest number.
+# .NET takes the most recently captured number according to MSDN:
+# A backreference refers to the most recent definition of 
+# a group (the definition most immediately to the left, 
+# when matching left to right). When a group makes multiple
+# captures, a backreference refers to the most recent capture.
+
+#/(?<n>A)(?:(?<n>foo)|(?<n>bar))\k<n>/dupnames
+#    AfooA
+# 0: AfooA
+# 1: A
+# 2: foo
+#    AbarA  
+# 0: AbarA
+# 1: A
+# 2: <unset>
+# 3: bar
+#\= Expect no match 
+#    Afoofoo
+#No match
+#    Abarbar
+#No match
+
+/^(\d+)\s+IN\s+SOA\s+(\S+)\s+(\S+)\s*\(\s*$/
+    1 IN SOA non-sp1 non-sp2(
+ 0: 1 IN SOA non-sp1 non-sp2(
+ 1: 1
+ 2: non-sp1
+ 3: non-sp2
+
+# TODO: .NET's group number ordering here in the second example is a bit odd
+/^ (?:(?<A>A)|(?'B'B)(?<A>A)) (?(A)x) (?(B)y)$/x,dupnames
+    Ax
+ 0: Ax
+ 1: A
+    BAxy
+ 0: BAxy
+ 1: A
+ 2: B
+ 
+/ ^ a + b $ /x
+    aaaab
+ 0: aaaab
+    
+/ ^ a + #comment
+   b $ /x
+    aaaab
+ 0: aaaab
+    
+/ ^ a + #comment
+  #comment
+   b $ /x
+    aaaab
+ 0: aaaab
+    
+/ ^ (?> a + ) b $ /x
+    aaaab 
+ 0: aaaab
+
+/ ^ ( a + ) + \w $ /x
+    aaaab 
+ 0: aaaab
+ 1: aaaa
+
+/(?:x|(?:(xx|yy)+|x|x|x|x|x)|a|a|a)bc/
+\= Expect no match
+    acb
+No match
+
+#Posses
+#/\A(?:[^\"]+|\"(?:[^\"]*|\"\")*\")+/
+#    NON QUOTED \"QUOT\"\"ED\" AFTER \"NOT MATCHED
+# 0: NON QUOTED "QUOT""ED" AFTER 
+
+#Posses
+#/\A(?:[^\"]+|\"(?:[^\"]+|\"\")*\")+/
+#    NON QUOTED \"QUOT\"\"ED\" AFTER \"NOT MATCHED
+# 0: NON QUOTED "QUOT""ED" AFTER 
+
+#Posses
+#/\A(?:[^\"]+|\"(?:[^\"]+|\"\")+\")+/
+#    NON QUOTED \"QUOT\"\"ED\" AFTER \"NOT MATCHED
+# 0: NON QUOTED "QUOT""ED" AFTER 
+
+#Posses
+#/\A([^\"1]+|[\"2]([^\"3]*|[\"4][\"5])*[\"6])+/
+#    NON QUOTED \"QUOT\"\"ED\" AFTER \"NOT MATCHED
+# 0: NON QUOTED "QUOT""ED" AFTER 
+# 1:  AFTER 
+# 2: 
+
+/^\w+(?>\s*)(?<=\w)/
+    test test
+ 0: tes
+
+#/(?P<Name>a)?(?P<Name2>b)?(?(<Name>)c|d)*l/
+#    acl
+# 0: acl
+# 1: a
+#    bdl
+# 0: bdl
+# 1: <unset>
+# 2: b
+#    adl
+# 0: dl
+#    bcl    
+# 0: l
+
+/\sabc/
+    \x0babc
+ 0: \x0babc
+
+#/[\Qa]\E]+/
+#    aa]]
+# 0: aa]]
+
+#/[\Q]a\E]+/
+#    aa]]
+# 0: aa]]
+
+/A((((((((a))))))))\8B/ 
+    AaaB
+ 0: AaaB
+ 1: a
+ 2: a
+ 3: a
+ 4: a
+ 5: a
+ 6: a
+ 7: a
+ 8: a
+
+/A(((((((((a)))))))))\9B/ 
+    AaaB
+ 0: AaaB
+ 1: a
+ 2: a
+ 3: a
+ 4: a
+ 5: a
+ 6: a
+ 7: a
+ 8: a
+ 9: a
+    
+/(|ab)*?d/
+    abd
+ 0: abd
+ 1: ab
+    xyd 
+ 0: d
+
+/(\2|a)(\1)/
+    aaa
+ 0: aa
+ 1: a
+ 2: a
+
+/(\2)(\1)/
+
+"Z*(|d*){216}"
+
+/((((((((((((x))))))))))))\12/
+    xx
+ 0: xx
+ 1: x
+ 2: x
+ 3: x
+ 4: x
+ 5: x
+ 6: x
+ 7: x
+ 8: x
+ 9: x
+10: x
+11: x
+12: x
+
+#"(?|(\k'Pm')|(?'Pm'))"
+#    abcd
+# 0: 
+# 1: 
+
+#/(?|(aaa)|(b))\g{1}/
+#    aaaaaa
+# 0: aaaaaa
+# 1: aaa
+#    bb 
+# 0: bb
+# 1: b
+
+#/(?|(aaa)|(b))(?1)/
+#    aaaaaa
+# 0: aaaaaa
+# 1: aaa
+#    baaa 
+# 0: baaa
+# 1: b
+#\= Expect no match 
+#    bb 
+#No match
+
+#/(?|(aaa)|(b))/
+#    xaaa
+# 0: aaa
+# 1: aaa
+#    xbc 
+# 0: b
+# 1: b
+
+#/(?|(?'a'aaa)|(?'a'b))\k'a'/
+#    aaaaaa
+# 0: aaaaaa
+# 1: aaa
+#    bb 
+# 0: bb
+# 1: b
+
+#/(?|(?'a'aaa)|(?'a'b))(?'a'cccc)\k'a'/dupnames
+#    aaaccccaaa
+# 0: aaaccccaaa
+# 1: aaa
+# 2: cccc
+#    bccccb 
+# 0: bccccb
+# 1: b
+# 2: cccc
+
+# End of testinput1 

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/.gitmodules
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "testdata/JSON-Schema-Test-Suite"]
+	path = testdata/JSON-Schema-Test-Suite
+	url = https://github.com/json-schema-org/JSON-Schema-Test-Suite.git
+	branch = main

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/.golangci.yml
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/.golangci.yml
@@ -1,0 +1,7 @@
+version: "2"
+linters:
+  enable:
+    - nakedret
+    - errname
+    - godot
+    - misspell

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/.pre-commit-hooks.yaml
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: jsonschema-validate
+  name: Validate JSON against JSON Schema
+  description: ensure json files follow specified JSON Schema
+  entry: jv
+  language: golang
+  additional_dependencies:
+  - ./cmd/jv

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/LICENSE
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/LICENSE
@@ -1,0 +1,175 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/README.md
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/README.md
@@ -1,0 +1,88 @@
+# jsonschema v6.0.2
+
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![GoDoc](https://godoc.org/github.com/santhosh-tekuri/jsonschema?status.svg)](https://pkg.go.dev/github.com/santhosh-tekuri/jsonschema/v6)
+[![Go Report Card](https://goreportcard.com/badge/github.com/santhosh-tekuri/jsonschema/v6)](https://goreportcard.com/report/github.com/santhosh-tekuri/jsonschema/v6)
+[![Build Status](https://github.com/santhosh-tekuri/jsonschema/actions/workflows/go.yaml/badge.svg?branch=boon)](https://github.com/santhosh-tekuri/jsonschema/actions/workflows/go.yaml)
+[![codecov](https://codecov.io/gh/santhosh-tekuri/jsonschema/branch/boon/graph/badge.svg?token=JMVj1pFT2l)](https://codecov.io/gh/santhosh-tekuri/jsonschema/tree/boon)
+
+see [godoc](https://pkg.go.dev/github.com/santhosh-tekuri/jsonschema/v6) for examples
+
+## Library Features
+
+- [x] pass [JSON-Schema-Test-Suite](https://github.com/json-schema-org/JSON-Schema-Test-Suite) excluding optional(compare with other impls at [bowtie](https://bowtie-json-schema.github.io/bowtie/#))
+  - [x] [![draft-04](https://img.shields.io/endpoint?url=https://bowtie.report/badges/go-jsonschema/compliance/draft4.json)](https://bowtie.report/#/dialects/draft4)
+  - [x] [![draft-06](https://img.shields.io/endpoint?url=https://bowtie.report/badges/go-jsonschema/compliance/draft6.json)](https://bowtie.report/#/dialects/draft6)
+  - [x] [![draft-07](https://img.shields.io/endpoint?url=https://bowtie.report/badges/go-jsonschema/compliance/draft7.json)](https://bowtie.report/#/dialects/draft7)
+  - [x] [![draft/2019-09](https://img.shields.io/endpoint?url=https://bowtie.report/badges/go-jsonschema/compliance/draft2019-09.json)](https://bowtie.report/#/dialects/draft2019-09)
+  - [x] [![draft/2020-12](https://img.shields.io/endpoint?url=https://bowtie.report/badges/go-jsonschema/compliance/draft2020-12.json)](https://bowtie.report/#/dialects/draft2020-12)
+- [x] detect infinite loop traps
+  - [x] `$schema` cycle
+  - [x] validation cycle
+- [x] custom `$schema` url
+- [x] vocabulary based validation
+- [x] custom regex engine
+- [x] format assertions
+  - [x] flag to enable in draft >= 2019-09
+  - [x] custom format registration
+  - [x] built-in formats
+    - [x] regex, uuid
+    - [x] ipv4, ipv6
+    - [x] hostname, email
+    - [x] date, time, date-time, duration
+    - [x] json-pointer, relative-json-pointer
+    - [x] uri, uri-reference, uri-template
+    - [x] iri, iri-reference
+    - [x] period, semver
+- [x] content assertions
+  - [x] flag to enable in draft >= 7
+  - [x] contentEncoding
+    - [x] base64
+    - [x] custom
+  - [x] contentMediaType
+    - [x] application/json
+    - [x] custom
+  - [x] contentSchema
+- [x] errors
+  - [x] introspectable
+  - [x] hierarchy
+    - [x] alternative display with `#`
+  - [x] output
+    - [x] flag
+    - [x] basic
+    - [x] detailed
+- [x] custom vocabulary
+    - enable via `$vocabulary` for draft >=2019-19
+    - enable via flag for draft <= 7
+- [x] mixed dialect support
+
+## CLI v0.7.0
+
+to install: `go install github.com/santhosh-tekuri/jsonschema/cmd/jv@latest`
+
+Note that the cli is versioned independently. you can see it in git tags `cmd/jv/v0.7.0`
+
+```
+Usage: jv [OPTIONS] SCHEMA [INSTANCE...]
+
+Options:
+  -c, --assert-content    Enable content assertions with draft >= 7
+  -f, --assert-format     Enable format assertions with draft >= 2019
+      --cacert pem-file   Use the specified pem-file to verify the peer. The file may contain multiple CA certificates
+  -d, --draft version     Draft version used when '$schema' is missing. Valid values 4, 6, 7, 2019, 2020 (default 2020)
+  -h, --help              Print help information
+  -k, --insecure          Use insecure TLS connection
+  -o, --output format     Output format. Valid values simple, alt, flag, basic, detailed (default "simple")
+  -q, --quiet             Do not print errors
+  -v, --version           Print build information
+```
+
+- [x] exit code `1` for validation errors, `2` for usage errors
+- [x] validate both schema and multiple instances
+- [x] support both json and yaml files
+- [x] support standard input, use `-`
+- [x] quite mode with parsable output
+- [x] http(s) url support
+  - [x] custom certs for validation, use `--cacert`
+  - [x] flag to skip certificate verification, use `--insecure`
+

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/compiler.go
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/compiler.go
@@ -1,0 +1,332 @@
+package jsonschema
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+)
+
+// Compiler compiles json schema into *Schema.
+type Compiler struct {
+	schemas       map[urlPtr]*Schema
+	roots         *roots
+	formats       map[string]*Format
+	decoders      map[string]*Decoder
+	mediaTypes    map[string]*MediaType
+	assertFormat  bool
+	assertContent bool
+}
+
+// NewCompiler create Compiler Object.
+func NewCompiler() *Compiler {
+	return &Compiler{
+		schemas:       map[urlPtr]*Schema{},
+		roots:         newRoots(),
+		formats:       map[string]*Format{},
+		decoders:      map[string]*Decoder{},
+		mediaTypes:    map[string]*MediaType{},
+		assertFormat:  false,
+		assertContent: false,
+	}
+}
+
+// DefaultDraft overrides the draft used to
+// compile schemas without `$schema` field.
+//
+// By default, this library uses the latest
+// draft supported.
+//
+// The use of this option is HIGHLY encouraged
+// to ensure continued correct operation of your
+// schema. The current default value will not stay
+// the same overtime.
+func (c *Compiler) DefaultDraft(d *Draft) {
+	c.roots.defaultDraft = d
+}
+
+// AssertFormat always enables format assertions.
+//
+// Default Behavior:
+// for draft-07: enabled.
+// for draft/2019-09: disabled unless metaschema says `format` vocabulary is required.
+// for draft/2020-12: disabled unless metaschema says `format-assertion` vocabulary is required.
+func (c *Compiler) AssertFormat() {
+	c.assertFormat = true
+}
+
+// AssertContent enables content assertions.
+//
+// Content assertions include keywords:
+//   - contentEncoding
+//   - contentMediaType
+//   - contentSchema
+//
+// Default behavior is always disabled.
+func (c *Compiler) AssertContent() {
+	c.assertContent = true
+}
+
+// RegisterFormat registers custom format.
+//
+// NOTE:
+//   - "regex" format can not be overridden
+//   - format assertions are disabled for draft >= 2019-09
+//     see [Compiler.AssertFormat]
+func (c *Compiler) RegisterFormat(f *Format) {
+	if f.Name != "regex" {
+		c.formats[f.Name] = f
+	}
+}
+
+// RegisterContentEncoding registers custom contentEncoding.
+//
+// NOTE: content assertions are disabled by default.
+// see [Compiler.AssertContent].
+func (c *Compiler) RegisterContentEncoding(d *Decoder) {
+	c.decoders[d.Name] = d
+}
+
+// RegisterContentMediaType registers custom contentMediaType.
+//
+// NOTE: content assertions are disabled by default.
+// see [Compiler.AssertContent].
+func (c *Compiler) RegisterContentMediaType(mt *MediaType) {
+	c.mediaTypes[mt.Name] = mt
+}
+
+// RegisterVocabulary registers custom vocabulary.
+//
+// NOTE:
+//   - vocabularies are disabled for draft >= 2019-09
+//     see [Compiler.AssertVocabs]
+func (c *Compiler) RegisterVocabulary(vocab *Vocabulary) {
+	c.roots.vocabularies[vocab.URL] = vocab
+}
+
+// AssertVocabs always enables user-defined vocabularies assertions.
+//
+// Default Behavior:
+// for draft-07: enabled.
+// for draft/2019-09: disabled unless metaschema enables a vocabulary.
+// for draft/2020-12: disabled unless metaschema enables a vocabulary.
+func (c *Compiler) AssertVocabs() {
+	c.roots.assertVocabs = true
+}
+
+// AddResource adds schema resource which gets used later in reference
+// resolution.
+//
+// The argument url can be file path or url. Any fragment in url is ignored.
+// The argument doc must be valid json value.
+func (c *Compiler) AddResource(url string, doc any) error {
+	uf, err := absolute(url)
+	if err != nil {
+		return err
+	}
+	if isMeta(string(uf.url)) {
+		return &ResourceExistsError{string(uf.url)}
+	}
+	if !c.roots.loader.add(uf.url, doc) {
+		return &ResourceExistsError{string(uf.url)}
+	}
+	return nil
+}
+
+// UseLoader overrides the default [URLLoader] used
+// to load schema resources.
+func (c *Compiler) UseLoader(loader URLLoader) {
+	c.roots.loader.loader = loader
+}
+
+// UseRegexpEngine changes the regexp-engine used.
+// By default it uses regexp package from go standard
+// library.
+//
+// NOTE: must be called before compiling any schemas.
+func (c *Compiler) UseRegexpEngine(engine RegexpEngine) {
+	if engine == nil {
+		engine = goRegexpCompile
+	}
+	c.roots.regexpEngine = engine
+}
+
+func (c *Compiler) enqueue(q *queue, up urlPtr) *Schema {
+	if sch, ok := c.schemas[up]; ok {
+		// already got compiled
+		return sch
+	}
+	if sch := q.get(up); sch != nil {
+		return sch
+	}
+	sch := newSchema(up)
+	q.append(sch)
+	return sch
+}
+
+// MustCompile is like [Compile] but panics if compilation fails.
+// It simplifies safe initialization of global variables holding
+// compiled schema.
+func (c *Compiler) MustCompile(loc string) *Schema {
+	sch, err := c.Compile(loc)
+	if err != nil {
+		panic(fmt.Sprintf("jsonschema: Compile(%q): %v", loc, err))
+	}
+	return sch
+}
+
+// Compile compiles json-schema at given loc.
+func (c *Compiler) Compile(loc string) (*Schema, error) {
+	uf, err := absolute(loc)
+	if err != nil {
+		return nil, err
+	}
+	up, err := c.roots.resolveFragment(*uf)
+	if err != nil {
+		return nil, err
+	}
+	return c.doCompile(up)
+}
+
+func (c *Compiler) doCompile(up urlPtr) (*Schema, error) {
+	q := &queue{}
+	compiled := 0
+
+	c.enqueue(q, up)
+	for q.len() > compiled {
+		sch := q.at(compiled)
+		if err := c.roots.ensureSubschema(sch.up); err != nil {
+			return nil, err
+		}
+		r := c.roots.roots[sch.up.url]
+		v, err := sch.up.lookup(r.doc)
+		if err != nil {
+			return nil, err
+		}
+		if err := c.compileValue(v, sch, r, q); err != nil {
+			return nil, err
+		}
+		compiled++
+	}
+	for _, sch := range *q {
+		c.schemas[sch.up] = sch
+	}
+	return c.schemas[up], nil
+}
+
+func (c *Compiler) compileValue(v any, sch *Schema, r *root, q *queue) error {
+	res := r.resource(sch.up.ptr)
+	sch.DraftVersion = res.dialect.draft.version
+
+	base := urlPtr{sch.up.url, res.ptr}
+	sch.resource = c.enqueue(q, base)
+
+	// if resource, enqueue dynamic anchors for compilation
+	if sch.DraftVersion >= 2020 && sch.up == sch.resource.up {
+		res := r.resource(sch.up.ptr)
+		for anchor, anchorPtr := range res.anchors {
+			if slices.Contains(res.dynamicAnchors, anchor) {
+				up := urlPtr{sch.up.url, anchorPtr}
+				danchorSch := c.enqueue(q, up)
+				if sch.dynamicAnchors == nil {
+					sch.dynamicAnchors = map[string]*Schema{}
+				}
+				sch.dynamicAnchors[string(anchor)] = danchorSch
+			}
+		}
+	}
+
+	switch v := v.(type) {
+	case bool:
+		sch.Bool = &v
+	case map[string]any:
+		if err := c.compileObject(v, sch, r, q); err != nil {
+			return err
+		}
+	}
+
+	sch.allPropsEvaluated = sch.AdditionalProperties != nil
+	if sch.DraftVersion < 2020 {
+		sch.allItemsEvaluated = sch.AdditionalItems != nil
+		switch items := sch.Items.(type) {
+		case *Schema:
+			sch.allItemsEvaluated = true
+		case []*Schema:
+			sch.numItemsEvaluated = len(items)
+		}
+	} else {
+		sch.allItemsEvaluated = sch.Items2020 != nil
+		sch.numItemsEvaluated = len(sch.PrefixItems)
+	}
+
+	return nil
+}
+
+func (c *Compiler) compileObject(obj map[string]any, sch *Schema, r *root, q *queue) error {
+	if len(obj) == 0 {
+		b := true
+		sch.Bool = &b
+		return nil
+	}
+	oc := objCompiler{
+		c:   c,
+		obj: obj,
+		up:  sch.up,
+		r:   r,
+		res: r.resource(sch.up.ptr),
+		q:   q,
+	}
+	return oc.compile(sch)
+}
+
+// queue --
+
+type queue []*Schema
+
+func (q *queue) append(sch *Schema) {
+	*q = append(*q, sch)
+}
+
+func (q *queue) at(i int) *Schema {
+	return (*q)[i]
+}
+
+func (q *queue) len() int {
+	return len(*q)
+}
+
+func (q *queue) get(up urlPtr) *Schema {
+	i := slices.IndexFunc(*q, func(sch *Schema) bool { return sch.up == up })
+	if i != -1 {
+		return (*q)[i]
+	}
+	return nil
+}
+
+// regexp --
+
+// Regexp is the representation of compiled regular expression.
+type Regexp interface {
+	fmt.Stringer
+
+	// MatchString reports whether the string s contains
+	// any match of the regular expression.
+	MatchString(string) bool
+}
+
+// RegexpEngine parses a regular expression and returns,
+// if successful, a Regexp object that can be used to
+// match against text.
+type RegexpEngine func(string) (Regexp, error)
+
+func (re RegexpEngine) validate(v any) error {
+	s, ok := v.(string)
+	if !ok {
+		return nil
+	}
+	_, err := re(s)
+	return err
+}
+
+func goRegexpCompile(s string) (Regexp, error) {
+	return regexp.Compile(s)
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/content.go
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/content.go
@@ -1,0 +1,51 @@
+package jsonschema
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+)
+
+// Decoder specifies how to decode specific contentEncoding.
+type Decoder struct {
+	// Name of contentEncoding.
+	Name string
+	// Decode given string to byte array.
+	Decode func(string) ([]byte, error)
+}
+
+var decoders = map[string]*Decoder{
+	"base64": {
+		Name: "base64",
+		Decode: func(s string) ([]byte, error) {
+			return base64.StdEncoding.DecodeString(s)
+		},
+	},
+}
+
+// MediaType specified how to validate bytes against specific contentMediaType.
+type MediaType struct {
+	// Name of contentMediaType.
+	Name string
+
+	// Validate checks whether bytes conform to this mediatype.
+	Validate func([]byte) error
+
+	// UnmarshalJSON unmarshals bytes into json value.
+	// This must be nil if this mediatype is not compatible
+	// with json.
+	UnmarshalJSON func([]byte) (any, error)
+}
+
+var mediaTypes = map[string]*MediaType{
+	"application/json": {
+		Name: "application/json",
+		Validate: func(b []byte) error {
+			var v any
+			return json.Unmarshal(b, &v)
+		},
+		UnmarshalJSON: func(b []byte) (any, error) {
+			return UnmarshalJSON(bytes.NewReader(b))
+		},
+	},
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/draft.go
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/draft.go
@@ -1,0 +1,360 @@
+package jsonschema
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// A Draft represents json-schema specification.
+type Draft struct {
+	version       int
+	url           string
+	sch           *Schema
+	id            string             // property name used to represent id
+	subschemas    []SchemaPath       // locations of subschemas
+	vocabPrefix   string             // prefix used for vocabulary
+	allVocabs     map[string]*Schema // names of supported vocabs with its schemas
+	defaultVocabs []string           // names of default vocabs
+}
+
+// String returns the specification url.
+func (d *Draft) String() string {
+	return d.url
+}
+
+var (
+	Draft4 = &Draft{
+		version: 4,
+		url:     "http://json-schema.org/draft-04/schema",
+		id:      "id",
+		subschemas: []SchemaPath{
+			// type agonistic
+			schemaPath("definitions/*"),
+			schemaPath("not"),
+			schemaPath("allOf/[]"),
+			schemaPath("anyOf/[]"),
+			schemaPath("oneOf/[]"),
+			// object
+			schemaPath("properties/*"),
+			schemaPath("additionalProperties"),
+			schemaPath("patternProperties/*"),
+			// array
+			schemaPath("items"),
+			schemaPath("items/[]"),
+			schemaPath("additionalItems"),
+			schemaPath("dependencies/*"),
+		},
+		vocabPrefix:   "",
+		allVocabs:     map[string]*Schema{},
+		defaultVocabs: []string{},
+	}
+
+	Draft6 = &Draft{
+		version: 6,
+		url:     "http://json-schema.org/draft-06/schema",
+		id:      "$id",
+		subschemas: joinSubschemas(Draft4.subschemas,
+			schemaPath("propertyNames"),
+			schemaPath("contains"),
+		),
+		vocabPrefix:   "",
+		allVocabs:     map[string]*Schema{},
+		defaultVocabs: []string{},
+	}
+
+	Draft7 = &Draft{
+		version: 7,
+		url:     "http://json-schema.org/draft-07/schema",
+		id:      "$id",
+		subschemas: joinSubschemas(Draft6.subschemas,
+			schemaPath("if"),
+			schemaPath("then"),
+			schemaPath("else"),
+		),
+		vocabPrefix:   "",
+		allVocabs:     map[string]*Schema{},
+		defaultVocabs: []string{},
+	}
+
+	Draft2019 = &Draft{
+		version: 2019,
+		url:     "https://json-schema.org/draft/2019-09/schema",
+		id:      "$id",
+		subschemas: joinSubschemas(Draft7.subschemas,
+			schemaPath("$defs/*"),
+			schemaPath("dependentSchemas/*"),
+			schemaPath("unevaluatedProperties"),
+			schemaPath("unevaluatedItems"),
+			schemaPath("contentSchema"),
+		),
+		vocabPrefix: "https://json-schema.org/draft/2019-09/vocab/",
+		allVocabs: map[string]*Schema{
+			"core":       nil,
+			"applicator": nil,
+			"validation": nil,
+			"meta-data":  nil,
+			"format":     nil,
+			"content":    nil,
+		},
+		defaultVocabs: []string{"core", "applicator", "validation"},
+	}
+
+	Draft2020 = &Draft{
+		version: 2020,
+		url:     "https://json-schema.org/draft/2020-12/schema",
+		id:      "$id",
+		subschemas: joinSubschemas(Draft2019.subschemas,
+			schemaPath("prefixItems/[]"),
+		),
+		vocabPrefix: "https://json-schema.org/draft/2020-12/vocab/",
+		allVocabs: map[string]*Schema{
+			"core":              nil,
+			"applicator":        nil,
+			"unevaluated":       nil,
+			"validation":        nil,
+			"meta-data":         nil,
+			"format-annotation": nil,
+			"format-assertion":  nil,
+			"content":           nil,
+		},
+		defaultVocabs: []string{"core", "applicator", "unevaluated", "validation"},
+	}
+
+	draftLatest = Draft2020
+)
+
+func init() {
+	c := NewCompiler()
+	c.AssertFormat()
+	for _, d := range []*Draft{Draft4, Draft6, Draft7, Draft2019, Draft2020} {
+		d.sch = c.MustCompile(d.url)
+		for name := range d.allVocabs {
+			d.allVocabs[name] = c.MustCompile(strings.TrimSuffix(d.url, "schema") + "meta/" + name)
+		}
+	}
+}
+
+func draftFromURL(url string) *Draft {
+	u, frag := split(url)
+	if frag != "" {
+		return nil
+	}
+	u, ok := strings.CutPrefix(u, "http://")
+	if !ok {
+		u, _ = strings.CutPrefix(u, "https://")
+	}
+	switch u {
+	case "json-schema.org/schema":
+		return draftLatest
+	case "json-schema.org/draft/2020-12/schema":
+		return Draft2020
+	case "json-schema.org/draft/2019-09/schema":
+		return Draft2019
+	case "json-schema.org/draft-07/schema":
+		return Draft7
+	case "json-schema.org/draft-06/schema":
+		return Draft6
+	case "json-schema.org/draft-04/schema":
+		return Draft4
+	default:
+		return nil
+	}
+}
+
+func (d *Draft) getID(obj map[string]any) string {
+	if d.version < 2019 {
+		if _, ok := obj["$ref"]; ok {
+			// All other properties in a "$ref" object MUST be ignored
+			return ""
+		}
+	}
+
+	id, ok := strVal(obj, d.id)
+	if !ok {
+		return ""
+	}
+	id, _ = split(id) // ignore fragment
+	return id
+}
+
+func (d *Draft) getVocabs(url url, doc any, vocabularies map[string]*Vocabulary) ([]string, error) {
+	if d.version < 2019 {
+		return nil, nil
+	}
+	obj, ok := doc.(map[string]any)
+	if !ok {
+		return nil, nil
+	}
+	v, ok := obj["$vocabulary"]
+	if !ok {
+		return nil, nil
+	}
+	obj, ok = v.(map[string]any)
+	if !ok {
+		return nil, nil
+	}
+
+	var vocabs []string
+	for vocab, reqd := range obj {
+		if reqd, ok := reqd.(bool); !ok || !reqd {
+			continue
+		}
+		name, ok := strings.CutPrefix(vocab, d.vocabPrefix)
+		if ok {
+			if _, ok := d.allVocabs[name]; ok {
+				if !slices.Contains(vocabs, name) {
+					vocabs = append(vocabs, name)
+					continue
+				}
+			}
+		}
+		if _, ok := vocabularies[vocab]; !ok {
+			return nil, &UnsupportedVocabularyError{url.String(), vocab}
+		}
+		if !slices.Contains(vocabs, vocab) {
+			vocabs = append(vocabs, vocab)
+		}
+	}
+	if !slices.Contains(vocabs, "core") {
+		vocabs = append(vocabs, "core")
+	}
+	return vocabs, nil
+}
+
+// --
+
+type dialect struct {
+	draft  *Draft
+	vocabs []string // nil means use draft.defaultVocabs
+}
+
+func (d *dialect) hasVocab(name string) bool {
+	if name == "core" || d.draft.version < 2019 {
+		return true
+	}
+	if d.vocabs != nil {
+		return slices.Contains(d.vocabs, name)
+	}
+	return slices.Contains(d.draft.defaultVocabs, name)
+}
+
+func (d *dialect) activeVocabs(assertVocabs bool, vocabularies map[string]*Vocabulary) []string {
+	if len(vocabularies) == 0 {
+		return d.vocabs
+	}
+	if d.draft.version < 2019 {
+		assertVocabs = true
+	}
+	if !assertVocabs {
+		return d.vocabs
+	}
+	var vocabs []string
+	if d.vocabs == nil {
+		vocabs = slices.Clone(d.draft.defaultVocabs)
+	} else {
+		vocabs = slices.Clone(d.vocabs)
+	}
+	for vocab := range vocabularies {
+		if !slices.Contains(vocabs, vocab) {
+			vocabs = append(vocabs, vocab)
+		}
+	}
+	return vocabs
+}
+
+func (d *dialect) getSchema(assertVocabs bool, vocabularies map[string]*Vocabulary) *Schema {
+	vocabs := d.activeVocabs(assertVocabs, vocabularies)
+	if vocabs == nil {
+		return d.draft.sch
+	}
+
+	var allOf []*Schema
+	for _, vocab := range vocabs {
+		sch := d.draft.allVocabs[vocab]
+		if sch == nil {
+			if v, ok := vocabularies[vocab]; ok {
+				sch = v.Schema
+			}
+		}
+		if sch != nil {
+			allOf = append(allOf, sch)
+		}
+	}
+	if !slices.Contains(vocabs, "core") {
+		sch := d.draft.allVocabs["core"]
+		if sch == nil {
+			sch = d.draft.sch
+		}
+		allOf = append(allOf, sch)
+	}
+	sch := &Schema{
+		Location:     "urn:mem:metaschema",
+		up:           urlPtr{url("urn:mem:metaschema"), ""},
+		DraftVersion: d.draft.version,
+		AllOf:        allOf,
+	}
+	sch.resource = sch
+	if sch.DraftVersion >= 2020 {
+		sch.DynamicAnchor = "meta"
+		sch.dynamicAnchors = map[string]*Schema{
+			"meta": sch,
+		}
+	}
+	return sch
+}
+
+// --
+
+type ParseIDError struct {
+	URL string
+}
+
+func (e *ParseIDError) Error() string {
+	return fmt.Sprintf("error in parsing id at %q", e.URL)
+}
+
+// --
+
+type ParseAnchorError struct {
+	URL string
+}
+
+func (e *ParseAnchorError) Error() string {
+	return fmt.Sprintf("error in parsing anchor at %q", e.URL)
+}
+
+// --
+
+type DuplicateIDError struct {
+	ID   string
+	URL  string
+	Ptr1 string
+	Ptr2 string
+}
+
+func (e *DuplicateIDError) Error() string {
+	return fmt.Sprintf("duplicate id %q in %q at %q and %q", e.ID, e.URL, e.Ptr1, e.Ptr2)
+}
+
+// --
+
+type DuplicateAnchorError struct {
+	Anchor string
+	URL    string
+	Ptr1   string
+	Ptr2   string
+}
+
+func (e *DuplicateAnchorError) Error() string {
+	return fmt.Sprintf("duplicate anchor %q in %q at %q and %q", e.Anchor, e.URL, e.Ptr1, e.Ptr2)
+}
+
+// --
+
+func joinSubschemas(a1 []SchemaPath, a2 ...SchemaPath) []SchemaPath {
+	var a []SchemaPath
+	a = append(a, a1...)
+	a = append(a, a2...)
+	return a
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/format.go
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/format.go
@@ -1,0 +1,708 @@
+package jsonschema
+
+import (
+	"net/netip"
+	gourl "net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Format defined specific format.
+type Format struct {
+	// Name of format.
+	Name string
+
+	// Validate checks if given value is of this format.
+	Validate func(v any) error
+}
+
+var formats = map[string]*Format{
+	"json-pointer":          {"json-pointer", validateJSONPointer},
+	"relative-json-pointer": {"relative-json-pointer", validateRelativeJSONPointer},
+	"uuid":                  {"uuid", validateUUID},
+	"duration":              {"duration", validateDuration},
+	"period":                {"period", validatePeriod},
+	"ipv4":                  {"ipv4", validateIPV4},
+	"ipv6":                  {"ipv6", validateIPV6},
+	"hostname":              {"hostname", validateHostname},
+	"email":                 {"email", validateEmail},
+	"date":                  {"date", validateDate},
+	"time":                  {"time", validateTime},
+	"date-time":             {"date-time", validateDateTime},
+	"uri":                   {"uri", validateURI},
+	"iri":                   {"iri", validateURI},
+	"uri-reference":         {"uri-reference", validateURIReference},
+	"iri-reference":         {"iri-reference", validateURIReference},
+	"uri-template":          {"uri-template", validateURITemplate},
+	"semver":                {"semver", validateSemver},
+}
+
+// see https://www.rfc-editor.org/rfc/rfc6901#section-3
+func validateJSONPointer(v any) error {
+	s, ok := v.(string)
+	if !ok {
+		return nil
+	}
+	if s == "" {
+		return nil
+	}
+	if !strings.HasPrefix(s, "/") {
+		return LocalizableError("not starting with /")
+	}
+	for _, tok := range strings.Split(s, "/")[1:] {
+		escape := false
+		for _, ch := range tok {
+			if escape {
+				escape = false
+				if ch != '0' && ch != '1' {
+					return LocalizableError("~ must be followed by 0 or 1")
+				}
+				continue
+			}
+			if ch == '~' {
+				escape = true
+				continue
+			}
+			switch {
+			case ch >= '\x00' && ch <= '\x2E':
+			case ch >= '\x30' && ch <= '\x7D':
+			case ch >= '\x7F' && ch <= '\U0010FFFF':
+			default:
+				return LocalizableError("invalid character %q", ch)
+			}
+		}
+		if escape {
+			return LocalizableError("~ must be followed by 0 or 1")
+		}
+	}
+	return nil
+}
+
+// see https://tools.ietf.org/html/draft-handrews-relative-json-pointer-01#section-3
+func validateRelativeJSONPointer(v any) error {
+	s, ok := v.(string)
+	if !ok {
+		return nil
+	}
+
+	// start with non-negative-integer
+	numDigits := 0
+	for _, ch := range s {
+		if ch >= '0' && ch <= '9' {
+			numDigits++
+		} else {
+			break
+		}
+	}
+	if numDigits == 0 {
+		return LocalizableError("must start with non-negative integer")
+	}
+	if numDigits > 1 && strings.HasPrefix(s, "0") {
+		return LocalizableError("starts with zero")
+	}
+	s = s[numDigits:]
+
+	// followed by either json-pointer or '#'
+	if s == "#" {
+		return nil
+	}
+	return validateJSONPointer(s)
+}
+
+// see https://datatracker.ietf.org/doc/html/rfc4122#page-4
+func validateUUID(v any) error {
+	s, ok := v.(string)
+	if !ok {
+		return nil
+	}
+
+	hexGroups := []int{8, 4, 4, 4, 12}
+	groups := strings.Split(s, "-")
+	if len(groups) != len(hexGroups) {
+		return LocalizableError("must have %d elements", len(hexGroups))
+	}
+	for i, group := range groups {
+		if len(group) != hexGroups[i] {
+			return LocalizableError("element %d must be %d characters long", i+1, hexGroups[i])
+		}
+		for _, ch := range group {
+			switch {
+			case ch >= '0' && ch <= '9':
+			case ch >= 'a' && ch <= 'f':
+			case ch >= 'A' && ch <= 'F':
+			default:
+				return LocalizableError("non-hex character %q", ch)
+			}
+		}
+	}
+	return nil
+}
+
+// see https://datatracker.ietf.org/doc/html/rfc3339#appendix-A
+func validateDuration(v any) error {
+	s, ok := v.(string)
+	if !ok {
+		return nil
+	}
+
+	// must start with 'P'
+	s, ok = strings.CutPrefix(s, "P")
+	if !ok {
+		return LocalizableError("must start with P")
+	}
+	if s == "" {
+		return LocalizableError("nothing after P")
+	}
+
+	// dur-week
+	if s, ok := strings.CutSuffix(s, "W"); ok {
+		if s == "" {
+			return LocalizableError("no number in week")
+		}
+		for _, ch := range s {
+			if ch < '0' || ch > '9' {
+				return LocalizableError("invalid week")
+			}
+		}
+		return nil
+	}
+
+	allUnits := []string{"YMD", "HMS"}
+	for i, s := range strings.Split(s, "T") {
+		if i != 0 && s == "" {
+			return LocalizableError("no time elements")
+		}
+		if i >= len(allUnits) {
+			return LocalizableError("more than one T")
+		}
+		units := allUnits[i]
+		for s != "" {
+			digitCount := 0
+			for _, ch := range s {
+				if ch >= '0' && ch <= '9' {
+					digitCount++
+				} else {
+					break
+				}
+			}
+			if digitCount == 0 {
+				return LocalizableError("missing number")
+			}
+			s = s[digitCount:]
+			if s == "" {
+				return LocalizableError("missing unit")
+			}
+			unit := s[0]
+			j := strings.IndexByte(units, unit)
+			if j == -1 {
+				if strings.IndexByte(allUnits[i], unit) != -1 {
+					return LocalizableError("unit %q out of order", unit)
+				}
+				return LocalizableError("invalid unit %q", unit)
+			}
+			units = units[j+1:]
+			s = s[1:]
+		}
+	}
+
+	return nil
+}
+
+func validateIPV4(v any) error {
+	s, ok := v.(string)
+	if !ok {
+		return nil
+	}
+	groups := strings.Split(s, ".")
+	if len(groups) != 4 {
+		return LocalizableError("expected four decimals")
+	}
+	for _, group := range groups {
+		if len(group) > 1 && group[0] == '0' {
+			return LocalizableError("leading zeros")
+		}
+		n, err := strconv.Atoi(group)
+		if err != nil {
+			return err
+		}
+		if n < 0 || n > 255 {
+			return LocalizableError("decimal must be between 0 and 255")
+		}
+	}
+	return nil
+}
+
+func validateIPV6(v any) error {
+	s, ok := v.(string)
+	if !ok {
+		return nil
+	}
+	if !strings.Contains(s, ":") {
+		return LocalizableError("missing colon")
+	}
+	addr, err := netip.ParseAddr(s)
+	if err != nil {
+		return err
+	}
+	if addr.Zone() != "" {
+		return LocalizableError("zone id is not a part of ipv6 address")
+	}
+	return nil
+}
+
+// see https://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_host_names
+func validateHostname(v any) error {
+	s, ok := v.(string)
+	if !ok {
+		return nil
+	}
+
+	// entire hostname (including the delimiting dots but not a trailing dot) has a maximum of 253 ASCII characters
+	s = strings.TrimSuffix(s, ".")
+	if len(s) > 253 {
+		return LocalizableError("more than 253 characters long")
+	}
+
+	// Hostnames are composed of series of labels concatenated with dots, as are all domain names
+	for _, label := range strings.Split(s, ".") {
+		// Each label must be from 1 to 63 characters long
+		if len(label) < 1 || len(label) > 63 {
+			return LocalizableError("label must be 1 to 63 characters long")
+		}
+
+		// labels must not start or end with a hyphen
+		if strings.HasPrefix(label, "-") {
+			return LocalizableError("label starts with hyphen")
+		}
+		if strings.HasSuffix(label, "-") {
+			return LocalizableError("label ends with hyphen")
+		}
+
+		// labels may contain only the ASCII letters 'a' through 'z' (in a case-insensitive manner),
+		// the digits '0' through '9', and the hyphen ('-')
+		for _, ch := range label {
+			switch {
+			case ch >= 'a' && ch <= 'z':
+			case ch >= 'A' && ch <= 'Z':
+			case ch >= '0' && ch <= '9':
+			case ch == '-':
+			default:
+				return LocalizableError("invalid character %q", ch)
+			}
+		}
+	}
+	return nil
+}
+
+// see https://en.wikipedia.org/wiki/Email_address
+func validateEmail(v any) error {
+	s, ok := v.(string)
+	if !ok {
+		return nil
+	}
+	// entire email address to be no more than 254 characters long
+	if len(s) > 254 {
+		return LocalizableError("more than 255 characters long")
+	}
+
+	// email address is generally recognized as having two parts joined with an at-sign
+	at := strings.LastIndexByte(s, '@')
+	if at == -1 {
+		return LocalizableError("missing @")
+	}
+	local, domain := s[:at], s[at+1:]
+
+	// local part may be up to 64 characters long
+	if len(local) > 64 {
+		return LocalizableError("local part more than 64 characters long")
+	}
+
+	if len(local) > 1 && strings.HasPrefix(local, `"`) && strings.HasPrefix(local, `"`) {
+		// quoted
+		local := local[1 : len(local)-1]
+		if strings.IndexByte(local, '\\') != -1 || strings.IndexByte(local, '"') != -1 {
+			return LocalizableError("backslash and quote are not allowed within quoted local part")
+		}
+	} else {
+		// unquoted
+		if strings.HasPrefix(local, ".") {
+			return LocalizableError("starts with dot")
+		}
+		if strings.HasSuffix(local, ".") {
+			return LocalizableError("ends with dot")
+		}
+
+		// consecutive dots not allowed
+		if strings.Contains(local, "..") {
+			return LocalizableError("consecutive dots")
+		}
+
+		// check allowed chars
+		for _, ch := range local {
+			switch {
+			case ch >= 'a' && ch <= 'z':
+			case ch >= 'A' && ch <= 'Z':
+			case ch >= '0' && ch <= '9':
+			case strings.ContainsRune(".!#$%&'*+-/=?^_`{|}~", ch):
+			default:
+				return LocalizableError("invalid character %q", ch)
+			}
+		}
+	}
+
+	// domain if enclosed in brackets, must match an IP address
+	if strings.HasPrefix(domain, "[") && strings.HasSuffix(domain, "]") {
+		domain = domain[1 : len(domain)-1]
+		if rem, ok := strings.CutPrefix(domain, "IPv6:"); ok {
+			if err := validateIPV6(rem); err != nil {
+				return LocalizableError("invalid ipv6 address: %v", err)
+			}
+			return nil
+		}
+		if err := validateIPV4(domain); err != nil {
+			return LocalizableError("invalid ipv4 address: %v", err)
+		}
+		return nil
+	}
+
+	// domain must match the requirements for a hostname
+	if err := validateHostname(domain); err != nil {
+		return LocalizableError("invalid domain: %v", err)
+	}
+
+	return nil
+}
+
+// see see https://datatracker.ietf.org/doc/html/rfc3339#section-5.6
+func validateDate(v any) error {
+	s, ok := v.(string)
+	if !ok {
+		return nil
+	}
+	_, err := time.Parse("2006-01-02", s)
+	return err
+}
+
+// see https://datatracker.ietf.org/doc/html/rfc3339#section-5.6
+// NOTE: golang time package does not support leap seconds.
+func validateTime(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return nil
+	}
+
+	// min: hh:mm:ssZ
+	if len(str) < 9 {
+		return LocalizableError("less than 9 characters long")
+	}
+	if str[2] != ':' || str[5] != ':' {
+		return LocalizableError("missing colon in correct place")
+	}
+
+	// parse hh:mm:ss
+	var hms []int
+	for _, tok := range strings.SplitN(str[:8], ":", 3) {
+		i, err := strconv.Atoi(tok)
+		if err != nil {
+			return LocalizableError("invalid hour/min/sec")
+		}
+		if i < 0 {
+			return LocalizableError("non-positive hour/min/sec")
+		}
+		hms = append(hms, i)
+	}
+	if len(hms) != 3 {
+		return LocalizableError("missing hour/min/sec")
+	}
+	h, m, s := hms[0], hms[1], hms[2]
+	if h > 23 || m > 59 || s > 60 {
+		return LocalizableError("hour/min/sec out of range")
+	}
+	str = str[8:]
+
+	// parse sec-frac if present
+	if rem, ok := strings.CutPrefix(str, "."); ok {
+		numDigits := 0
+		for _, ch := range rem {
+			if ch >= '0' && ch <= '9' {
+				numDigits++
+			} else {
+				break
+			}
+		}
+		if numDigits == 0 {
+			return LocalizableError("no digits in second fraction")
+		}
+		str = rem[numDigits:]
+	}
+
+	if str != "z" && str != "Z" {
+		// parse time-numoffset
+		if len(str) != 6 {
+			return LocalizableError("offset must be 6 characters long")
+		}
+		var sign int
+		switch str[0] {
+		case '+':
+			sign = -1
+		case '-':
+			sign = +1
+		default:
+			return LocalizableError("offset must begin with plus/minus")
+		}
+		str = str[1:]
+		if str[2] != ':' {
+			return LocalizableError("missing colon in offset in correct place")
+		}
+
+		var zhm []int
+		for _, tok := range strings.SplitN(str, ":", 2) {
+			i, err := strconv.Atoi(tok)
+			if err != nil {
+				return LocalizableError("invalid hour/min in offset")
+			}
+			if i < 0 {
+				return LocalizableError("non-positive hour/min in offset")
+			}
+			zhm = append(zhm, i)
+		}
+		zh, zm := zhm[0], zhm[1]
+		if zh > 23 || zm > 59 {
+			return LocalizableError("hour/min in offset out of range")
+		}
+
+		// apply timezone
+		hm := (h*60 + m) + sign*(zh*60+zm)
+		if hm < 0 {
+			hm += 24 * 60
+		}
+		h, m = hm/60, hm%60
+	}
+
+	// check leap second
+	if s >= 60 && (h != 23 || m != 59) {
+		return LocalizableError("invalid leap second")
+	}
+
+	return nil
+}
+
+// see https://datatracker.ietf.org/doc/html/rfc3339#section-5.6
+func validateDateTime(v any) error {
+	s, ok := v.(string)
+	if !ok {
+		return nil
+	}
+
+	// min: yyyy-mm-ddThh:mm:ssZ
+	if len(s) < 20 {
+		return LocalizableError("less than 20 characters long")
+	}
+
+	if s[10] != 't' && s[10] != 'T' {
+		return LocalizableError("11th character must be t or T")
+	}
+	if err := validateDate(s[:10]); err != nil {
+		return LocalizableError("invalid date element: %v", err)
+	}
+	if err := validateTime(s[11:]); err != nil {
+		return LocalizableError("invalid time element: %v", err)
+	}
+	return nil
+}
+
+func parseURL(s string) (*gourl.URL, error) {
+	u, err := gourl.Parse(s)
+	if err != nil {
+		return nil, err
+	}
+
+	// gourl does not validate ipv6 host address
+	hostName := u.Hostname()
+	if strings.Contains(hostName, ":") {
+		if !strings.Contains(u.Host, "[") || !strings.Contains(u.Host, "]") {
+			return nil, LocalizableError("ipv6 address not enclosed in brackets")
+		}
+		if err := validateIPV6(hostName); err != nil {
+			return nil, LocalizableError("invalid ipv6 address: %v", err)
+		}
+	}
+
+	return u, nil
+}
+
+func validateURI(v any) error {
+	s, ok := v.(string)
+	if !ok {
+		return nil
+	}
+	u, err := parseURL(s)
+	if err != nil {
+		return err
+	}
+	if !u.IsAbs() {
+		return LocalizableError("relative url")
+	}
+	return nil
+}
+
+func validateURIReference(v any) error {
+	s, ok := v.(string)
+	if !ok {
+		return nil
+	}
+	if strings.Contains(s, `\`) {
+		return LocalizableError(`contains \`)
+	}
+	_, err := parseURL(s)
+	return err
+}
+
+func validateURITemplate(v any) error {
+	s, ok := v.(string)
+	if !ok {
+		return nil
+	}
+	u, err := parseURL(s)
+	if err != nil {
+		return err
+	}
+	for _, tok := range strings.Split(u.RawPath, "/") {
+		tok, err = decode(tok)
+		if err != nil {
+			return LocalizableError("percent decode failed: %v", err)
+		}
+		want := true
+		for _, ch := range tok {
+			var got bool
+			switch ch {
+			case '{':
+				got = true
+			case '}':
+				got = false
+			default:
+				continue
+			}
+			if got != want {
+				return LocalizableError("nested curly braces")
+			}
+			want = !want
+		}
+		if !want {
+			return LocalizableError("no matching closing brace")
+		}
+	}
+	return nil
+}
+
+func validatePeriod(v any) error {
+	s, ok := v.(string)
+	if !ok {
+		return nil
+	}
+
+	slash := strings.IndexByte(s, '/')
+	if slash == -1 {
+		return LocalizableError("missing slash")
+	}
+
+	start, end := s[:slash], s[slash+1:]
+	if strings.HasPrefix(start, "P") {
+		if err := validateDuration(start); err != nil {
+			return LocalizableError("invalid start duration: %v", err)
+		}
+		if err := validateDateTime(end); err != nil {
+			return LocalizableError("invalid end date-time: %v", err)
+		}
+	} else {
+		if err := validateDateTime(start); err != nil {
+			return LocalizableError("invalid start date-time: %v", err)
+		}
+		if strings.HasPrefix(end, "P") {
+			if err := validateDuration(end); err != nil {
+				return LocalizableError("invalid end duration: %v", err)
+			}
+		} else if err := validateDateTime(end); err != nil {
+			return LocalizableError("invalid end date-time: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// see https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions
+func validateSemver(v any) error {
+	s, ok := v.(string)
+	if !ok {
+		return nil
+	}
+
+	// build --
+	if i := strings.IndexByte(s, '+'); i != -1 {
+		build := s[i+1:]
+		if build == "" {
+			return LocalizableError("build is empty")
+		}
+		for _, buildID := range strings.Split(build, ".") {
+			if buildID == "" {
+				return LocalizableError("build identifier is empty")
+			}
+			for _, ch := range buildID {
+				switch {
+				case ch >= '0' && ch <= '9':
+				case (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '-':
+				default:
+					return LocalizableError("invalid character %q in build identifier", ch)
+				}
+			}
+		}
+		s = s[:i]
+	}
+
+	// pre-release --
+	if i := strings.IndexByte(s, '-'); i != -1 {
+		preRelease := s[i+1:]
+		for _, preReleaseID := range strings.Split(preRelease, ".") {
+			if preReleaseID == "" {
+				return LocalizableError("pre-release identifier is empty")
+			}
+			allDigits := true
+			for _, ch := range preReleaseID {
+				switch {
+				case ch >= '0' && ch <= '9':
+				case (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '-':
+					allDigits = false
+				default:
+					return LocalizableError("invalid character %q in pre-release identifier", ch)
+				}
+			}
+			if allDigits && len(preReleaseID) > 1 && preReleaseID[0] == '0' {
+				return LocalizableError("pre-release numeric identifier starts with zero")
+			}
+		}
+		s = s[:i]
+	}
+
+	// versionCore --
+	versions := strings.Split(s, ".")
+	if len(versions) != 3 {
+		return LocalizableError("versionCore must have 3 numbers separated by dot")
+	}
+	names := []string{"major", "minor", "patch"}
+	for i, version := range versions {
+		if version == "" {
+			return LocalizableError("%s is empty", names[i])
+		}
+		if len(version) > 1 && version[0] == '0' {
+			return LocalizableError("%s starts with zero", names[i])
+		}
+		for _, ch := range version {
+			if ch < '0' || ch > '9' {
+				return LocalizableError("%s contains non-digit", names[i])
+			}
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/go.work.sum
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/go.work.sum
@@ -1,0 +1,4 @@
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.1/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
+golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/kind/kind.go
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/kind/kind.go
@@ -1,0 +1,651 @@
+package kind
+
+import (
+	"fmt"
+	"math/big"
+	"strings"
+
+	"golang.org/x/text/message"
+)
+
+// --
+
+type InvalidJsonValue struct {
+	Value any
+}
+
+func (*InvalidJsonValue) KeywordPath() []string {
+	return nil
+}
+
+func (k *InvalidJsonValue) LocalizedString(p *message.Printer) string {
+	return p.Sprintf("invalid jsonType %T", k.Value)
+}
+
+// --
+
+type Schema struct {
+	Location string
+}
+
+func (*Schema) KeywordPath() []string {
+	return nil
+}
+
+func (k *Schema) LocalizedString(p *message.Printer) string {
+	return p.Sprintf("jsonschema validation failed with %s", quote(k.Location))
+}
+
+// --
+
+type Group struct{}
+
+func (*Group) KeywordPath() []string {
+	return nil
+}
+
+func (*Group) LocalizedString(p *message.Printer) string {
+	return p.Sprintf("validation failed")
+}
+
+// --
+
+type Not struct{}
+
+func (*Not) KeywordPath() []string {
+	return nil
+}
+
+func (*Not) LocalizedString(p *message.Printer) string {
+	return p.Sprintf("'not' failed")
+}
+
+// --
+
+type AllOf struct{}
+
+func (*AllOf) KeywordPath() []string {
+	return []string{"allOf"}
+}
+
+func (*AllOf) LocalizedString(p *message.Printer) string {
+	return p.Sprintf("'allOf' failed")
+}
+
+// --
+
+type AnyOf struct{}
+
+func (*AnyOf) KeywordPath() []string {
+	return []string{"anyOf"}
+}
+
+func (*AnyOf) LocalizedString(p *message.Printer) string {
+	return p.Sprintf("'anyOf' failed")
+}
+
+// --
+
+type OneOf struct {
+	// Subschemas gives indexes of Subschemas that have matched.
+	// Value nil, means none of the subschemas matched.
+	Subschemas []int
+}
+
+func (*OneOf) KeywordPath() []string {
+	return []string{"oneOf"}
+}
+
+func (k *OneOf) LocalizedString(p *message.Printer) string {
+	if len(k.Subschemas) == 0 {
+		return p.Sprintf("'oneOf' failed, none matched")
+	}
+	return p.Sprintf("'oneOf' failed, subschemas %d, %d matched", k.Subschemas[0], k.Subschemas[1])
+}
+
+//--
+
+type FalseSchema struct{}
+
+func (*FalseSchema) KeywordPath() []string {
+	return nil
+}
+
+func (*FalseSchema) LocalizedString(p *message.Printer) string {
+	return p.Sprintf("false schema")
+}
+
+// --
+
+type RefCycle struct {
+	URL              string
+	KeywordLocation1 string
+	KeywordLocation2 string
+}
+
+func (*RefCycle) KeywordPath() []string {
+	return nil
+}
+
+func (k *RefCycle) LocalizedString(p *message.Printer) string {
+	return p.Sprintf("both %s and %s resolve to %q causing reference cycle", k.KeywordLocation1, k.KeywordLocation2, k.URL)
+}
+
+// --
+
+type Type struct {
+	Got  string
+	Want []string
+}
+
+func (*Type) KeywordPath() []string {
+	return []string{"type"}
+}
+
+func (k *Type) LocalizedString(p *message.Printer) string {
+	want := strings.Join(k.Want, " or ")
+	return p.Sprintf("got %s, want %s", k.Got, want)
+}
+
+// --
+
+type Enum struct {
+	Got  any
+	Want []any
+}
+
+// KeywordPath implements jsonschema.ErrorKind.
+func (*Enum) KeywordPath() []string {
+	return []string{"enum"}
+}
+
+func (k *Enum) LocalizedString(p *message.Printer) string {
+	allPrimitive := true
+loop:
+	for _, item := range k.Want {
+		switch item.(type) {
+		case []any, map[string]any:
+			allPrimitive = false
+			break loop
+		}
+	}
+	if allPrimitive {
+		if len(k.Want) == 1 {
+			return p.Sprintf("value must be %s", display(k.Want[0]))
+		}
+		var want []string
+		for _, v := range k.Want {
+			want = append(want, display(v))
+		}
+		return p.Sprintf("value must be one of %s", strings.Join(want, ", "))
+	}
+	return p.Sprintf("'enum' failed")
+}
+
+// --
+
+type Const struct {
+	Got  any
+	Want any
+}
+
+func (*Const) KeywordPath() []string {
+	return []string{"const"}
+}
+
+func (k *Const) LocalizedString(p *message.Printer) string {
+	switch want := k.Want.(type) {
+	case []any, map[string]any:
+		return p.Sprintf("'const' failed")
+	default:
+		return p.Sprintf("value must be %s", display(want))
+	}
+}
+
+// --
+
+type Format struct {
+	Got  any
+	Want string
+	Err  error
+}
+
+func (*Format) KeywordPath() []string {
+	return []string{"format"}
+}
+
+func (k *Format) LocalizedString(p *message.Printer) string {
+	return p.Sprintf("%s is not valid %s: %v", display(k.Got), k.Want, localizedError(k.Err, p))
+}
+
+// --
+
+type Reference struct {
+	Keyword string
+	URL     string
+}
+
+func (k *Reference) KeywordPath() []string {
+	return []string{k.Keyword}
+}
+
+func (*Reference) LocalizedString(p *message.Printer) string {
+	return p.Sprintf("validation failed")
+}
+
+// --
+
+type MinProperties struct {
+	Got, Want int
+}
+
+func (*MinProperties) KeywordPath() []string {
+	return []string{"minProperties"}
+}
+
+func (k *MinProperties) LocalizedString(p *message.Printer) string {
+	return p.Sprintf("minProperties: got %d, want %d", k.Got, k.Want)
+}
+
+// --
+
+type MaxProperties struct {
+	Got, Want int
+}
+
+func (*MaxProperties) KeywordPath() []string {
+	return []string{"maxProperties"}
+}
+
+func (k *MaxProperties) LocalizedString(p *message.Printer) string {
+	return p.Sprintf("maxProperties: got %d, want %d", k.Got, k.Want)
+}
+
+// --
+
+type MinItems struct {
+	Got, Want int
+}
+
+func (*MinItems) KeywordPath() []string {
+	return []string{"minItems"}
+}
+
+func (k *MinItems) LocalizedString(p *message.Printer) string {
+	return p.Sprintf("minItems: got %d, want %d", k.Got, k.Want)
+}
+
+// --
+
+type MaxItems struct {
+	Got, Want int
+}
+
+func (*MaxItems) KeywordPath() []string {
+	return []string{"maxItems"}
+}
+
+func (k *MaxItems) LocalizedString(p *message.Printer) string {
+	return p.Sprintf("maxItems: got %d, want %d", k.Got, k.Want)
+}
+
+// --
+
+type AdditionalItems struct {
+	Count int
+}
+
+func (*AdditionalItems) KeywordPath() []string {
+	return []string{"additionalItems"}
+}
+
+func (k *AdditionalItems) LocalizedString(p *message.Printer) string {
+	return p.Sprintf("last %d additionalItem(s) not allowed", k.Count)
+}
+
+// --
+
+type Required struct {
+	Missing []string
+}
+
+func (*Required) KeywordPath() []string {
+	return []string{"required"}
+}
+
+func (k *Required) LocalizedString(p *message.Printer) string {
+	if len(k.Missing) == 1 {
+		return p.Sprintf("missing property %s", quote(k.Missing[0]))
+	}
+	return p.Sprintf("missing properties %s", joinQuoted(k.Missing, ", "))
+}
+
+// --
+
+type Dependency struct {
+	Prop    string   // dependency of prop that failed
+	Missing []string // missing props
+}
+
+func (k *Dependency) KeywordPath() []string {
+	return []string{"dependency", k.Prop}
+}
+
+func (k *Dependency) LocalizedString(p *message.Printer) string {
+	return p.Sprintf("properties %s required, if %s exists", joinQuoted(k.Missing, ", "), quote(k.Prop))
+}
+
+// --
+
+type DependentRequired struct {
+	Prop    string   // dependency of prop that failed
+	Missing []string // missing props
+}
+
+func (k *DependentRequired) KeywordPath() []string {
+	return []string{"dependentRequired", k.Prop}
+}
+
+func (k *DependentRequired) LocalizedString(p *message.Printer) string {
+	return p.Sprintf("properties %s required, if %s exists", joinQuoted(k.Missing, ", "), quote(k.Prop))
+}
+
+// --
+
+type AdditionalProperties struct {
+	Properties []string
+}
+
+func (*AdditionalProperties) KeywordPath() []string {
+	return []string{"additionalProperties"}
+}
+
+func (k *AdditionalProperties) LocalizedString(p *message.Printer) string {
+	return p.Sprintf("additional properties %s not allowed", joinQuoted(k.Properties, ", "))
+}
+
+// --
+
+type PropertyNames struct {
+	Property string
+}
+
+func (*PropertyNames) KeywordPath() []string {
+	return []string{"propertyNames"}
+}
+
+func (k *PropertyNames) LocalizedString(p *message.Printer) string {
+	return p.Sprintf("invalid propertyName %s", quote(k.Property))
+}
+
+// --
+
+type UniqueItems struct {
+	Duplicates [2]int
+}
+
+func (*UniqueItems) KeywordPath() []string {
+	return []string{"uniqueItems"}
+}
+
+func (k *UniqueItems) LocalizedString(p *message.Printer) string {
+	return p.Sprintf("items at %d and %d are equal", k.Duplicates[0], k.Duplicates[1])
+}
+
+// --
+
+type Contains struct{}
+
+func (*Contains) KeywordPath() []string {
+	return []string{"contains"}
+}
+
+func (*Contains) LocalizedString(p *message.Printer) string {
+	return p.Sprintf("no items match contains schema")
+}
+
+// --
+
+type MinContains struct {
+	Got  []int
+	Want int
+}
+
+func (*MinContains) KeywordPath() []string {
+	return []string{"minContains"}
+}
+
+func (k *MinContains) LocalizedString(p *message.Printer) string {
+	if len(k.Got) == 0 {
+		return p.Sprintf("min %d items required to match contains schema, but none matched", k.Want)
+	} else {
+		got := fmt.Sprintf("%v", k.Got)
+		return p.Sprintf("min %d items required to match contains schema, but matched %d items at %v", k.Want, len(k.Got), got[1:len(got)-1])
+	}
+}
+
+// --
+
+type MaxContains struct {
+	Got  []int
+	Want int
+}
+
+func (*MaxContains) KeywordPath() []string {
+	return []string{"maxContains"}
+}
+
+func (k *MaxContains) LocalizedString(p *message.Printer) string {
+	got := fmt.Sprintf("%v", k.Got)
+	return p.Sprintf("max %d items required to match contains schema, but matched %d items at %v", k.Want, len(k.Got), got[1:len(got)-1])
+}
+
+// --
+
+type MinLength struct {
+	Got, Want int
+}
+
+func (*MinLength) KeywordPath() []string {
+	return []string{"minLength"}
+}
+
+func (k *MinLength) LocalizedString(p *message.Printer) string {
+	return p.Sprintf("minLength: got %d, want %d", k.Got, k.Want)
+}
+
+// --
+
+type MaxLength struct {
+	Got, Want int
+}
+
+func (*MaxLength) KeywordPath() []string {
+	return []string{"maxLength"}
+}
+
+func (k *MaxLength) LocalizedString(p *message.Printer) string {
+	return p.Sprintf("maxLength: got %d, want %d", k.Got, k.Want)
+}
+
+// --
+
+type Pattern struct {
+	Got  string
+	Want string
+}
+
+func (*Pattern) KeywordPath() []string {
+	return []string{"pattern"}
+}
+
+func (k *Pattern) LocalizedString(p *message.Printer) string {
+	return p.Sprintf("%s does not match pattern %s", quote(k.Got), quote(k.Want))
+}
+
+// --
+
+type ContentEncoding struct {
+	Want string
+	Err  error
+}
+
+func (*ContentEncoding) KeywordPath() []string {
+	return []string{"contentEncoding"}
+}
+
+func (k *ContentEncoding) LocalizedString(p *message.Printer) string {
+	return p.Sprintf("value is not %s encoded: %v", quote(k.Want), localizedError(k.Err, p))
+}
+
+// --
+
+type ContentMediaType struct {
+	Got  []byte
+	Want string
+	Err  error
+}
+
+func (*ContentMediaType) KeywordPath() []string {
+	return []string{"contentMediaType"}
+}
+
+func (k *ContentMediaType) LocalizedString(p *message.Printer) string {
+	return p.Sprintf("value if not of mediatype %s: %v", quote(k.Want), k.Err)
+}
+
+// --
+
+type ContentSchema struct{}
+
+func (*ContentSchema) KeywordPath() []string {
+	return []string{"contentSchema"}
+}
+
+func (*ContentSchema) LocalizedString(p *message.Printer) string {
+	return p.Sprintf("'contentSchema' failed")
+}
+
+// --
+
+type Minimum struct {
+	Got  *big.Rat
+	Want *big.Rat
+}
+
+func (*Minimum) KeywordPath() []string {
+	return []string{"minimum"}
+}
+
+func (k *Minimum) LocalizedString(p *message.Printer) string {
+	got, _ := k.Got.Float64()
+	want, _ := k.Want.Float64()
+	return p.Sprintf("minimum: got %v, want %v", got, want)
+}
+
+// --
+
+type Maximum struct {
+	Got  *big.Rat
+	Want *big.Rat
+}
+
+func (*Maximum) KeywordPath() []string {
+	return []string{"maximum"}
+}
+
+func (k *Maximum) LocalizedString(p *message.Printer) string {
+	got, _ := k.Got.Float64()
+	want, _ := k.Want.Float64()
+	return p.Sprintf("maximum: got %v, want %v", got, want)
+}
+
+// --
+
+type ExclusiveMinimum struct {
+	Got  *big.Rat
+	Want *big.Rat
+}
+
+func (*ExclusiveMinimum) KeywordPath() []string {
+	return []string{"exclusiveMinimum"}
+}
+
+func (k *ExclusiveMinimum) LocalizedString(p *message.Printer) string {
+	got, _ := k.Got.Float64()
+	want, _ := k.Want.Float64()
+	return p.Sprintf("exclusiveMinimum: got %v, want %v", got, want)
+}
+
+// --
+
+type ExclusiveMaximum struct {
+	Got  *big.Rat
+	Want *big.Rat
+}
+
+func (*ExclusiveMaximum) KeywordPath() []string {
+	return []string{"exclusiveMaximum"}
+}
+
+func (k *ExclusiveMaximum) LocalizedString(p *message.Printer) string {
+	got, _ := k.Got.Float64()
+	want, _ := k.Want.Float64()
+	return p.Sprintf("exclusiveMaximum: got %v, want %v", got, want)
+}
+
+// --
+
+type MultipleOf struct {
+	Got  *big.Rat
+	Want *big.Rat
+}
+
+func (*MultipleOf) KeywordPath() []string {
+	return []string{"multipleOf"}
+}
+
+func (k *MultipleOf) LocalizedString(p *message.Printer) string {
+	got, _ := k.Got.Float64()
+	want, _ := k.Want.Float64()
+	return p.Sprintf("multipleOf: got %v, want %v", got, want)
+}
+
+// --
+
+func quote(s string) string {
+	s = fmt.Sprintf("%q", s)
+	s = strings.ReplaceAll(s, `\"`, `"`)
+	s = strings.ReplaceAll(s, `'`, `\'`)
+	return "'" + s[1:len(s)-1] + "'"
+}
+
+func joinQuoted(arr []string, sep string) string {
+	var sb strings.Builder
+	for _, s := range arr {
+		if sb.Len() > 0 {
+			sb.WriteString(sep)
+		}
+		sb.WriteString(quote(s))
+	}
+	return sb.String()
+}
+
+// to be used only for primitive.
+func display(v any) string {
+	switch v := v.(type) {
+	case string:
+		return quote(v)
+	case []any, map[string]any:
+		return "value"
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+func localizedError(err error, p *message.Printer) string {
+	if err, ok := err.(interface{ LocalizedError(*message.Printer) string }); ok {
+		return err.LocalizedError(p)
+	}
+	return err.Error()
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/loader.go
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/loader.go
@@ -1,0 +1,266 @@
+package jsonschema
+
+import (
+	"embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	gourl "net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// URLLoader knows how to load json from given url.
+type URLLoader interface {
+	// Load loads json from given absolute url.
+	Load(url string) (any, error)
+}
+
+// --
+
+// FileLoader loads json file url.
+type FileLoader struct{}
+
+func (l FileLoader) Load(url string) (any, error) {
+	path, err := l.ToFile(url)
+	if err != nil {
+		return nil, err
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return UnmarshalJSON(f)
+}
+
+// ToFile is helper method to convert file url to file path.
+func (l FileLoader) ToFile(url string) (string, error) {
+	u, err := gourl.Parse(url)
+	if err != nil {
+		return "", err
+	}
+	if u.Scheme != "file" {
+		return "", fmt.Errorf("invalid file url: %s", u)
+	}
+	path := u.Path
+	if runtime.GOOS == "windows" {
+		path = strings.TrimPrefix(path, "/")
+		path = filepath.FromSlash(path)
+	}
+	return path, nil
+}
+
+// --
+
+// SchemeURLLoader delegates to other [URLLoaders]
+// based on url scheme.
+type SchemeURLLoader map[string]URLLoader
+
+func (l SchemeURLLoader) Load(url string) (any, error) {
+	u, err := gourl.Parse(url)
+	if err != nil {
+		return nil, err
+	}
+	ll, ok := l[u.Scheme]
+	if !ok {
+		return nil, &UnsupportedURLSchemeError{u.String()}
+	}
+	return ll.Load(url)
+}
+
+// --
+
+//go:embed metaschemas
+var metaFS embed.FS
+
+func openMeta(url string) (fs.File, error) {
+	u, meta := strings.CutPrefix(url, "http://json-schema.org/")
+	if !meta {
+		u, meta = strings.CutPrefix(url, "https://json-schema.org/")
+	}
+	if meta {
+		if u == "schema" {
+			return openMeta(draftLatest.url)
+		}
+		f, err := metaFS.Open("metaschemas/" + u)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil, nil
+			}
+			return nil, err
+		}
+		return f, err
+	}
+	return nil, nil
+
+}
+
+func isMeta(url string) bool {
+	f, err := openMeta(url)
+	if err != nil {
+		return true
+	}
+	if f != nil {
+		f.Close()
+		return true
+	}
+	return false
+}
+
+func loadMeta(url string) (any, error) {
+	f, err := openMeta(url)
+	if err != nil {
+		return nil, err
+	}
+	if f == nil {
+		return nil, nil
+	}
+	defer f.Close()
+	return UnmarshalJSON(f)
+}
+
+// --
+
+type defaultLoader struct {
+	docs   map[url]any // docs loaded so far
+	loader URLLoader
+}
+
+func (l *defaultLoader) add(url url, doc any) bool {
+	if _, ok := l.docs[url]; ok {
+		return false
+	}
+	l.docs[url] = doc
+	return true
+}
+
+func (l *defaultLoader) load(url url) (any, error) {
+	if doc, ok := l.docs[url]; ok {
+		return doc, nil
+	}
+	doc, err := loadMeta(url.String())
+	if err != nil {
+		return nil, err
+	}
+	if doc != nil {
+		l.add(url, doc)
+		return doc, nil
+	}
+	if l.loader == nil {
+		return nil, &LoadURLError{url.String(), errors.New("no URLLoader set")}
+	}
+	doc, err = l.loader.Load(url.String())
+	if err != nil {
+		return nil, &LoadURLError{URL: url.String(), Err: err}
+	}
+	l.add(url, doc)
+	return doc, nil
+}
+
+func (l *defaultLoader) getDraft(up urlPtr, doc any, defaultDraft *Draft, cycle map[url]struct{}) (*Draft, error) {
+	obj, ok := doc.(map[string]any)
+	if !ok {
+		return defaultDraft, nil
+	}
+	sch, ok := strVal(obj, "$schema")
+	if !ok {
+		return defaultDraft, nil
+	}
+	if draft := draftFromURL(sch); draft != nil {
+		return draft, nil
+	}
+	sch, _ = split(sch)
+	if _, err := gourl.Parse(sch); err != nil {
+		return nil, &InvalidMetaSchemaURLError{up.String(), err}
+	}
+	schUrl := url(sch)
+	if up.ptr.isEmpty() && schUrl == up.url {
+		return nil, &UnsupportedDraftError{schUrl.String()}
+	}
+	if _, ok := cycle[schUrl]; ok {
+		return nil, &MetaSchemaCycleError{schUrl.String()}
+	}
+	cycle[schUrl] = struct{}{}
+	doc, err := l.load(schUrl)
+	if err != nil {
+		return nil, err
+	}
+	return l.getDraft(urlPtr{schUrl, ""}, doc, defaultDraft, cycle)
+}
+
+func (l *defaultLoader) getMetaVocabs(doc any, draft *Draft, vocabularies map[string]*Vocabulary) ([]string, error) {
+	obj, ok := doc.(map[string]any)
+	if !ok {
+		return nil, nil
+	}
+	sch, ok := strVal(obj, "$schema")
+	if !ok {
+		return nil, nil
+	}
+	if draft := draftFromURL(sch); draft != nil {
+		return nil, nil
+	}
+	sch, _ = split(sch)
+	if _, err := gourl.Parse(sch); err != nil {
+		return nil, &ParseURLError{sch, err}
+	}
+	schUrl := url(sch)
+	doc, err := l.load(schUrl)
+	if err != nil {
+		return nil, err
+	}
+	return draft.getVocabs(schUrl, doc, vocabularies)
+}
+
+// --
+
+type LoadURLError struct {
+	URL string
+	Err error
+}
+
+func (e *LoadURLError) Error() string {
+	return fmt.Sprintf("failing loading %q: %v", e.URL, e.Err)
+}
+
+// --
+
+type UnsupportedURLSchemeError struct {
+	url string
+}
+
+func (e *UnsupportedURLSchemeError) Error() string {
+	return fmt.Sprintf("no URLLoader registered for %q", e.url)
+}
+
+// --
+
+type ResourceExistsError struct {
+	url string
+}
+
+func (e *ResourceExistsError) Error() string {
+	return fmt.Sprintf("resource for %q already exists", e.url)
+}
+
+// --
+
+// UnmarshalJSON unmarshals into [any] without losing
+// number precision using [json.Number].
+func UnmarshalJSON(r io.Reader) (any, error) {
+	decoder := json.NewDecoder(r)
+	decoder.UseNumber()
+	var doc any
+	if err := decoder.Decode(&doc); err != nil {
+		return nil, err
+	}
+	if _, err := decoder.Token(); err == nil || err != io.EOF {
+		return nil, fmt.Errorf("invalid character after top-level value")
+	}
+	return doc, nil
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft-04/schema
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft-04/schema
@@ -1,0 +1,151 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"description": "Core schema meta-schema",
+	"definitions": {
+		"schemaArray": {
+			"type": "array",
+			"minItems": 1,
+			"items": { "$ref": "#" }
+		},
+		"positiveInteger": {
+			"type": "integer",
+			"minimum": 0
+		},
+		"positiveIntegerDefault0": {
+			"allOf": [ { "$ref": "#/definitions/positiveInteger" }, { "default": 0 } ]
+		},
+		"simpleTypes": {
+			"enum": [ "array", "boolean", "integer", "null", "number", "object", "string" ]
+		},
+		"stringArray": {
+			"type": "array",
+			"items": { "type": "string" },
+			"minItems": 1,
+			"uniqueItems": true
+		}
+	},
+	"type": "object",
+	"properties": {
+		"id": {
+			"type": "string",
+			"format": "uriref"
+		},
+		"$schema": {
+			"type": "string",
+			"format": "uri"
+		},
+		"title": {
+			"type": "string"
+		},
+		"description": {
+			"type": "string"
+		},
+		"default": {},
+		"multipleOf": {
+			"type": "number",
+			"minimum": 0,
+			"exclusiveMinimum": true
+		},
+		"maximum": {
+			"type": "number"
+		},
+		"exclusiveMaximum": {
+			"type": "boolean",
+			"default": false
+		},
+		"minimum": {
+			"type": "number"
+		},
+		"exclusiveMinimum": {
+			"type": "boolean",
+			"default": false
+		},
+		"maxLength": { "$ref": "#/definitions/positiveInteger" },
+		"minLength": { "$ref": "#/definitions/positiveIntegerDefault0" },
+		"pattern": {
+			"type": "string",
+			"format": "regex"
+		},
+		"additionalItems": {
+			"anyOf": [
+				{ "type": "boolean" },
+				{ "$ref": "#" }
+			],
+			"default": {}
+		},
+		"items": {
+			"anyOf": [
+				{ "$ref": "#" },
+				{ "$ref": "#/definitions/schemaArray" }
+			],
+			"default": {}
+		},
+		"maxItems": { "$ref": "#/definitions/positiveInteger" },
+		"minItems": { "$ref": "#/definitions/positiveIntegerDefault0" },
+		"uniqueItems": {
+			"type": "boolean",
+			"default": false
+		},
+		"maxProperties": { "$ref": "#/definitions/positiveInteger" },
+		"minProperties": { "$ref": "#/definitions/positiveIntegerDefault0" },
+		"required": { "$ref": "#/definitions/stringArray" },
+		"additionalProperties": {
+			"anyOf": [
+				{ "type": "boolean" },
+				{ "$ref": "#" }
+			],
+			"default": {}
+		},
+		"definitions": {
+			"type": "object",
+			"additionalProperties": { "$ref": "#" },
+			"default": {}
+		},
+		"properties": {
+			"type": "object",
+			"additionalProperties": { "$ref": "#" },
+			"default": {}
+		},
+		"patternProperties": {
+			"type": "object",
+			"additionalProperties": { "$ref": "#" },
+			"default": {}
+		},
+		"dependencies": {
+			"type": "object",
+			"additionalProperties": {
+				"anyOf": [
+					{ "$ref": "#" },
+					{ "$ref": "#/definitions/stringArray" }
+				]
+			}
+		},
+		"enum": {
+			"type": "array",
+			"minItems": 1,
+			"uniqueItems": true
+		},
+		"type": {
+			"anyOf": [
+				{ "$ref": "#/definitions/simpleTypes" },
+				{
+					"type": "array",
+					"items": { "$ref": "#/definitions/simpleTypes" },
+					"minItems": 1,
+					"uniqueItems": true
+				}
+			]
+		},
+		"allOf": { "$ref": "#/definitions/schemaArray" },
+		"anyOf": { "$ref": "#/definitions/schemaArray" },
+		"oneOf": { "$ref": "#/definitions/schemaArray" },
+		"not": { "$ref": "#" },
+		"format": { "type": "string" },
+		"$ref": { "type": "string" }
+	},
+	"dependencies": {
+		"exclusiveMaximum": [ "maximum" ],
+		"exclusiveMinimum": [ "minimum" ]
+	},
+	"default": {}
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft-06/schema
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft-06/schema
@@ -1,0 +1,150 @@
+{
+	"$schema": "http://json-schema.org/draft-06/schema#",
+	"$id": "http://json-schema.org/draft-06/schema#",
+	"title": "Core schema meta-schema",
+	"definitions": {
+		"schemaArray": {
+			"type": "array",
+			"minItems": 1,
+			"items": { "$ref": "#" }
+		},
+		"nonNegativeInteger": {
+			"type": "integer",
+			"minimum": 0
+		},
+		"nonNegativeIntegerDefault0": {
+			"allOf": [
+				{ "$ref": "#/definitions/nonNegativeInteger" },
+				{ "default": 0 }
+			]
+		},
+		"simpleTypes": {
+			"enum": [
+				"array",
+				"boolean",
+				"integer",
+				"null",
+				"number",
+				"object",
+				"string"
+			]
+		},
+		"stringArray": {
+			"type": "array",
+			"items": { "type": "string" },
+			"uniqueItems": true,
+			"default": []
+		}
+	},
+	"type": ["object", "boolean"],
+	"properties": {
+		"$id": {
+			"type": "string",
+			"format": "uri-reference"
+		},
+		"$schema": {
+			"type": "string",
+			"format": "uri"
+		},
+		"$ref": {
+			"type": "string",
+			"format": "uri-reference"
+		},
+		"title": {
+			"type": "string"
+		},
+		"description": {
+			"type": "string"
+		},
+		"default": {},
+		"multipleOf": {
+			"type": "number",
+			"exclusiveMinimum": 0
+		},
+		"maximum": {
+			"type": "number"
+		},
+		"exclusiveMaximum": {
+			"type": "number"
+		},
+		"minimum": {
+			"type": "number"
+		},
+		"exclusiveMinimum": {
+			"type": "number"
+		},
+		"maxLength": { "$ref": "#/definitions/nonNegativeInteger" },
+		"minLength": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+		"pattern": {
+			"type": "string",
+			"format": "regex"
+		},
+		"additionalItems": { "$ref": "#" },
+		"items": {
+			"anyOf": [
+				{ "$ref": "#" },
+				{ "$ref": "#/definitions/schemaArray" }
+			],
+			"default": {}
+		},
+		"maxItems": { "$ref": "#/definitions/nonNegativeInteger" },
+		"minItems": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+		"uniqueItems": {
+			"type": "boolean",
+			"default": false
+		},
+		"contains": { "$ref": "#" },
+		"maxProperties": { "$ref": "#/definitions/nonNegativeInteger" },
+		"minProperties": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+		"required": { "$ref": "#/definitions/stringArray" },
+		"additionalProperties": { "$ref": "#" },
+		"definitions": {
+			"type": "object",
+			"additionalProperties": { "$ref": "#" },
+			"default": {}
+		},
+		"properties": {
+			"type": "object",
+			"additionalProperties": { "$ref": "#" },
+			"default": {}
+		},
+		"patternProperties": {
+			"type": "object",
+			"additionalProperties": { "$ref": "#" },
+			"default": {}
+		},
+		"dependencies": {
+			"type": "object",
+			"additionalProperties": {
+				"anyOf": [
+					{ "$ref": "#" },
+					{ "$ref": "#/definitions/stringArray" }
+				]
+			}
+		},
+		"propertyNames": { "$ref": "#" },
+		"const": {},
+		"enum": {
+			"type": "array",
+			"minItems": 1,
+			"uniqueItems": true
+		},
+		"type": {
+			"anyOf": [
+				{ "$ref": "#/definitions/simpleTypes" },
+				{
+					"type": "array",
+					"items": { "$ref": "#/definitions/simpleTypes" },
+					"minItems": 1,
+					"uniqueItems": true
+				}
+			]
+		},
+		"format": { "type": "string" },
+		"allOf": { "$ref": "#/definitions/schemaArray" },
+		"anyOf": { "$ref": "#/definitions/schemaArray" },
+		"oneOf": { "$ref": "#/definitions/schemaArray" },
+		"not": { "$ref": "#" }
+	},
+	"default": {}
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft-07/schema
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft-07/schema
@@ -1,0 +1,172 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "http://json-schema.org/draft-07/schema#",
+	"title": "Core schema meta-schema",
+	"definitions": {
+		"schemaArray": {
+			"type": "array",
+			"minItems": 1,
+			"items": { "$ref": "#" }
+		},
+		"nonNegativeInteger": {
+			"type": "integer",
+			"minimum": 0
+		},
+		"nonNegativeIntegerDefault0": {
+			"allOf": [
+				{ "$ref": "#/definitions/nonNegativeInteger" },
+				{ "default": 0 }
+			]
+		},
+		"simpleTypes": {
+			"enum": [
+				"array",
+				"boolean",
+				"integer",
+				"null",
+				"number",
+				"object",
+				"string"
+			]
+		},
+		"stringArray": {
+			"type": "array",
+			"items": { "type": "string" },
+			"uniqueItems": true,
+			"default": []
+		}
+	},
+	"type": ["object", "boolean"],
+	"properties": {
+		"$id": {
+			"type": "string",
+			"format": "uri-reference"
+		},
+		"$schema": {
+			"type": "string",
+			"format": "uri"
+		},
+		"$ref": {
+			"type": "string",
+			"format": "uri-reference"
+		},
+		"$comment": {
+			"type": "string"
+		},
+		"title": {
+			"type": "string"
+		},
+		"description": {
+			"type": "string"
+		},
+		"default": true,
+		"readOnly": {
+			"type": "boolean",
+			"default": false
+		},
+		"writeOnly": {
+			"type": "boolean",
+			"default": false
+		},
+		"examples": {
+			"type": "array",
+			"items": true
+		},
+		"multipleOf": {
+			"type": "number",
+			"exclusiveMinimum": 0
+		},
+		"maximum": {
+			"type": "number"
+		},
+		"exclusiveMaximum": {
+			"type": "number"
+		},
+		"minimum": {
+			"type": "number"
+		},
+		"exclusiveMinimum": {
+			"type": "number"
+		},
+		"maxLength": { "$ref": "#/definitions/nonNegativeInteger" },
+		"minLength": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+		"pattern": {
+			"type": "string",
+			"format": "regex"
+		},
+		"additionalItems": { "$ref": "#" },
+		"items": {
+			"anyOf": [
+				{ "$ref": "#" },
+				{ "$ref": "#/definitions/schemaArray" }
+			],
+			"default": true
+		},
+		"maxItems": { "$ref": "#/definitions/nonNegativeInteger" },
+		"minItems": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+		"uniqueItems": {
+			"type": "boolean",
+			"default": false
+		},
+		"contains": { "$ref": "#" },
+		"maxProperties": { "$ref": "#/definitions/nonNegativeInteger" },
+		"minProperties": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+		"required": { "$ref": "#/definitions/stringArray" },
+		"additionalProperties": { "$ref": "#" },
+		"definitions": {
+			"type": "object",
+			"additionalProperties": { "$ref": "#" },
+			"default": {}
+		},
+		"properties": {
+			"type": "object",
+			"additionalProperties": { "$ref": "#" },
+			"default": {}
+		},
+		"patternProperties": {
+			"type": "object",
+			"additionalProperties": { "$ref": "#" },
+			"propertyNames": { "format": "regex" },
+			"default": {}
+		},
+		"dependencies": {
+			"type": "object",
+			"additionalProperties": {
+				"anyOf": [
+					{ "$ref": "#" },
+					{ "$ref": "#/definitions/stringArray" }
+				]
+			}
+		},
+		"propertyNames": { "$ref": "#" },
+		"const": true,
+		"enum": {
+			"type": "array",
+			"items": true,
+			"minItems": 1,
+			"uniqueItems": true
+		},
+		"type": {
+			"anyOf": [
+				{ "$ref": "#/definitions/simpleTypes" },
+				{
+					"type": "array",
+					"items": { "$ref": "#/definitions/simpleTypes" },
+					"minItems": 1,
+					"uniqueItems": true
+				}
+			]
+		},
+		"format": { "type": "string" },
+		"contentMediaType": { "type": "string" },
+		"contentEncoding": { "type": "string" },
+		"if": { "$ref": "#" },
+		"then": { "$ref": "#" },
+		"else": { "$ref": "#" },
+		"allOf": { "$ref": "#/definitions/schemaArray" },
+		"anyOf": { "$ref": "#/definitions/schemaArray" },
+		"oneOf": { "$ref": "#/definitions/schemaArray" },
+		"not": { "$ref": "#" }
+	},
+	"default": true
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2019-09/meta/applicator
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2019-09/meta/applicator
@@ -1,0 +1,55 @@
+{
+	"$schema": "https://json-schema.org/draft/2019-09/schema",
+	"$id": "https://json-schema.org/draft/2019-09/meta/applicator",
+	"$vocabulary": {
+		"https://json-schema.org/draft/2019-09/vocab/applicator": true
+	},
+	"$recursiveAnchor": true,
+	"title": "Applicator vocabulary meta-schema",
+	"type": ["object", "boolean"],
+	"properties": {
+		"additionalItems": { "$recursiveRef": "#" },
+		"unevaluatedItems": { "$recursiveRef": "#" },
+		"items": {
+			"anyOf": [
+				{ "$recursiveRef": "#" },
+				{ "$ref": "#/$defs/schemaArray" }
+			]
+		},
+		"contains": { "$recursiveRef": "#" },
+		"additionalProperties": { "$recursiveRef": "#" },
+		"unevaluatedProperties": { "$recursiveRef": "#" },
+		"properties": {
+			"type": "object",
+			"additionalProperties": { "$recursiveRef": "#" },
+			"default": {}
+		},
+		"patternProperties": {
+			"type": "object",
+			"additionalProperties": { "$recursiveRef": "#" },
+			"propertyNames": { "format": "regex" },
+			"default": {}
+		},
+		"dependentSchemas": {
+			"type": "object",
+			"additionalProperties": {
+				"$recursiveRef": "#"
+			}
+		},
+		"propertyNames": { "$recursiveRef": "#" },
+		"if": { "$recursiveRef": "#" },
+		"then": { "$recursiveRef": "#" },
+		"else": { "$recursiveRef": "#" },
+		"allOf": { "$ref": "#/$defs/schemaArray" },
+		"anyOf": { "$ref": "#/$defs/schemaArray" },
+		"oneOf": { "$ref": "#/$defs/schemaArray" },
+		"not": { "$recursiveRef": "#" }
+	},
+	"$defs": {
+		"schemaArray": {
+			"type": "array",
+			"minItems": 1,
+			"items": { "$recursiveRef": "#" }
+		}
+	}
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2019-09/meta/content
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2019-09/meta/content
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://json-schema.org/draft/2019-09/schema",
+	"$id": "https://json-schema.org/draft/2019-09/meta/content",
+	"$vocabulary": {
+		"https://json-schema.org/draft/2019-09/vocab/content": true
+	},
+	"$recursiveAnchor": true,
+	"title": "Content vocabulary meta-schema",
+	"type": ["object", "boolean"],
+	"properties": {
+		"contentMediaType": { "type": "string" },
+		"contentEncoding": { "type": "string" },
+		"contentSchema": { "$recursiveRef": "#" }
+	}
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2019-09/meta/core
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2019-09/meta/core
@@ -1,0 +1,56 @@
+{
+	"$schema": "https://json-schema.org/draft/2019-09/schema",
+	"$id": "https://json-schema.org/draft/2019-09/meta/core",
+	"$vocabulary": {
+		"https://json-schema.org/draft/2019-09/vocab/core": true
+	},
+	"$recursiveAnchor": true,
+	"title": "Core vocabulary meta-schema",
+	"type": ["object", "boolean"],
+	"properties": {
+		"$id": {
+			"type": "string",
+			"format": "uri-reference",
+			"$comment": "Non-empty fragments not allowed.",
+			"pattern": "^[^#]*#?$"
+		},
+		"$schema": {
+			"type": "string",
+			"format": "uri"
+		},
+		"$anchor": {
+			"type": "string",
+			"pattern": "^[A-Za-z][-A-Za-z0-9.:_]*$"
+		},
+		"$ref": {
+			"type": "string",
+			"format": "uri-reference"
+		},
+		"$recursiveRef": {
+			"type": "string",
+			"format": "uri-reference"
+		},
+		"$recursiveAnchor": {
+			"type": "boolean",
+			"default": false
+		},
+		"$vocabulary": {
+			"type": "object",
+			"propertyNames": {
+				"type": "string",
+				"format": "uri"
+			},
+			"additionalProperties": {
+				"type": "boolean"
+			}
+		},
+		"$comment": {
+			"type": "string"
+		},
+		"$defs": {
+			"type": "object",
+			"additionalProperties": { "$recursiveRef": "#" },
+			"default": {}
+		}
+	}
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2019-09/meta/format
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2019-09/meta/format
@@ -1,0 +1,13 @@
+{
+	"$schema": "https://json-schema.org/draft/2019-09/schema",
+	"$id": "https://json-schema.org/draft/2019-09/meta/format",
+	"$vocabulary": {
+		"https://json-schema.org/draft/2019-09/vocab/format": true
+	},
+	"$recursiveAnchor": true,
+	"title": "Format vocabulary meta-schema",
+	"type": ["object", "boolean"],
+	"properties": {
+		"format": { "type": "string" }
+	}
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2019-09/meta/meta-data
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2019-09/meta/meta-data
@@ -1,0 +1,35 @@
+{
+	"$schema": "https://json-schema.org/draft/2019-09/schema",
+	"$id": "https://json-schema.org/draft/2019-09/meta/meta-data",
+	"$vocabulary": {
+		"https://json-schema.org/draft/2019-09/vocab/meta-data": true
+	},
+	"$recursiveAnchor": true,
+	"title": "Meta-data vocabulary meta-schema",
+	"type": ["object", "boolean"],
+	"properties": {
+		"title": {
+			"type": "string"
+		},
+		"description": {
+			"type": "string"
+		},
+		"default": true,
+		"deprecated": {
+			"type": "boolean",
+			"default": false
+		},
+		"readOnly": {
+			"type": "boolean",
+			"default": false
+		},
+		"writeOnly": {
+			"type": "boolean",
+			"default": false
+		},
+		"examples": {
+			"type": "array",
+			"items": true
+		}
+	}
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2019-09/meta/validation
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2019-09/meta/validation
@@ -1,0 +1,97 @@
+{
+	"$schema": "https://json-schema.org/draft/2019-09/schema",
+	"$id": "https://json-schema.org/draft/2019-09/meta/validation",
+	"$vocabulary": {
+		"https://json-schema.org/draft/2019-09/vocab/validation": true
+	},
+	"$recursiveAnchor": true,
+	"title": "Validation vocabulary meta-schema",
+	"type": ["object", "boolean"],
+	"properties": {
+		"multipleOf": {
+			"type": "number",
+			"exclusiveMinimum": 0
+		},
+		"maximum": {
+			"type": "number"
+		},
+		"exclusiveMaximum": {
+			"type": "number"
+		},
+		"minimum": {
+			"type": "number"
+		},
+		"exclusiveMinimum": {
+			"type": "number"
+		},
+		"maxLength": { "$ref": "#/$defs/nonNegativeInteger" },
+		"minLength": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+		"pattern": {
+			"type": "string",
+			"format": "regex"
+		},
+		"maxItems": { "$ref": "#/$defs/nonNegativeInteger" },
+		"minItems": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+		"uniqueItems": {
+			"type": "boolean",
+			"default": false
+		},
+		"maxContains": { "$ref": "#/$defs/nonNegativeInteger" },
+		"minContains": {
+			"$ref": "#/$defs/nonNegativeInteger",
+			"default": 1
+		},
+		"maxProperties": { "$ref": "#/$defs/nonNegativeInteger" },
+		"minProperties": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+		"required": { "$ref": "#/$defs/stringArray" },
+		"dependentRequired": {
+			"type": "object",
+			"additionalProperties": {
+				"$ref": "#/$defs/stringArray"
+			}
+		},
+		"const": true,
+		"enum": {
+			"type": "array",
+			"items": true
+		},
+		"type": {
+			"anyOf": [
+				{ "$ref": "#/$defs/simpleTypes" },
+				{
+					"type": "array",
+					"items": { "$ref": "#/$defs/simpleTypes" },
+					"minItems": 1,
+					"uniqueItems": true
+				}
+			]
+		}
+	},
+	"$defs": {
+		"nonNegativeInteger": {
+			"type": "integer",
+			"minimum": 0
+		},
+		"nonNegativeIntegerDefault0": {
+			"$ref": "#/$defs/nonNegativeInteger",
+			"default": 0
+		},
+		"simpleTypes": {
+			"enum": [
+				"array",
+				"boolean",
+				"integer",
+				"null",
+				"number",
+				"object",
+				"string"
+			]
+		},
+		"stringArray": {
+			"type": "array",
+			"items": { "type": "string" },
+			"uniqueItems": true,
+			"default": []
+		}
+	}
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2019-09/schema
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2019-09/schema
@@ -1,0 +1,41 @@
+{
+	"$schema": "https://json-schema.org/draft/2019-09/schema",
+	"$id": "https://json-schema.org/draft/2019-09/schema",
+	"$vocabulary": {
+		"https://json-schema.org/draft/2019-09/vocab/core": true,
+		"https://json-schema.org/draft/2019-09/vocab/applicator": true,
+		"https://json-schema.org/draft/2019-09/vocab/validation": true,
+		"https://json-schema.org/draft/2019-09/vocab/meta-data": true,
+		"https://json-schema.org/draft/2019-09/vocab/format": false,
+		"https://json-schema.org/draft/2019-09/vocab/content": true
+	},
+	"$recursiveAnchor": true,
+	"title": "Core and Validation specifications meta-schema",
+	"allOf": [
+		{"$ref": "meta/core"},
+		{"$ref": "meta/applicator"},
+		{"$ref": "meta/validation"},
+		{"$ref": "meta/meta-data"},
+		{"$ref": "meta/format"},
+		{"$ref": "meta/content"}
+	],
+	"type": ["object", "boolean"],
+	"properties": {
+		"definitions": {
+			"$comment": "While no longer an official keyword as it is replaced by $defs, this keyword is retained in the meta-schema to prevent incompatible extensions as it remains in common use.",
+			"type": "object",
+			"additionalProperties": { "$recursiveRef": "#" },
+			"default": {}
+		},
+		"dependencies": {
+			"$comment": "\"dependencies\" is no longer a keyword, but schema authors should avoid redefining it to facilitate a smooth transition to \"dependentSchemas\" and \"dependentRequired\"",
+			"type": "object",
+			"additionalProperties": {
+				"anyOf": [
+					{ "$recursiveRef": "#" },
+					{ "$ref": "meta/validation#/$defs/stringArray" }
+				]
+			}
+		}
+	}
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2020-12/meta/applicator
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2020-12/meta/applicator
@@ -1,0 +1,47 @@
+{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"$id": "https://json-schema.org/draft/2020-12/meta/applicator",
+		"$vocabulary": {
+			"https://json-schema.org/draft/2020-12/vocab/applicator": true
+		},
+		"$dynamicAnchor": "meta",
+		"title": "Applicator vocabulary meta-schema",
+		"type": ["object", "boolean"],
+		"properties": {
+			"prefixItems": { "$ref": "#/$defs/schemaArray" },
+			"items": { "$dynamicRef": "#meta" },
+			"contains": { "$dynamicRef": "#meta" },
+			"additionalProperties": { "$dynamicRef": "#meta" },
+			"properties": {
+				"type": "object",
+				"additionalProperties": { "$dynamicRef": "#meta" },
+				"default": {}
+			},
+			"patternProperties": {
+				"type": "object",
+				"additionalProperties": { "$dynamicRef": "#meta" },
+				"propertyNames": { "format": "regex" },
+				"default": {}
+			},
+			"dependentSchemas": {
+				"type": "object",
+				"additionalProperties": { "$dynamicRef": "#meta" },
+				"default": {}
+			},
+			"propertyNames": { "$dynamicRef": "#meta" },
+			"if": { "$dynamicRef": "#meta" },
+			"then": { "$dynamicRef": "#meta" },
+			"else": { "$dynamicRef": "#meta" },
+			"allOf": { "$ref": "#/$defs/schemaArray" },
+			"anyOf": { "$ref": "#/$defs/schemaArray" },
+			"oneOf": { "$ref": "#/$defs/schemaArray" },
+			"not": { "$dynamicRef": "#meta" }
+		},
+		"$defs": {
+			"schemaArray": {
+				"type": "array",
+				"minItems": 1,
+				"items": { "$dynamicRef": "#meta" }
+			}
+		}
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2020-12/meta/content
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2020-12/meta/content
@@ -1,0 +1,15 @@
+{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"$id": "https://json-schema.org/draft/2020-12/meta/content",
+		"$vocabulary": {
+			"https://json-schema.org/draft/2020-12/vocab/content": true
+		},
+		"$dynamicAnchor": "meta",
+		"title": "Content vocabulary meta-schema",
+		"type": ["object", "boolean"],
+		"properties": {
+			"contentEncoding": { "type": "string" },
+			"contentMediaType": { "type": "string" },
+			"contentSchema": { "$dynamicRef": "#meta" }
+		}
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2020-12/meta/core
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2020-12/meta/core
@@ -1,0 +1,50 @@
+{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"$id": "https://json-schema.org/draft/2020-12/meta/core",
+		"$vocabulary": {
+			"https://json-schema.org/draft/2020-12/vocab/core": true
+		},
+		"$dynamicAnchor": "meta",
+		"title": "Core vocabulary meta-schema",
+		"type": ["object", "boolean"],
+		"properties": {
+			"$id": {
+				"$ref": "#/$defs/uriReferenceString",
+				"$comment": "Non-empty fragments not allowed.",
+				"pattern": "^[^#]*#?$"
+			},
+			"$schema": { "$ref": "#/$defs/uriString" },
+			"$ref": { "$ref": "#/$defs/uriReferenceString" },
+			"$anchor": { "$ref": "#/$defs/anchorString" },
+			"$dynamicRef": { "$ref": "#/$defs/uriReferenceString" },
+			"$dynamicAnchor": { "$ref": "#/$defs/anchorString" },
+			"$vocabulary": {
+				"type": "object",
+				"propertyNames": { "$ref": "#/$defs/uriString" },
+				"additionalProperties": {
+					"type": "boolean"
+				}
+			},
+			"$comment": {
+				"type": "string"
+			},
+			"$defs": {
+				"type": "object",
+				"additionalProperties": { "$dynamicRef": "#meta" }
+			}
+		},
+		"$defs": {
+			"anchorString": {
+				"type": "string",
+				"pattern": "^[A-Za-z_][-A-Za-z0-9._]*$"
+			},
+			"uriString": {
+				"type": "string",
+				"format": "uri"
+			},
+			"uriReferenceString": {
+				"type": "string",
+				"format": "uri-reference"
+			}
+		}
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2020-12/meta/format-annotation
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2020-12/meta/format-annotation
@@ -1,0 +1,13 @@
+{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"$id": "https://json-schema.org/draft/2020-12/meta/format-annotation",
+		"$vocabulary": {
+			"https://json-schema.org/draft/2020-12/vocab/format-annotation": true
+		},
+		"$dynamicAnchor": "meta",
+		"title": "Format vocabulary meta-schema for annotation results",
+		"type": ["object", "boolean"],
+		"properties": {
+			"format": { "type": "string" }
+		}
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2020-12/meta/format-assertion
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2020-12/meta/format-assertion
@@ -1,0 +1,13 @@
+{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"$id": "https://json-schema.org/draft/2020-12/meta/format-assertion",
+		"$vocabulary": {
+			"https://json-schema.org/draft/2020-12/vocab/format-assertion": true
+		},
+		"$dynamicAnchor": "meta",
+		"title": "Format vocabulary meta-schema for assertion results",
+		"type": ["object", "boolean"],
+		"properties": {
+			"format": { "type": "string" }
+		}
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2020-12/meta/meta-data
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2020-12/meta/meta-data
@@ -1,0 +1,35 @@
+{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"$id": "https://json-schema.org/draft/2020-12/meta/meta-data",
+		"$vocabulary": {
+			"https://json-schema.org/draft/2020-12/vocab/meta-data": true
+		},
+		"$dynamicAnchor": "meta",
+		"title": "Meta-data vocabulary meta-schema",
+		"type": ["object", "boolean"],
+		"properties": {
+			"title": {
+				"type": "string"
+			},
+			"description": {
+				"type": "string"
+			},
+			"default": true,
+			"deprecated": {
+				"type": "boolean",
+				"default": false
+			},
+			"readOnly": {
+				"type": "boolean",
+				"default": false
+			},
+			"writeOnly": {
+				"type": "boolean",
+				"default": false
+			},
+			"examples": {
+				"type": "array",
+				"items": true
+			}
+		}
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2020-12/meta/unevaluated
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2020-12/meta/unevaluated
@@ -1,0 +1,14 @@
+{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"$id": "https://json-schema.org/draft/2020-12/meta/unevaluated",
+		"$vocabulary": {
+			"https://json-schema.org/draft/2020-12/vocab/unevaluated": true
+		},
+		"$dynamicAnchor": "meta",
+		"title": "Unevaluated applicator vocabulary meta-schema",
+		"type": ["object", "boolean"],
+		"properties": {
+			"unevaluatedItems": { "$dynamicRef": "#meta" },
+			"unevaluatedProperties": { "$dynamicRef": "#meta" }
+		}
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2020-12/meta/validation
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2020-12/meta/validation
@@ -1,0 +1,97 @@
+{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"$id": "https://json-schema.org/draft/2020-12/meta/validation",
+		"$vocabulary": {
+			"https://json-schema.org/draft/2020-12/vocab/validation": true
+		},
+		"$dynamicAnchor": "meta",
+		"title": "Validation vocabulary meta-schema",
+		"type": ["object", "boolean"],
+		"properties": {
+			"type": {
+				"anyOf": [
+					{ "$ref": "#/$defs/simpleTypes" },
+					{
+						"type": "array",
+						"items": { "$ref": "#/$defs/simpleTypes" },
+						"minItems": 1,
+						"uniqueItems": true
+					}
+				]
+			},
+			"const": true,
+			"enum": {
+				"type": "array",
+				"items": true
+			},
+			"multipleOf": {
+				"type": "number",
+				"exclusiveMinimum": 0
+			},
+			"maximum": {
+				"type": "number"
+			},
+			"exclusiveMaximum": {
+				"type": "number"
+			},
+			"minimum": {
+				"type": "number"
+			},
+			"exclusiveMinimum": {
+				"type": "number"
+			},
+			"maxLength": { "$ref": "#/$defs/nonNegativeInteger" },
+			"minLength": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+			"pattern": {
+				"type": "string",
+				"format": "regex"
+			},
+			"maxItems": { "$ref": "#/$defs/nonNegativeInteger" },
+			"minItems": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+			"uniqueItems": {
+				"type": "boolean",
+				"default": false
+			},
+			"maxContains": { "$ref": "#/$defs/nonNegativeInteger" },
+			"minContains": {
+				"$ref": "#/$defs/nonNegativeInteger",
+				"default": 1
+			},
+			"maxProperties": { "$ref": "#/$defs/nonNegativeInteger" },
+			"minProperties": { "$ref": "#/$defs/nonNegativeIntegerDefault0" },
+			"required": { "$ref": "#/$defs/stringArray" },
+			"dependentRequired": {
+				"type": "object",
+				"additionalProperties": {
+					"$ref": "#/$defs/stringArray"
+				}
+			}
+		},
+		"$defs": {
+			"nonNegativeInteger": {
+				"type": "integer",
+				"minimum": 0
+			},
+			"nonNegativeIntegerDefault0": {
+				"$ref": "#/$defs/nonNegativeInteger",
+				"default": 0
+			},
+			"simpleTypes": {
+				"enum": [
+					"array",
+					"boolean",
+					"integer",
+					"null",
+					"number",
+					"object",
+					"string"
+				]
+			},
+			"stringArray": {
+				"type": "array",
+				"items": { "type": "string" },
+				"uniqueItems": true,
+				"default": []
+			}
+		}
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2020-12/schema
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/metaschemas/draft/2020-12/schema
@@ -1,0 +1,57 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://json-schema.org/draft/2020-12/schema",
+	"$vocabulary": {
+		"https://json-schema.org/draft/2020-12/vocab/core": true,
+		"https://json-schema.org/draft/2020-12/vocab/applicator": true,
+		"https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
+		"https://json-schema.org/draft/2020-12/vocab/validation": true,
+		"https://json-schema.org/draft/2020-12/vocab/meta-data": true,
+		"https://json-schema.org/draft/2020-12/vocab/format-annotation": true,
+		"https://json-schema.org/draft/2020-12/vocab/content": true
+	},
+	"$dynamicAnchor": "meta",
+	"title": "Core and Validation specifications meta-schema",
+	"allOf": [
+		{"$ref": "meta/core"},
+		{"$ref": "meta/applicator"},
+		{"$ref": "meta/unevaluated"},
+		{"$ref": "meta/validation"},
+		{"$ref": "meta/meta-data"},
+		{"$ref": "meta/format-annotation"},
+		{"$ref": "meta/content"}
+	],
+	"type": ["object", "boolean"],
+	"$comment": "This meta-schema also defines keywords that have appeared in previous drafts in order to prevent incompatible extensions as they remain in common use.",
+	"properties": {
+		"definitions": {
+			"$comment": "\"definitions\" has been replaced by \"$defs\".",
+			"type": "object",
+			"additionalProperties": { "$dynamicRef": "#meta" },
+			"deprecated": true,
+			"default": {}
+		},
+		"dependencies": {
+			"$comment": "\"dependencies\" has been split and replaced by \"dependentSchemas\" and \"dependentRequired\" in order to serve their differing semantics.",
+			"type": "object",
+			"additionalProperties": {
+				"anyOf": [
+					{ "$dynamicRef": "#meta" },
+					{ "$ref": "meta/validation#/$defs/stringArray" }
+				]
+			},
+			"deprecated": true,
+			"default": {}
+		},
+		"$recursiveAnchor": {
+			"$comment": "\"$recursiveAnchor\" has been replaced by \"$dynamicAnchor\".",
+			"$ref": "meta/core#/$defs/anchorString",
+			"deprecated": true
+		},
+		"$recursiveRef": {
+			"$comment": "\"$recursiveRef\" has been replaced by \"$dynamicRef\".",
+			"$ref": "meta/core#/$defs/uriReferenceString",
+			"deprecated": true
+		}
+	}
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/objcompiler.go
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/objcompiler.go
@@ -1,0 +1,549 @@
+package jsonschema
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"strconv"
+)
+
+type objCompiler struct {
+	c   *Compiler
+	obj map[string]any
+	up  urlPtr
+	r   *root
+	res *resource
+	q   *queue
+}
+
+func (c *objCompiler) compile(s *Schema) error {
+	// id --
+	if id := c.res.dialect.draft.getID(c.obj); id != "" {
+		s.ID = id
+	}
+
+	// anchor --
+	if s.DraftVersion < 2019 {
+		// anchor is specified in id
+		id := c.string(c.res.dialect.draft.id)
+		if id != "" {
+			_, f := split(id)
+			if f != "" {
+				var err error
+				s.Anchor, err = decode(f)
+				if err != nil {
+					return &ParseAnchorError{URL: s.Location}
+				}
+			}
+		}
+	} else {
+		s.Anchor = c.string("$anchor")
+	}
+
+	if err := c.compileDraft4(s); err != nil {
+		return err
+	}
+	if s.DraftVersion >= 6 {
+		if err := c.compileDraft6(s); err != nil {
+			return err
+		}
+	}
+	if s.DraftVersion >= 7 {
+		if err := c.compileDraft7(s); err != nil {
+			return err
+		}
+	}
+	if s.DraftVersion >= 2019 {
+		if err := c.compileDraft2019(s); err != nil {
+			return err
+		}
+	}
+	if s.DraftVersion >= 2020 {
+		if err := c.compileDraft2020(s); err != nil {
+			return err
+		}
+	}
+
+	// vocabularies
+	vocabs := c.res.dialect.activeVocabs(c.c.roots.assertVocabs, c.c.roots.vocabularies)
+	for _, vocab := range vocabs {
+		v := c.c.roots.vocabularies[vocab]
+		if v == nil {
+			continue
+		}
+		ext, err := v.Compile(&CompilerContext{c}, c.obj)
+		if err != nil {
+			return err
+		}
+		if ext != nil {
+			s.Extensions = append(s.Extensions, ext)
+		}
+	}
+
+	return nil
+}
+
+func (c *objCompiler) compileDraft4(s *Schema) error {
+	var err error
+
+	if c.hasVocab("core") {
+		if s.Ref, err = c.enqueueRef("$ref"); err != nil {
+			return err
+		}
+		if s.DraftVersion < 2019 && s.Ref != nil {
+			// All other properties in a "$ref" object MUST be ignored
+			return nil
+		}
+	}
+
+	if c.hasVocab("applicator") {
+		s.AllOf = c.enqueueArr("allOf")
+		s.AnyOf = c.enqueueArr("anyOf")
+		s.OneOf = c.enqueueArr("oneOf")
+		s.Not = c.enqueueProp("not")
+
+		if s.DraftVersion < 2020 {
+			if items, ok := c.obj["items"]; ok {
+				if _, ok := items.([]any); ok {
+					s.Items = c.enqueueArr("items")
+					s.AdditionalItems = c.enqueueAdditional("additionalItems")
+				} else {
+					s.Items = c.enqueueProp("items")
+				}
+			}
+		}
+
+		s.Properties = c.enqueueMap("properties")
+		if m := c.enqueueMap("patternProperties"); m != nil {
+			s.PatternProperties = map[Regexp]*Schema{}
+			for pname, sch := range m {
+				re, err := c.c.roots.regexpEngine(pname)
+				if err != nil {
+					return &InvalidRegexError{c.up.format("patternProperties"), pname, err}
+				}
+				s.PatternProperties[re] = sch
+			}
+		}
+		s.AdditionalProperties = c.enqueueAdditional("additionalProperties")
+
+		if m := c.objVal("dependencies"); m != nil {
+			s.Dependencies = map[string]any{}
+			for pname, pvalue := range m {
+				if arr, ok := pvalue.([]any); ok {
+					s.Dependencies[pname] = toStrings(arr)
+				} else {
+					ptr := c.up.ptr.append2("dependencies", pname)
+					s.Dependencies[pname] = c.enqueuePtr(ptr)
+				}
+			}
+		}
+	}
+
+	if c.hasVocab("validation") {
+		if t, ok := c.obj["type"]; ok {
+			s.Types = newTypes(t)
+		}
+		if arr := c.arrVal("enum"); arr != nil {
+			s.Enum = newEnum(arr)
+		}
+		s.MultipleOf = c.numVal("multipleOf")
+		s.Maximum = c.numVal("maximum")
+		if c.boolean("exclusiveMaximum") {
+			s.ExclusiveMaximum = s.Maximum
+			s.Maximum = nil
+		} else {
+			s.ExclusiveMaximum = c.numVal("exclusiveMaximum")
+		}
+		s.Minimum = c.numVal("minimum")
+		if c.boolean("exclusiveMinimum") {
+			s.ExclusiveMinimum = s.Minimum
+			s.Minimum = nil
+		} else {
+			s.ExclusiveMinimum = c.numVal("exclusiveMinimum")
+		}
+
+		s.MinLength = c.intVal("minLength")
+		s.MaxLength = c.intVal("maxLength")
+		if pat := c.strVal("pattern"); pat != nil {
+			s.Pattern, err = c.c.roots.regexpEngine(*pat)
+			if err != nil {
+				return &InvalidRegexError{c.up.format("pattern"), *pat, err}
+			}
+		}
+
+		s.MinItems = c.intVal("minItems")
+		s.MaxItems = c.intVal("maxItems")
+		s.UniqueItems = c.boolean("uniqueItems")
+
+		s.MaxProperties = c.intVal("maxProperties")
+		s.MinProperties = c.intVal("minProperties")
+		if arr := c.arrVal("required"); arr != nil {
+			s.Required = toStrings(arr)
+		}
+	}
+
+	// format --
+	if c.assertFormat(s.DraftVersion) {
+		if f := c.strVal("format"); f != nil {
+			if *f == "regex" {
+				s.Format = &Format{
+					Name:     "regex",
+					Validate: c.c.roots.regexpEngine.validate,
+				}
+			} else {
+				s.Format = c.c.formats[*f]
+				if s.Format == nil {
+					s.Format = formats[*f]
+				}
+			}
+		}
+	}
+
+	// annotations --
+	s.Title = c.string("title")
+	s.Description = c.string("description")
+	if v, ok := c.obj["default"]; ok {
+		s.Default = &v
+	}
+
+	return nil
+}
+
+func (c *objCompiler) compileDraft6(s *Schema) error {
+	if c.hasVocab("applicator") {
+		s.Contains = c.enqueueProp("contains")
+		s.PropertyNames = c.enqueueProp("propertyNames")
+	}
+	if c.hasVocab("validation") {
+		if v, ok := c.obj["const"]; ok {
+			s.Const = &v
+		}
+	}
+	return nil
+}
+
+func (c *objCompiler) compileDraft7(s *Schema) error {
+	if c.hasVocab("applicator") {
+		s.If = c.enqueueProp("if")
+		if s.If != nil {
+			b := c.boolVal("if")
+			if b == nil || *b {
+				s.Then = c.enqueueProp("then")
+			}
+			if b == nil || !*b {
+				s.Else = c.enqueueProp("else")
+			}
+		}
+	}
+
+	if c.c.assertContent {
+		if ce := c.strVal("contentEncoding"); ce != nil {
+			s.ContentEncoding = c.c.decoders[*ce]
+			if s.ContentEncoding == nil {
+				s.ContentEncoding = decoders[*ce]
+			}
+		}
+		if cm := c.strVal("contentMediaType"); cm != nil {
+			s.ContentMediaType = c.c.mediaTypes[*cm]
+			if s.ContentMediaType == nil {
+				s.ContentMediaType = mediaTypes[*cm]
+			}
+		}
+	}
+
+	// annotations --
+	s.Comment = c.string("$comment")
+	s.ReadOnly = c.boolean("readOnly")
+	s.WriteOnly = c.boolean("writeOnly")
+	if arr, ok := c.obj["examples"].([]any); ok {
+		s.Examples = arr
+	}
+
+	return nil
+}
+
+func (c *objCompiler) compileDraft2019(s *Schema) error {
+	var err error
+
+	if c.hasVocab("core") {
+		if s.RecursiveRef, err = c.enqueueRef("$recursiveRef"); err != nil {
+			return err
+		}
+		s.RecursiveAnchor = c.boolean("$recursiveAnchor")
+	}
+
+	if c.hasVocab("validation") {
+		if s.Contains != nil {
+			s.MinContains = c.intVal("minContains")
+			s.MaxContains = c.intVal("maxContains")
+		}
+		if m := c.objVal("dependentRequired"); m != nil {
+			s.DependentRequired = map[string][]string{}
+			for pname, pvalue := range m {
+				if arr, ok := pvalue.([]any); ok {
+					s.DependentRequired[pname] = toStrings(arr)
+				}
+			}
+		}
+	}
+
+	if c.hasVocab("applicator") {
+		s.DependentSchemas = c.enqueueMap("dependentSchemas")
+	}
+
+	var unevaluated bool
+	if s.DraftVersion == 2019 {
+		unevaluated = c.hasVocab("applicator")
+	} else {
+		unevaluated = c.hasVocab("unevaluated")
+	}
+	if unevaluated {
+		s.UnevaluatedItems = c.enqueueProp("unevaluatedItems")
+		s.UnevaluatedProperties = c.enqueueProp("unevaluatedProperties")
+	}
+
+	if c.c.assertContent {
+		if s.ContentMediaType != nil && s.ContentMediaType.UnmarshalJSON != nil {
+			s.ContentSchema = c.enqueueProp("contentSchema")
+		}
+	}
+
+	// annotations --
+	s.Deprecated = c.boolean("deprecated")
+
+	return nil
+}
+
+func (c *objCompiler) compileDraft2020(s *Schema) error {
+	if c.hasVocab("core") {
+		sch, err := c.enqueueRef("$dynamicRef")
+		if err != nil {
+			return err
+		}
+		if sch != nil {
+			dref := c.strVal("$dynamicRef")
+			_, frag, err := splitFragment(*dref)
+			if err != nil {
+				return err
+			}
+			var anch string
+			if anchor, ok := frag.convert().(anchor); ok {
+				anch = string(anchor)
+			}
+			s.DynamicRef = &DynamicRef{sch, anch}
+		}
+		s.DynamicAnchor = c.string("$dynamicAnchor")
+	}
+
+	if c.hasVocab("applicator") {
+		s.PrefixItems = c.enqueueArr("prefixItems")
+		s.Items2020 = c.enqueueProp("items")
+	}
+
+	return nil
+}
+
+// enqueue helpers --
+
+func (c *objCompiler) enqueuePtr(ptr jsonPointer) *Schema {
+	up := urlPtr{c.up.url, ptr}
+	return c.c.enqueue(c.q, up)
+}
+
+func (c *objCompiler) enqueueRef(pname string) (*Schema, error) {
+	ref := c.strVal(pname)
+	if ref == nil {
+		return nil, nil
+	}
+	baseURL := c.res.id
+	// baseURL := c.r.baseURL(c.up.ptr)
+	uf, err := baseURL.join(*ref)
+	if err != nil {
+		return nil, err
+	}
+
+	up, err := c.r.resolve(*uf)
+	if err != nil {
+		return nil, err
+	}
+	if up != nil {
+		// local ref
+		return c.enqueuePtr(up.ptr), nil
+	}
+
+	// remote ref
+	up_, err := c.c.roots.resolveFragment(*uf)
+	if err != nil {
+		return nil, err
+	}
+	return c.c.enqueue(c.q, up_), nil
+}
+
+func (c *objCompiler) enqueueProp(pname string) *Schema {
+	if _, ok := c.obj[pname]; !ok {
+		return nil
+	}
+	ptr := c.up.ptr.append(pname)
+	return c.enqueuePtr(ptr)
+}
+
+func (c *objCompiler) enqueueArr(pname string) []*Schema {
+	arr := c.arrVal(pname)
+	if arr == nil {
+		return nil
+	}
+	sch := make([]*Schema, len(arr))
+	for i := range arr {
+		ptr := c.up.ptr.append2(pname, strconv.Itoa(i))
+		sch[i] = c.enqueuePtr(ptr)
+	}
+	return sch
+}
+
+func (c *objCompiler) enqueueMap(pname string) map[string]*Schema {
+	obj := c.objVal(pname)
+	if obj == nil {
+		return nil
+	}
+	sch := make(map[string]*Schema)
+	for k := range obj {
+		ptr := c.up.ptr.append2(pname, k)
+		sch[k] = c.enqueuePtr(ptr)
+	}
+	return sch
+}
+
+func (c *objCompiler) enqueueAdditional(pname string) any {
+	if b := c.boolVal(pname); b != nil {
+		return *b
+	}
+	if sch := c.enqueueProp(pname); sch != nil {
+		return sch
+	}
+	return nil
+}
+
+// --
+
+func (c *objCompiler) hasVocab(name string) bool {
+	return c.res.dialect.hasVocab(name)
+}
+
+func (c *objCompiler) assertFormat(draftVersion int) bool {
+	if c.c.assertFormat || draftVersion < 2019 {
+		return true
+	}
+	if draftVersion == 2019 {
+		return c.hasVocab("format")
+	} else {
+		return c.hasVocab("format-assertion")
+	}
+}
+
+// value helpers --
+
+func (c *objCompiler) boolVal(pname string) *bool {
+	v, ok := c.obj[pname]
+	if !ok {
+		return nil
+	}
+	b, ok := v.(bool)
+	if !ok {
+		return nil
+	}
+	return &b
+}
+
+func (c *objCompiler) boolean(pname string) bool {
+	b := c.boolVal(pname)
+	return b != nil && *b
+}
+
+func (c *objCompiler) strVal(pname string) *string {
+	v, ok := c.obj[pname]
+	if !ok {
+		return nil
+	}
+	s, ok := v.(string)
+	if !ok {
+		return nil
+	}
+	return &s
+}
+
+func (c *objCompiler) string(pname string) string {
+	if s := c.strVal(pname); s != nil {
+		return *s
+	}
+	return ""
+}
+
+func (c *objCompiler) numVal(pname string) *big.Rat {
+	v, ok := c.obj[pname]
+	if !ok {
+		return nil
+	}
+	switch v.(type) {
+	case json.Number, float32, float64, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		if n, ok := new(big.Rat).SetString(fmt.Sprint(v)); ok {
+			return n
+		}
+	}
+	return nil
+}
+
+func (c *objCompiler) intVal(pname string) *int {
+	if n := c.numVal(pname); n != nil && n.IsInt() {
+		n := int(n.Num().Int64())
+		return &n
+	}
+	return nil
+}
+
+func (c *objCompiler) objVal(pname string) map[string]any {
+	v, ok := c.obj[pname]
+	if !ok {
+		return nil
+	}
+	obj, ok := v.(map[string]any)
+	if !ok {
+		return nil
+	}
+	return obj
+}
+
+func (c *objCompiler) arrVal(pname string) []any {
+	v, ok := c.obj[pname]
+	if !ok {
+		return nil
+	}
+	arr, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	return arr
+}
+
+// --
+
+type InvalidRegexError struct {
+	URL   string
+	Regex string
+	Err   error
+}
+
+func (e *InvalidRegexError) Error() string {
+	return fmt.Sprintf("invalid regex %q at %q: %v", e.Regex, e.URL, e.Err)
+}
+
+// --
+
+func toStrings(arr []any) []string {
+	var strings []string
+	for _, item := range arr {
+		if s, ok := item.(string); ok {
+			strings = append(strings, s)
+		}
+	}
+	return strings
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/output.go
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/output.go
@@ -1,0 +1,216 @@
+package jsonschema
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v6/kind"
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
+)
+
+var defaultPrinter = message.NewPrinter(language.English)
+
+// format ---
+
+func (e *ValidationError) schemaURL() string {
+	if ref, ok := e.ErrorKind.(*kind.Reference); ok {
+		return ref.URL
+	} else {
+		return e.SchemaURL
+	}
+}
+
+func (e *ValidationError) absoluteKeywordLocation() string {
+	var schemaURL string
+	var keywordPath []string
+	if ref, ok := e.ErrorKind.(*kind.Reference); ok {
+		schemaURL = ref.URL
+		keywordPath = nil
+	} else {
+		schemaURL = e.SchemaURL
+		keywordPath = e.ErrorKind.KeywordPath()
+	}
+	return fmt.Sprintf("%s%s", schemaURL, encode(jsonPtr(keywordPath)))
+}
+
+func (e *ValidationError) skip() bool {
+	if len(e.Causes) == 1 {
+		_, ok := e.ErrorKind.(*kind.Reference)
+		return ok
+	}
+	return false
+}
+
+func (e *ValidationError) display(sb *strings.Builder, verbose bool, indent int, absKwLoc string, p *message.Printer) {
+	if !e.skip() {
+		if indent > 0 {
+			sb.WriteByte('\n')
+			for i := 0; i < indent-1; i++ {
+				sb.WriteString("  ")
+			}
+			sb.WriteString("- ")
+		}
+		indent = indent + 1
+
+		prevAbsKwLoc := absKwLoc
+		absKwLoc = e.absoluteKeywordLocation()
+
+		if _, ok := e.ErrorKind.(*kind.Schema); ok {
+			sb.WriteString(e.ErrorKind.LocalizedString(p))
+		} else {
+			sb.WriteString(p.Sprintf("at %s", quote(jsonPtr(e.InstanceLocation))))
+			if verbose {
+				schLoc := absKwLoc
+				if prevAbsKwLoc != "" {
+					pu, _ := split(prevAbsKwLoc)
+					u, f := split(absKwLoc)
+					if u == pu {
+						schLoc = fmt.Sprintf("S#%s", f)
+					}
+				}
+				fmt.Fprintf(sb, " [%s]", schLoc)
+			}
+			fmt.Fprintf(sb, ": %s", e.ErrorKind.LocalizedString(p))
+		}
+	}
+	for _, cause := range e.Causes {
+		cause.display(sb, verbose, indent, absKwLoc, p)
+	}
+}
+
+func (e *ValidationError) Error() string {
+	return e.LocalizedError(defaultPrinter)
+}
+
+func (e *ValidationError) LocalizedError(p *message.Printer) string {
+	var sb strings.Builder
+	e.display(&sb, false, 0, "", p)
+	return sb.String()
+}
+
+func (e *ValidationError) GoString() string {
+	return e.LocalizedGoString(defaultPrinter)
+}
+
+func (e *ValidationError) LocalizedGoString(p *message.Printer) string {
+	var sb strings.Builder
+	e.display(&sb, true, 0, "", p)
+	return sb.String()
+}
+
+func jsonPtr(tokens []string) string {
+	var sb strings.Builder
+	for _, tok := range tokens {
+		sb.WriteByte('/')
+		sb.WriteString(escape(tok))
+	}
+	return sb.String()
+}
+
+// --
+
+// Flag is output format with simple boolean property valid.
+type FlagOutput struct {
+	Valid bool `json:"valid"`
+}
+
+// The `Flag` output format, merely the boolean result.
+func (e *ValidationError) FlagOutput() *FlagOutput {
+	return &FlagOutput{Valid: false}
+}
+
+// --
+
+type OutputUnit struct {
+	Valid                   bool         `json:"valid"`
+	KeywordLocation         string       `json:"keywordLocation"`
+	AbsoluteKeywordLocation string       `json:"AbsoluteKeywordLocation,omitempty"`
+	InstanceLocation        string       `json:"instanceLocation"`
+	Error                   *OutputError `json:"error,omitempty"`
+	Errors                  []OutputUnit `json:"errors,omitempty"`
+}
+
+type OutputError struct {
+	Kind ErrorKind
+	p    *message.Printer
+}
+
+func (k OutputError) String() string {
+	return k.Kind.LocalizedString(k.p)
+}
+
+func (k OutputError) MarshalJSON() ([]byte, error) {
+	return json.Marshal(k.Kind.LocalizedString(k.p))
+}
+
+// The `Basic` structure, a flat list of output units.
+func (e *ValidationError) BasicOutput() *OutputUnit {
+	return e.LocalizedBasicOutput(defaultPrinter)
+}
+
+func (e *ValidationError) LocalizedBasicOutput(p *message.Printer) *OutputUnit {
+	out := e.output(true, false, "", "", p)
+	return &out
+}
+
+// The `Detailed` structure, based on the schema.
+func (e *ValidationError) DetailedOutput() *OutputUnit {
+	return e.LocalizedDetailedOutput(defaultPrinter)
+}
+
+func (e *ValidationError) LocalizedDetailedOutput(p *message.Printer) *OutputUnit {
+	out := e.output(false, false, "", "", p)
+	return &out
+}
+
+func (e *ValidationError) output(flatten, inRef bool, schemaURL, kwLoc string, p *message.Printer) OutputUnit {
+	if !inRef {
+		if _, ok := e.ErrorKind.(*kind.Reference); ok {
+			inRef = true
+		}
+	}
+	if schemaURL != "" {
+		kwLoc += e.SchemaURL[len(schemaURL):]
+		if ref, ok := e.ErrorKind.(*kind.Reference); ok {
+			kwLoc += jsonPtr(ref.KeywordPath())
+		}
+	}
+	schemaURL = e.schemaURL()
+
+	keywordLocation := kwLoc
+	if _, ok := e.ErrorKind.(*kind.Reference); !ok {
+		keywordLocation += jsonPtr(e.ErrorKind.KeywordPath())
+	}
+
+	out := OutputUnit{
+		Valid:            false,
+		InstanceLocation: jsonPtr(e.InstanceLocation),
+		KeywordLocation:  keywordLocation,
+	}
+	if inRef {
+		out.AbsoluteKeywordLocation = e.absoluteKeywordLocation()
+	}
+	for _, cause := range e.Causes {
+		causeOut := cause.output(flatten, inRef, schemaURL, kwLoc, p)
+		if cause.skip() {
+			causeOut = causeOut.Errors[0]
+		}
+		if flatten {
+			errors := causeOut.Errors
+			causeOut.Errors = nil
+			causeOut.Error = &OutputError{cause.ErrorKind, p}
+			out.Errors = append(out.Errors, causeOut)
+			if len(errors) > 0 {
+				out.Errors = append(out.Errors, errors...)
+			}
+		} else {
+			out.Errors = append(out.Errors, causeOut)
+		}
+	}
+	if len(out.Errors) == 0 {
+		out.Error = &OutputError{e.ErrorKind, p}
+	}
+	return out
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/position.go
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/position.go
@@ -1,0 +1,142 @@
+package jsonschema
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Position tells possible tokens in json.
+type Position interface {
+	collect(v any, ptr jsonPointer) map[jsonPointer]any
+}
+
+// --
+
+type AllProp struct{}
+
+func (AllProp) collect(v any, ptr jsonPointer) map[jsonPointer]any {
+	obj, ok := v.(map[string]any)
+	if !ok {
+		return nil
+	}
+	m := map[jsonPointer]any{}
+	for pname, pvalue := range obj {
+		m[ptr.append(pname)] = pvalue
+	}
+	return m
+}
+
+// --
+
+type AllItem struct{}
+
+func (AllItem) collect(v any, ptr jsonPointer) map[jsonPointer]any {
+	arr, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	m := map[jsonPointer]any{}
+	for i, item := range arr {
+		m[ptr.append(strconv.Itoa(i))] = item
+	}
+	return m
+}
+
+// --
+
+type Prop string
+
+func (p Prop) collect(v any, ptr jsonPointer) map[jsonPointer]any {
+	obj, ok := v.(map[string]any)
+	if !ok {
+		return nil
+	}
+	pvalue, ok := obj[string(p)]
+	if !ok {
+		return nil
+	}
+	return map[jsonPointer]any{
+		ptr.append(string(p)): pvalue,
+	}
+}
+
+// --
+
+type Item int
+
+func (i Item) collect(v any, ptr jsonPointer) map[jsonPointer]any {
+	arr, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	if i < 0 || int(i) >= len(arr) {
+		return nil
+	}
+	return map[jsonPointer]any{
+		ptr.append(strconv.Itoa(int(i))): arr[int(i)],
+	}
+}
+
+// --
+
+// SchemaPath tells where to look for subschema inside keyword.
+type SchemaPath []Position
+
+func schemaPath(path string) SchemaPath {
+	var sp SchemaPath
+	for _, tok := range strings.Split(path, "/") {
+		var pos Position
+		switch tok {
+		case "*":
+			pos = AllProp{}
+		case "[]":
+			pos = AllItem{}
+		default:
+			if i, err := strconv.Atoi(tok); err == nil {
+				pos = Item(i)
+			} else {
+				pos = Prop(tok)
+			}
+		}
+		sp = append(sp, pos)
+	}
+	return sp
+}
+
+func (sp SchemaPath) collect(v any, ptr jsonPointer) map[jsonPointer]any {
+	if len(sp) == 0 {
+		return map[jsonPointer]any{
+			ptr: v,
+		}
+	}
+	p, sp := sp[0], sp[1:]
+	m := p.collect(v, ptr)
+	mm := map[jsonPointer]any{}
+	for ptr, v := range m {
+		m = sp.collect(v, ptr)
+		for k, v := range m {
+			mm[k] = v
+		}
+	}
+	return mm
+}
+
+func (sp SchemaPath) String() string {
+	var sb strings.Builder
+	for _, pos := range sp {
+		if sb.Len() != 0 {
+			sb.WriteByte('/')
+		}
+		switch pos := pos.(type) {
+		case AllProp:
+			sb.WriteString("*")
+		case AllItem:
+			sb.WriteString("[]")
+		case Prop:
+			sb.WriteString(string(pos))
+		case Item:
+			sb.WriteString(strconv.Itoa(int(pos)))
+		}
+	}
+	return sb.String()
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/root.go
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/root.go
@@ -1,0 +1,202 @@
+package jsonschema
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+type root struct {
+	url                 url
+	doc                 any
+	resources           map[jsonPointer]*resource
+	subschemasProcessed map[jsonPointer]struct{}
+}
+
+func (r *root) rootResource() *resource {
+	return r.resources[""]
+}
+
+func (r *root) resource(ptr jsonPointer) *resource {
+	for {
+		if res, ok := r.resources[ptr]; ok {
+			return res
+		}
+		slash := strings.LastIndexByte(string(ptr), '/')
+		if slash == -1 {
+			break
+		}
+		ptr = ptr[:slash]
+	}
+	return r.rootResource()
+}
+
+func (r *root) resolveFragmentIn(frag fragment, res *resource) (urlPtr, error) {
+	var ptr jsonPointer
+	switch f := frag.convert().(type) {
+	case jsonPointer:
+		ptr = res.ptr.concat(f)
+	case anchor:
+		aptr, ok := res.anchors[f]
+		if !ok {
+			return urlPtr{}, &AnchorNotFoundError{
+				URL:       r.url.String(),
+				Reference: (&urlFrag{res.id, frag}).String(),
+			}
+		}
+		ptr = aptr
+	}
+	return urlPtr{r.url, ptr}, nil
+}
+
+func (r *root) resolveFragment(frag fragment) (urlPtr, error) {
+	return r.resolveFragmentIn(frag, r.rootResource())
+}
+
+// resolves urlFrag to urlPtr from root.
+// returns nil if it is external.
+func (r *root) resolve(uf urlFrag) (*urlPtr, error) {
+	var res *resource
+	if uf.url == r.url {
+		res = r.rootResource()
+	} else {
+		// look for resource with id==uf.url
+		for _, v := range r.resources {
+			if v.id == uf.url {
+				res = v
+				break
+			}
+		}
+		if res == nil {
+			return nil, nil // external url
+		}
+	}
+	up, err := r.resolveFragmentIn(uf.frag, res)
+	return &up, err
+}
+
+func (r *root) collectAnchors(sch any, schPtr jsonPointer, res *resource) error {
+	obj, ok := sch.(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	addAnchor := func(anchor anchor) error {
+		ptr1, ok := res.anchors[anchor]
+		if ok {
+			if ptr1 == schPtr {
+				// anchor with same root_ptr already exists
+				return nil
+			}
+			return &DuplicateAnchorError{
+				string(anchor), r.url.String(), string(ptr1), string(schPtr),
+			}
+		}
+		res.anchors[anchor] = schPtr
+		return nil
+	}
+
+	if res.dialect.draft.version < 2019 {
+		if _, ok := obj["$ref"]; ok {
+			// All other properties in a "$ref" object MUST be ignored
+			return nil
+		}
+		// anchor is specified in id
+		if id, ok := strVal(obj, res.dialect.draft.id); ok {
+			_, frag, err := splitFragment(id)
+			if err != nil {
+				loc := urlPtr{r.url, schPtr}
+				return &ParseAnchorError{loc.String()}
+			}
+			if anchor, ok := frag.convert().(anchor); ok {
+				if err := addAnchor(anchor); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	if res.dialect.draft.version >= 2019 {
+		if s, ok := strVal(obj, "$anchor"); ok {
+			if err := addAnchor(anchor(s)); err != nil {
+				return err
+			}
+		}
+	}
+	if res.dialect.draft.version >= 2020 {
+		if s, ok := strVal(obj, "$dynamicAnchor"); ok {
+			if err := addAnchor(anchor(s)); err != nil {
+				return err
+			}
+			res.dynamicAnchors = append(res.dynamicAnchors, anchor(s))
+		}
+	}
+
+	return nil
+}
+
+func (r *root) clone() *root {
+	processed := map[jsonPointer]struct{}{}
+	for k := range r.subschemasProcessed {
+		processed[k] = struct{}{}
+	}
+	resources := map[jsonPointer]*resource{}
+	for k, v := range r.resources {
+		resources[k] = v.clone()
+	}
+	return &root{
+		url:                 r.url,
+		doc:                 r.doc,
+		resources:           resources,
+		subschemasProcessed: processed,
+	}
+}
+
+// --
+
+type resource struct {
+	ptr            jsonPointer
+	id             url
+	dialect        dialect
+	anchors        map[anchor]jsonPointer
+	dynamicAnchors []anchor
+}
+
+func newResource(ptr jsonPointer, id url) *resource {
+	return &resource{ptr: ptr, id: id, anchors: make(map[anchor]jsonPointer)}
+}
+
+func (res *resource) clone() *resource {
+	anchors := map[anchor]jsonPointer{}
+	for k, v := range res.anchors {
+		anchors[k] = v
+	}
+	return &resource{
+		ptr:            res.ptr,
+		id:             res.id,
+		dialect:        res.dialect,
+		anchors:        anchors,
+		dynamicAnchors: slices.Clone(res.dynamicAnchors),
+	}
+}
+
+//--
+
+type UnsupportedVocabularyError struct {
+	URL        string
+	Vocabulary string
+}
+
+func (e *UnsupportedVocabularyError) Error() string {
+	return fmt.Sprintf("unsupported vocabulary %q in %q", e.Vocabulary, e.URL)
+}
+
+// --
+
+type AnchorNotFoundError struct {
+	URL       string
+	Reference string
+}
+
+func (e *AnchorNotFoundError) Error() string {
+	return fmt.Sprintf("anchor in %q not found in schema %q", e.Reference, e.URL)
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/roots.go
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/roots.go
@@ -1,0 +1,286 @@
+package jsonschema
+
+import (
+	"fmt"
+	"strings"
+)
+
+type roots struct {
+	defaultDraft *Draft
+	roots        map[url]*root
+	loader       defaultLoader
+	regexpEngine RegexpEngine
+	vocabularies map[string]*Vocabulary
+	assertVocabs bool
+}
+
+func newRoots() *roots {
+	return &roots{
+		defaultDraft: draftLatest,
+		roots:        map[url]*root{},
+		loader: defaultLoader{
+			docs:   map[url]any{},
+			loader: FileLoader{},
+		},
+		regexpEngine: goRegexpCompile,
+		vocabularies: map[string]*Vocabulary{},
+	}
+}
+
+func (rr *roots) orLoad(u url) (*root, error) {
+	if r, ok := rr.roots[u]; ok {
+		return r, nil
+	}
+	doc, err := rr.loader.load(u)
+	if err != nil {
+		return nil, err
+	}
+	return rr.addRoot(u, doc)
+}
+
+func (rr *roots) addRoot(u url, doc any) (*root, error) {
+	r := &root{
+		url:                 u,
+		doc:                 doc,
+		resources:           map[jsonPointer]*resource{},
+		subschemasProcessed: map[jsonPointer]struct{}{},
+	}
+	if err := rr.collectResources(r, doc, u, "", dialect{rr.defaultDraft, nil}); err != nil {
+		return nil, err
+	}
+	if !strings.HasPrefix(u.String(), "http://json-schema.org/") &&
+		!strings.HasPrefix(u.String(), "https://json-schema.org/") {
+		if err := rr.validate(r, doc, ""); err != nil {
+			return nil, err
+		}
+	}
+
+	rr.roots[u] = r
+	return r, nil
+}
+
+func (rr *roots) resolveFragment(uf urlFrag) (urlPtr, error) {
+	r, err := rr.orLoad(uf.url)
+	if err != nil {
+		return urlPtr{}, err
+	}
+	return r.resolveFragment(uf.frag)
+}
+
+func (rr *roots) collectResources(r *root, sch any, base url, schPtr jsonPointer, fallback dialect) error {
+	if _, ok := r.subschemasProcessed[schPtr]; ok {
+		return nil
+	}
+	if err := rr._collectResources(r, sch, base, schPtr, fallback); err != nil {
+		return err
+	}
+	r.subschemasProcessed[schPtr] = struct{}{}
+	return nil
+}
+
+func (rr *roots) _collectResources(r *root, sch any, base url, schPtr jsonPointer, fallback dialect) error {
+	obj, ok := sch.(map[string]any)
+	if !ok {
+		if schPtr.isEmpty() {
+			// root resource
+			res := newResource(schPtr, base)
+			res.dialect = fallback
+			r.resources[schPtr] = res
+		}
+		return nil
+	}
+
+	hasSchema := false
+	if sch, ok := obj["$schema"]; ok {
+		if _, ok := sch.(string); ok {
+			hasSchema = true
+		}
+	}
+
+	draft, err := rr.loader.getDraft(urlPtr{r.url, schPtr}, sch, fallback.draft, map[url]struct{}{})
+	if err != nil {
+		return err
+	}
+	id := draft.getID(obj)
+	if id == "" && !schPtr.isEmpty() {
+		// ignore $schema
+		draft = fallback.draft
+		hasSchema = false
+		id = draft.getID(obj)
+	}
+
+	var res *resource
+	if id != "" {
+		uf, err := base.join(id)
+		if err != nil {
+			loc := urlPtr{r.url, schPtr}
+			return &ParseIDError{loc.String()}
+		}
+		base = uf.url
+		res = newResource(schPtr, base)
+	} else if schPtr.isEmpty() {
+		// root resource
+		res = newResource(schPtr, base)
+	}
+
+	if res != nil {
+		found := false
+		for _, res := range r.resources {
+			if res.id == base {
+				found = true
+				if res.ptr != schPtr {
+					return &DuplicateIDError{base.String(), r.url.String(), string(schPtr), string(res.ptr)}
+				}
+			}
+		}
+		if !found {
+			if hasSchema {
+				vocabs, err := rr.loader.getMetaVocabs(sch, draft, rr.vocabularies)
+				if err != nil {
+					return err
+				}
+				res.dialect = dialect{draft, vocabs}
+			} else {
+				res.dialect = fallback
+			}
+			r.resources[schPtr] = res
+		}
+	}
+
+	var baseRes *resource
+	for _, res := range r.resources {
+		if res.id == base {
+			baseRes = res
+			break
+		}
+	}
+	if baseRes == nil {
+		panic("baseres is nil")
+	}
+
+	// found base resource
+	if err := r.collectAnchors(sch, schPtr, baseRes); err != nil {
+		return err
+	}
+
+	// process subschemas
+	subschemas := map[jsonPointer]any{}
+	for _, sp := range draft.subschemas {
+		ss := sp.collect(obj, schPtr)
+		for k, v := range ss {
+			subschemas[k] = v
+		}
+	}
+	for _, vocab := range baseRes.dialect.activeVocabs(true, rr.vocabularies) {
+		if v := rr.vocabularies[vocab]; v != nil {
+			for _, sp := range v.Subschemas {
+				ss := sp.collect(obj, schPtr)
+				for k, v := range ss {
+					subschemas[k] = v
+				}
+			}
+		}
+	}
+	for ptr, v := range subschemas {
+		if err := rr.collectResources(r, v, base, ptr, baseRes.dialect); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (rr *roots) ensureSubschema(up urlPtr) error {
+	r, err := rr.orLoad(up.url)
+	if err != nil {
+		return err
+	}
+	if _, ok := r.subschemasProcessed[up.ptr]; ok {
+		return nil
+	}
+	v, err := up.lookup(r.doc)
+	if err != nil {
+		return err
+	}
+	rClone := r.clone()
+	if err := rr.addSubschema(rClone, up.ptr); err != nil {
+		return err
+	}
+	if err := rr.validate(rClone, v, up.ptr); err != nil {
+		return err
+	}
+	rr.roots[r.url] = rClone
+	return nil
+}
+
+func (rr *roots) addSubschema(r *root, ptr jsonPointer) error {
+	v, err := (&urlPtr{r.url, ptr}).lookup(r.doc)
+	if err != nil {
+		return err
+	}
+	base := r.resource(ptr)
+	baseURL := base.id
+	if err := rr.collectResources(r, v, baseURL, ptr, base.dialect); err != nil {
+		return err
+	}
+
+	// collect anchors
+	if _, ok := r.resources[ptr]; !ok {
+		res := r.resource(ptr)
+		if err := r.collectAnchors(v, ptr, res); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (rr *roots) validate(r *root, v any, ptr jsonPointer) error {
+	dialect := r.resource(ptr).dialect
+	meta := dialect.getSchema(rr.assertVocabs, rr.vocabularies)
+	if err := meta.validate(v, rr.regexpEngine, meta, r.resources, rr.assertVocabs, rr.vocabularies); err != nil {
+		up := urlPtr{r.url, ptr}
+		return &SchemaValidationError{URL: up.String(), Err: err}
+	}
+	return nil
+}
+
+// --
+
+type InvalidMetaSchemaURLError struct {
+	URL string
+	Err error
+}
+
+func (e *InvalidMetaSchemaURLError) Error() string {
+	return fmt.Sprintf("invalid $schema in %q: %v", e.URL, e.Err)
+}
+
+// --
+
+type UnsupportedDraftError struct {
+	URL string
+}
+
+func (e *UnsupportedDraftError) Error() string {
+	return fmt.Sprintf("draft %q is not supported", e.URL)
+}
+
+// --
+
+type MetaSchemaCycleError struct {
+	URL string
+}
+
+func (e *MetaSchemaCycleError) Error() string {
+	return fmt.Sprintf("cycle in resolving $schema in %q", e.URL)
+}
+
+// --
+
+type MetaSchemaMismatchError struct {
+	URL string
+}
+
+func (e *MetaSchemaMismatchError) Error() string {
+	return fmt.Sprintf("$schema in %q does not match with $schema in root", e.URL)
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/schema.go
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/schema.go
@@ -1,0 +1,254 @@
+package jsonschema
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+)
+
+// Schema is the representation of a compiled
+// jsonschema.
+type Schema struct {
+	up                urlPtr
+	resource          *Schema
+	dynamicAnchors    map[string]*Schema
+	allPropsEvaluated bool
+	allItemsEvaluated bool
+	numItemsEvaluated int
+
+	DraftVersion int
+	Location     string
+
+	// type agnostic --
+	Bool            *bool // boolean schema
+	ID              string
+	Ref             *Schema
+	Anchor          string
+	RecursiveRef    *Schema
+	RecursiveAnchor bool
+	DynamicRef      *DynamicRef
+	DynamicAnchor   string // "" if not specified
+	Types           *Types
+	Enum            *Enum
+	Const           *any
+	Not             *Schema
+	AllOf           []*Schema
+	AnyOf           []*Schema
+	OneOf           []*Schema
+	If              *Schema
+	Then            *Schema
+	Else            *Schema
+	Format          *Format
+
+	// object --
+	MaxProperties         *int
+	MinProperties         *int
+	Required              []string
+	PropertyNames         *Schema
+	Properties            map[string]*Schema
+	PatternProperties     map[Regexp]*Schema
+	AdditionalProperties  any            // nil or bool or *Schema
+	Dependencies          map[string]any // value is []string or *Schema
+	DependentRequired     map[string][]string
+	DependentSchemas      map[string]*Schema
+	UnevaluatedProperties *Schema
+
+	// array --
+	MinItems         *int
+	MaxItems         *int
+	UniqueItems      bool
+	Contains         *Schema
+	MinContains      *int
+	MaxContains      *int
+	Items            any // nil or []*Schema or *Schema
+	AdditionalItems  any // nil or bool or *Schema
+	PrefixItems      []*Schema
+	Items2020        *Schema
+	UnevaluatedItems *Schema
+
+	// string --
+	MinLength        *int
+	MaxLength        *int
+	Pattern          Regexp
+	ContentEncoding  *Decoder
+	ContentMediaType *MediaType
+	ContentSchema    *Schema
+
+	// number --
+	Maximum          *big.Rat
+	Minimum          *big.Rat
+	ExclusiveMaximum *big.Rat
+	ExclusiveMinimum *big.Rat
+	MultipleOf       *big.Rat
+
+	Extensions []SchemaExt
+
+	// annotations --
+	Title       string
+	Description string
+	Default     *any
+	Comment     string
+	ReadOnly    bool
+	WriteOnly   bool
+	Examples    []any
+	Deprecated  bool
+}
+
+// --
+
+type jsonType int
+
+const (
+	invalidType jsonType = 0
+	nullType    jsonType = 1 << iota
+	booleanType
+	numberType
+	integerType
+	stringType
+	arrayType
+	objectType
+)
+
+func typeOf(v any) jsonType {
+	switch v.(type) {
+	case nil:
+		return nullType
+	case bool:
+		return booleanType
+	case json.Number, float32, float64, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		return numberType
+	case string:
+		return stringType
+	case []any:
+		return arrayType
+	case map[string]any:
+		return objectType
+	default:
+		return invalidType
+	}
+}
+
+func typeFromString(s string) jsonType {
+	switch s {
+	case "null":
+		return nullType
+	case "boolean":
+		return booleanType
+	case "number":
+		return numberType
+	case "integer":
+		return integerType
+	case "string":
+		return stringType
+	case "array":
+		return arrayType
+	case "object":
+		return objectType
+	}
+	return invalidType
+}
+
+func (jt jsonType) String() string {
+	switch jt {
+	case nullType:
+		return "null"
+	case booleanType:
+		return "boolean"
+	case numberType:
+		return "number"
+	case integerType:
+		return "integer"
+	case stringType:
+		return "string"
+	case arrayType:
+		return "array"
+	case objectType:
+		return "object"
+	}
+	return ""
+}
+
+// --
+
+// Types encapsulates list of json value types.
+type Types int
+
+func newTypes(v any) *Types {
+	var types Types
+	switch v := v.(type) {
+	case string:
+		types.Add(v)
+	case []any:
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				types.Add(s)
+			}
+		}
+	}
+	if types.IsEmpty() {
+		return nil
+	}
+	return &types
+}
+
+func (tt Types) IsEmpty() bool {
+	return tt == 0
+}
+
+// Add specified json type. If typ is
+// not valid json type it is ignored.
+func (tt *Types) Add(typ string) {
+	tt.add(typeFromString(typ))
+}
+
+func (tt *Types) add(t jsonType) {
+	*tt = Types(int(*tt) | int(t))
+}
+
+func (tt Types) contains(t jsonType) bool {
+	return int(tt)&int(t) != 0
+}
+
+func (tt Types) ToStrings() []string {
+	types := []jsonType{
+		nullType, booleanType, numberType, integerType,
+		stringType, arrayType, objectType,
+	}
+	var arr []string
+	for _, t := range types {
+		if tt.contains(t) {
+			arr = append(arr, t.String())
+		}
+	}
+	return arr
+}
+
+func (tt Types) String() string {
+	return fmt.Sprintf("%v", tt.ToStrings())
+}
+
+// --
+
+type Enum struct {
+	Values []any
+	types  Types
+}
+
+func newEnum(arr []any) *Enum {
+	var types Types
+	for _, item := range arr {
+		types.add(typeOf(item))
+	}
+	return &Enum{arr, types}
+}
+
+// --
+
+type DynamicRef struct {
+	Ref    *Schema
+	Anchor string // "" if not specified
+}
+
+func newSchema(up urlPtr) *Schema {
+	return &Schema{up: up, Location: up.String()}
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/util.go
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/util.go
@@ -1,0 +1,464 @@
+package jsonschema
+
+import (
+	"encoding/json"
+	"fmt"
+	"hash/maphash"
+	"math/big"
+	gourl "net/url"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v6/kind"
+	"golang.org/x/text/message"
+)
+
+// --
+
+type url (string)
+
+func (u url) String() string {
+	return string(u)
+}
+
+func (u url) join(ref string) (*urlFrag, error) {
+	base, err := gourl.Parse(string(u))
+	if err != nil {
+		return nil, &ParseURLError{URL: u.String(), Err: err}
+	}
+
+	ref, frag, err := splitFragment(ref)
+	if err != nil {
+		return nil, err
+	}
+	refURL, err := gourl.Parse(ref)
+	if err != nil {
+		return nil, &ParseURLError{URL: ref, Err: err}
+	}
+	resolved := base.ResolveReference(refURL)
+
+	// see https://github.com/golang/go/issues/66084 (net/url: ResolveReference ignores Opaque value)
+	if !refURL.IsAbs() && base.Opaque != "" {
+		resolved.Opaque = base.Opaque
+	}
+
+	return &urlFrag{url: url(resolved.String()), frag: frag}, nil
+}
+
+// --
+
+type jsonPointer string
+
+func escape(tok string) string {
+	tok = strings.ReplaceAll(tok, "~", "~0")
+	tok = strings.ReplaceAll(tok, "/", "~1")
+	return tok
+}
+
+func unescape(tok string) (string, bool) {
+	tilde := strings.IndexByte(tok, '~')
+	if tilde == -1 {
+		return tok, true
+	}
+	sb := new(strings.Builder)
+	for {
+		sb.WriteString(tok[:tilde])
+		tok = tok[tilde+1:]
+		if tok == "" {
+			return "", false
+		}
+		switch tok[0] {
+		case '0':
+			sb.WriteByte('~')
+		case '1':
+			sb.WriteByte('/')
+		default:
+			return "", false
+		}
+		tok = tok[1:]
+		tilde = strings.IndexByte(tok, '~')
+		if tilde == -1 {
+			sb.WriteString(tok)
+			break
+		}
+	}
+	return sb.String(), true
+}
+
+func (ptr jsonPointer) isEmpty() bool {
+	return string(ptr) == ""
+}
+
+func (ptr jsonPointer) concat(next jsonPointer) jsonPointer {
+	return jsonPointer(fmt.Sprintf("%s%s", ptr, next))
+}
+
+func (ptr jsonPointer) append(tok string) jsonPointer {
+	return jsonPointer(fmt.Sprintf("%s/%s", ptr, escape(tok)))
+}
+
+func (ptr jsonPointer) append2(tok1, tok2 string) jsonPointer {
+	return jsonPointer(fmt.Sprintf("%s/%s/%s", ptr, escape(tok1), escape(tok2)))
+}
+
+// --
+
+type anchor string
+
+// --
+
+type fragment string
+
+func decode(frag string) (string, error) {
+	return gourl.PathUnescape(frag)
+}
+
+// avoids escaping /.
+func encode(frag string) string {
+	var sb strings.Builder
+	for i, tok := range strings.Split(frag, "/") {
+		if i > 0 {
+			sb.WriteByte('/')
+		}
+		sb.WriteString(gourl.PathEscape(tok))
+	}
+	return sb.String()
+}
+
+func splitFragment(str string) (string, fragment, error) {
+	u, f := split(str)
+	f, err := decode(f)
+	if err != nil {
+		return "", fragment(""), &ParseURLError{URL: str, Err: err}
+	}
+	return u, fragment(f), nil
+}
+
+func split(str string) (string, string) {
+	hash := strings.IndexByte(str, '#')
+	if hash == -1 {
+		return str, ""
+	}
+	return str[:hash], str[hash+1:]
+}
+
+func (frag fragment) convert() any {
+	str := string(frag)
+	if str == "" || strings.HasPrefix(str, "/") {
+		return jsonPointer(str)
+	}
+	return anchor(str)
+}
+
+// --
+
+type urlFrag struct {
+	url  url
+	frag fragment
+}
+
+func startsWithWindowsDrive(s string) bool {
+	if s != "" && strings.HasPrefix(s[1:], `:\`) {
+		return (s[0] >= 'a' && s[0] <= 'z') || (s[0] >= 'A' && s[0] <= 'Z')
+	}
+	return false
+}
+
+func absolute(input string) (*urlFrag, error) {
+	u, frag, err := splitFragment(input)
+	if err != nil {
+		return nil, err
+	}
+
+	// if windows absolute file path, convert to file url
+	// because: net/url parses driver name as scheme
+	if runtime.GOOS == "windows" && startsWithWindowsDrive(u) {
+		u = "file:///" + filepath.ToSlash(u)
+	}
+
+	gourl, err := gourl.Parse(u)
+	if err != nil {
+		return nil, &ParseURLError{URL: input, Err: err}
+	}
+	if gourl.IsAbs() {
+		return &urlFrag{url(u), frag}, nil
+	}
+
+	// avoid filesystem api in wasm
+	if runtime.GOOS != "js" {
+		abs, err := filepath.Abs(u)
+		if err != nil {
+			return nil, &ParseURLError{URL: input, Err: err}
+		}
+		u = abs
+	}
+	if !strings.HasPrefix(u, "/") {
+		u = "/" + u
+	}
+	u = "file://" + filepath.ToSlash(u)
+
+	_, err = gourl.Parse(u)
+	if err != nil {
+		return nil, &ParseURLError{URL: input, Err: err}
+	}
+	return &urlFrag{url: url(u), frag: frag}, nil
+}
+
+func (uf *urlFrag) String() string {
+	return fmt.Sprintf("%s#%s", uf.url, encode(string(uf.frag)))
+}
+
+// --
+
+type urlPtr struct {
+	url url
+	ptr jsonPointer
+}
+
+func (up *urlPtr) lookup(v any) (any, error) {
+	for _, tok := range strings.Split(string(up.ptr), "/")[1:] {
+		tok, ok := unescape(tok)
+		if !ok {
+			return nil, &InvalidJsonPointerError{up.String()}
+		}
+		switch val := v.(type) {
+		case map[string]any:
+			if pvalue, ok := val[tok]; ok {
+				v = pvalue
+				continue
+			}
+		case []any:
+			if index, err := strconv.Atoi(tok); err == nil {
+				if index >= 0 && index < len(val) {
+					v = val[index]
+					continue
+				}
+			}
+		}
+		return nil, &JSONPointerNotFoundError{up.String()}
+	}
+	return v, nil
+}
+
+func (up *urlPtr) format(tok string) string {
+	return fmt.Sprintf("%s#%s/%s", up.url, encode(string(up.ptr)), encode(escape(tok)))
+}
+
+func (up *urlPtr) String() string {
+	return fmt.Sprintf("%s#%s", up.url, encode(string(up.ptr)))
+}
+
+// --
+
+func minInt(i, j int) int {
+	if i < j {
+		return i
+	}
+	return j
+}
+
+func strVal(obj map[string]any, prop string) (string, bool) {
+	v, ok := obj[prop]
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	return s, ok
+}
+
+func isInteger(num any) bool {
+	rat, ok := new(big.Rat).SetString(fmt.Sprint(num))
+	return ok && rat.IsInt()
+}
+
+// quote returns single-quoted string.
+// used for embedding quoted strings in json.
+func quote(s string) string {
+	s = fmt.Sprintf("%q", s)
+	s = strings.ReplaceAll(s, `\"`, `"`)
+	s = strings.ReplaceAll(s, `'`, `\'`)
+	return "'" + s[1:len(s)-1] + "'"
+}
+
+func equals(v1, v2 any) (bool, ErrorKind) {
+	switch v1 := v1.(type) {
+	case map[string]any:
+		v2, ok := v2.(map[string]any)
+		if !ok || len(v1) != len(v2) {
+			return false, nil
+		}
+		for k, val1 := range v1 {
+			val2, ok := v2[k]
+			if !ok {
+				return false, nil
+			}
+			if ok, k := equals(val1, val2); !ok || k != nil {
+				return ok, k
+			}
+		}
+		return true, nil
+	case []any:
+		v2, ok := v2.([]any)
+		if !ok || len(v1) != len(v2) {
+			return false, nil
+		}
+		for i := range v1 {
+			if ok, k := equals(v1[i], v2[i]); !ok || k != nil {
+				return ok, k
+			}
+		}
+		return true, nil
+	case nil:
+		return v2 == nil, nil
+	case bool:
+		v2, ok := v2.(bool)
+		return ok && v1 == v2, nil
+	case string:
+		v2, ok := v2.(string)
+		return ok && v1 == v2, nil
+	case json.Number, float32, float64, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		num1, ok1 := new(big.Rat).SetString(fmt.Sprint(v1))
+		num2, ok2 := new(big.Rat).SetString(fmt.Sprint(v2))
+		return ok1 && ok2 && num1.Cmp(num2) == 0, nil
+	default:
+		return false, &kind.InvalidJsonValue{Value: v1}
+	}
+}
+
+func duplicates(arr []any) (int, int, ErrorKind) {
+	if len(arr) <= 20 {
+		for i := 1; i < len(arr); i++ {
+			for j := 0; j < i; j++ {
+				if ok, k := equals(arr[i], arr[j]); ok || k != nil {
+					return j, i, k
+				}
+			}
+		}
+		return -1, -1, nil
+	}
+
+	m := make(map[uint64][]int)
+	h := new(maphash.Hash)
+	for i, item := range arr {
+		h.Reset()
+		writeHash(item, h)
+		hash := h.Sum64()
+		indexes, ok := m[hash]
+		if ok {
+			for _, j := range indexes {
+				if ok, k := equals(item, arr[j]); ok || k != nil {
+					return j, i, k
+				}
+			}
+		}
+		indexes = append(indexes, i)
+		m[hash] = indexes
+	}
+	return -1, -1, nil
+}
+
+func writeHash(v any, h *maphash.Hash) ErrorKind {
+	switch v := v.(type) {
+	case map[string]any:
+		_ = h.WriteByte(0)
+		props := make([]string, 0, len(v))
+		for prop := range v {
+			props = append(props, prop)
+		}
+		slices.Sort(props)
+		for _, prop := range props {
+			writeHash(prop, h)
+			writeHash(v[prop], h)
+		}
+	case []any:
+		_ = h.WriteByte(1)
+		for _, item := range v {
+			writeHash(item, h)
+		}
+	case nil:
+		_ = h.WriteByte(2)
+	case bool:
+		_ = h.WriteByte(3)
+		if v {
+			_ = h.WriteByte(1)
+		} else {
+			_ = h.WriteByte(0)
+		}
+	case string:
+		_ = h.WriteByte(4)
+		_, _ = h.WriteString(v)
+	case json.Number, float32, float64, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		_ = h.WriteByte(5)
+		num, _ := new(big.Rat).SetString(fmt.Sprint(v))
+		_, _ = h.Write(num.Num().Bytes())
+		_, _ = h.Write(num.Denom().Bytes())
+	default:
+		return &kind.InvalidJsonValue{Value: v}
+	}
+	return nil
+}
+
+// --
+
+type ParseURLError struct {
+	URL string
+	Err error
+}
+
+func (e *ParseURLError) Error() string {
+	return fmt.Sprintf("error in parsing %q: %v", e.URL, e.Err)
+}
+
+// --
+
+type InvalidJsonPointerError struct {
+	URL string
+}
+
+func (e *InvalidJsonPointerError) Error() string {
+	return fmt.Sprintf("invalid json-pointer %q", e.URL)
+}
+
+// --
+
+type JSONPointerNotFoundError struct {
+	URL string
+}
+
+func (e *JSONPointerNotFoundError) Error() string {
+	return fmt.Sprintf("json-pointer in %q not found", e.URL)
+}
+
+// --
+
+type SchemaValidationError struct {
+	URL string
+	Err error
+}
+
+func (e *SchemaValidationError) Error() string {
+	return fmt.Sprintf("%q is not valid against metaschema: %v", e.URL, e.Err)
+}
+
+// --
+
+// LocalizableError is an error whose message is localizable.
+func LocalizableError(format string, args ...any) error {
+	return &localizableError{format, args}
+}
+
+type localizableError struct {
+	msg  string
+	args []any
+}
+
+func (e *localizableError) Error() string {
+	return fmt.Sprintf(e.msg, e.args...)
+}
+
+func (e *localizableError) LocalizedError(p *message.Printer) string {
+	return p.Sprintf(e.msg, e.args...)
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/validator.go
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/validator.go
@@ -1,0 +1,975 @@
+package jsonschema
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"slices"
+	"strconv"
+	"unicode/utf8"
+
+	"github.com/santhosh-tekuri/jsonschema/v6/kind"
+	"golang.org/x/text/message"
+)
+
+func (sch *Schema) Validate(v any) error {
+	return sch.validate(v, nil, nil, nil, false, nil)
+}
+
+func (sch *Schema) validate(v any, regexpEngine RegexpEngine, meta *Schema, resources map[jsonPointer]*resource, assertVocabs bool, vocabularies map[string]*Vocabulary) error {
+	vd := validator{
+		v:            v,
+		vloc:         make([]string, 0, 8),
+		sch:          sch,
+		scp:          &scope{sch, "", 0, nil},
+		uneval:       unevalFrom(v, sch, false),
+		errors:       nil,
+		boolResult:   false,
+		regexpEngine: regexpEngine,
+		meta:         meta,
+		resources:    resources,
+		assertVocabs: assertVocabs,
+		vocabularies: vocabularies,
+	}
+	if _, err := vd.validate(); err != nil {
+		verr := err.(*ValidationError)
+		var causes []*ValidationError
+		if _, ok := verr.ErrorKind.(*kind.Group); ok {
+			causes = verr.Causes
+		} else {
+			causes = []*ValidationError{verr}
+		}
+		return &ValidationError{
+			SchemaURL:        sch.Location,
+			InstanceLocation: nil,
+			ErrorKind:        &kind.Schema{Location: sch.Location},
+			Causes:           causes,
+		}
+	}
+
+	return nil
+}
+
+type validator struct {
+	v            any
+	vloc         []string
+	sch          *Schema
+	scp          *scope
+	uneval       *uneval
+	errors       []*ValidationError
+	boolResult   bool // is interested to know valid or not (but not actuall error)
+	regexpEngine RegexpEngine
+
+	// meta validation
+	meta         *Schema                   // set only when validating with metaschema
+	resources    map[jsonPointer]*resource // resources which should be validated with their dialect
+	assertVocabs bool
+	vocabularies map[string]*Vocabulary
+}
+
+func (vd *validator) validate() (*uneval, error) {
+	s := vd.sch
+	v := vd.v
+
+	// boolean --
+	if s.Bool != nil {
+		if *s.Bool {
+			return vd.uneval, nil
+		} else {
+			return nil, vd.error(&kind.FalseSchema{})
+		}
+	}
+
+	// check cycle --
+	if scp := vd.scp.checkCycle(); scp != nil {
+		return nil, vd.error(&kind.RefCycle{
+			URL:              s.Location,
+			KeywordLocation1: vd.scp.kwLoc(),
+			KeywordLocation2: scp.kwLoc(),
+		})
+	}
+
+	t := typeOf(v)
+	if t == invalidType {
+		return nil, vd.error(&kind.InvalidJsonValue{Value: v})
+	}
+
+	// type --
+	if s.Types != nil && !s.Types.IsEmpty() {
+		matched := s.Types.contains(t) || (s.Types.contains(integerType) && t == numberType && isInteger(v))
+		if !matched {
+			return nil, vd.error(&kind.Type{Got: t.String(), Want: s.Types.ToStrings()})
+		}
+	}
+
+	// const --
+	if s.Const != nil {
+		ok, k := equals(v, *s.Const)
+		if k != nil {
+			return nil, vd.error(k)
+		} else if !ok {
+			return nil, vd.error(&kind.Const{Got: v, Want: *s.Const})
+		}
+	}
+
+	// enum --
+	if s.Enum != nil {
+		matched := s.Enum.types.contains(typeOf(v))
+		if matched {
+			matched = false
+			for _, item := range s.Enum.Values {
+				ok, k := equals(v, item)
+				if k != nil {
+					return nil, vd.error(k)
+				} else if ok {
+					matched = true
+					break
+				}
+			}
+		}
+		if !matched {
+			return nil, vd.error(&kind.Enum{Got: v, Want: s.Enum.Values})
+		}
+	}
+
+	// format --
+	if s.Format != nil {
+		var err error
+		if s.Format.Name == "regex" && vd.regexpEngine != nil {
+			err = vd.regexpEngine.validate(v)
+		} else {
+			err = s.Format.Validate(v)
+		}
+		if err != nil {
+			return nil, vd.error(&kind.Format{Got: v, Want: s.Format.Name, Err: err})
+		}
+	}
+
+	// $ref --
+	if s.Ref != nil {
+		err := vd.validateRef(s.Ref, "$ref")
+		if s.DraftVersion < 2019 {
+			return vd.uneval, err
+		}
+		if err != nil {
+			vd.addErr(err)
+		}
+	}
+
+	// type specific validations --
+	switch v := v.(type) {
+	case map[string]any:
+		vd.objValidate(v)
+	case []any:
+		vd.arrValidate(v)
+	case string:
+		vd.strValidate(v)
+	case json.Number, float32, float64, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		vd.numValidate(v)
+	}
+
+	if len(vd.errors) == 0 || !vd.boolResult {
+		if s.DraftVersion >= 2019 {
+			vd.validateRefs()
+		}
+		vd.condValidate()
+
+		for _, ext := range s.Extensions {
+			ext.Validate(&ValidatorContext{vd}, v)
+		}
+
+		if s.DraftVersion >= 2019 {
+			vd.unevalValidate()
+		}
+	}
+
+	switch len(vd.errors) {
+	case 0:
+		return vd.uneval, nil
+	case 1:
+		return nil, vd.errors[0]
+	default:
+		verr := vd.error(&kind.Group{})
+		verr.Causes = vd.errors
+		return nil, verr
+	}
+}
+
+func (vd *validator) objValidate(obj map[string]any) {
+	s := vd.sch
+
+	// minProperties --
+	if s.MinProperties != nil {
+		if len(obj) < *s.MinProperties {
+			vd.addError(&kind.MinProperties{Got: len(obj), Want: *s.MinProperties})
+		}
+	}
+
+	// maxProperties --
+	if s.MaxProperties != nil {
+		if len(obj) > *s.MaxProperties {
+			vd.addError(&kind.MaxProperties{Got: len(obj), Want: *s.MaxProperties})
+		}
+	}
+
+	// required --
+	if len(s.Required) > 0 {
+		if missing := vd.findMissing(obj, s.Required); missing != nil {
+			vd.addError(&kind.Required{Missing: missing})
+		}
+	}
+
+	if vd.boolResult && len(vd.errors) > 0 {
+		return
+	}
+
+	// dependencies --
+	for pname, dep := range s.Dependencies {
+		if _, ok := obj[pname]; ok {
+			switch dep := dep.(type) {
+			case []string:
+				if missing := vd.findMissing(obj, dep); missing != nil {
+					vd.addError(&kind.Dependency{Prop: pname, Missing: missing})
+				}
+			case *Schema:
+				vd.addErr(vd.validateSelf(dep, "", false))
+			}
+		}
+	}
+
+	var additionalPros []string
+	for pname, pvalue := range obj {
+		if vd.boolResult && len(vd.errors) > 0 {
+			return
+		}
+		evaluated := false
+
+		// properties --
+		if sch, ok := s.Properties[pname]; ok {
+			evaluated = true
+			vd.addErr(vd.validateVal(sch, pvalue, pname))
+		}
+
+		// patternProperties --
+		for regex, sch := range s.PatternProperties {
+			if regex.MatchString(pname) {
+				evaluated = true
+				vd.addErr(vd.validateVal(sch, pvalue, pname))
+			}
+		}
+
+		if !evaluated && s.AdditionalProperties != nil {
+			evaluated = true
+			switch additional := s.AdditionalProperties.(type) {
+			case bool:
+				if !additional {
+					additionalPros = append(additionalPros, pname)
+				}
+			case *Schema:
+				vd.addErr(vd.validateVal(additional, pvalue, pname))
+			}
+		}
+
+		if evaluated {
+			delete(vd.uneval.props, pname)
+		}
+	}
+	if len(additionalPros) > 0 {
+		vd.addError(&kind.AdditionalProperties{Properties: additionalPros})
+	}
+
+	if s.DraftVersion == 4 {
+		return
+	}
+
+	// propertyNames --
+	if s.PropertyNames != nil {
+		for pname := range obj {
+			sch, meta, resources := s.PropertyNames, vd.meta, vd.resources
+			res := vd.metaResource(sch)
+			if res != nil {
+				meta = res.dialect.getSchema(vd.assertVocabs, vd.vocabularies)
+				sch = meta
+			}
+			if err := sch.validate(pname, vd.regexpEngine, meta, resources, vd.assertVocabs, vd.vocabularies); err != nil {
+				verr := err.(*ValidationError)
+				verr.SchemaURL = s.PropertyNames.Location
+				verr.ErrorKind = &kind.PropertyNames{Property: pname}
+				vd.addErr(verr)
+			}
+		}
+	}
+
+	if s.DraftVersion == 6 {
+		return
+	}
+
+	// dependentSchemas --
+	for pname, sch := range s.DependentSchemas {
+		if _, ok := obj[pname]; ok {
+			vd.addErr(vd.validateSelf(sch, "", false))
+		}
+	}
+
+	// dependentRequired --
+	for pname, reqd := range s.DependentRequired {
+		if _, ok := obj[pname]; ok {
+			if missing := vd.findMissing(obj, reqd); missing != nil {
+				vd.addError(&kind.DependentRequired{Prop: pname, Missing: missing})
+			}
+		}
+	}
+}
+
+func (vd *validator) arrValidate(arr []any) {
+	s := vd.sch
+
+	// minItems --
+	if s.MinItems != nil {
+		if len(arr) < *s.MinItems {
+			vd.addError(&kind.MinItems{Got: len(arr), Want: *s.MinItems})
+		}
+	}
+
+	// maxItems --
+	if s.MaxItems != nil {
+		if len(arr) > *s.MaxItems {
+			vd.addError(&kind.MaxItems{Got: len(arr), Want: *s.MaxItems})
+		}
+	}
+
+	// uniqueItems --
+	if s.UniqueItems && len(arr) > 1 {
+		i, j, k := duplicates(arr)
+		if k != nil {
+			vd.addError(k)
+		} else if i != -1 {
+			vd.addError(&kind.UniqueItems{Duplicates: [2]int{i, j}})
+		}
+	}
+
+	if s.DraftVersion < 2020 {
+		evaluated := 0
+
+		// items --
+		switch items := s.Items.(type) {
+		case *Schema:
+			for i, item := range arr {
+				vd.addErr(vd.validateVal(items, item, strconv.Itoa(i)))
+			}
+			evaluated = len(arr)
+		case []*Schema:
+			min := minInt(len(arr), len(items))
+			for i, item := range arr[:min] {
+				vd.addErr(vd.validateVal(items[i], item, strconv.Itoa(i)))
+			}
+			evaluated = min
+		}
+
+		// additionalItems --
+		if s.AdditionalItems != nil {
+			switch additional := s.AdditionalItems.(type) {
+			case bool:
+				if !additional && evaluated != len(arr) {
+					vd.addError(&kind.AdditionalItems{Count: len(arr) - evaluated})
+				}
+			case *Schema:
+				for i, item := range arr[evaluated:] {
+					vd.addErr(vd.validateVal(additional, item, strconv.Itoa(i)))
+				}
+			}
+		}
+	} else {
+		evaluated := minInt(len(s.PrefixItems), len(arr))
+
+		// prefixItems --
+		for i, item := range arr[:evaluated] {
+			vd.addErr(vd.validateVal(s.PrefixItems[i], item, strconv.Itoa(i)))
+		}
+
+		// items2020 --
+		if s.Items2020 != nil {
+			for i, item := range arr[evaluated:] {
+				vd.addErr(vd.validateVal(s.Items2020, item, strconv.Itoa(i)))
+			}
+		}
+	}
+
+	// contains --
+	if s.Contains != nil {
+		var errors []*ValidationError
+		var matched []int
+
+		for i, item := range arr {
+			if err := vd.validateVal(s.Contains, item, strconv.Itoa(i)); err != nil {
+				errors = append(errors, err.(*ValidationError))
+			} else {
+				matched = append(matched, i)
+				if s.DraftVersion >= 2020 {
+					delete(vd.uneval.items, i)
+				}
+			}
+		}
+
+		// minContains --
+		if s.MinContains != nil {
+			if len(matched) < *s.MinContains {
+				vd.addErrors(errors, &kind.MinContains{Got: matched, Want: *s.MinContains})
+			}
+		} else if len(matched) == 0 {
+			vd.addErrors(errors, &kind.Contains{})
+		}
+
+		// maxContains --
+		if s.MaxContains != nil {
+			if len(matched) > *s.MaxContains {
+				vd.addError(&kind.MaxContains{Got: matched, Want: *s.MaxContains})
+			}
+		}
+	}
+}
+
+func (vd *validator) strValidate(str string) {
+	s := vd.sch
+
+	strLen := -1
+	if s.MinLength != nil || s.MaxLength != nil {
+		strLen = utf8.RuneCount([]byte(str))
+	}
+
+	// minLength --
+	if s.MinLength != nil {
+		if strLen < *s.MinLength {
+			vd.addError(&kind.MinLength{Got: strLen, Want: *s.MinLength})
+		}
+	}
+
+	// maxLength --
+	if s.MaxLength != nil {
+		if strLen > *s.MaxLength {
+			vd.addError(&kind.MaxLength{Got: strLen, Want: *s.MaxLength})
+		}
+	}
+
+	// pattern --
+	if s.Pattern != nil {
+		if !s.Pattern.MatchString(str) {
+			vd.addError(&kind.Pattern{Got: str, Want: s.Pattern.String()})
+		}
+	}
+
+	if s.DraftVersion == 6 {
+		return
+	}
+
+	var err error
+
+	// contentEncoding --
+	decoded := []byte(str)
+	if s.ContentEncoding != nil {
+		decoded, err = s.ContentEncoding.Decode(str)
+		if err != nil {
+			decoded = nil
+			vd.addError(&kind.ContentEncoding{Want: s.ContentEncoding.Name, Err: err})
+		}
+	}
+
+	var deserialized *any
+	if decoded != nil && s.ContentMediaType != nil {
+		if s.ContentSchema == nil {
+			err = s.ContentMediaType.Validate(decoded)
+		} else {
+			var value any
+			value, err = s.ContentMediaType.UnmarshalJSON(decoded)
+			if err == nil {
+				deserialized = &value
+			}
+		}
+		if err != nil {
+			vd.addError(&kind.ContentMediaType{
+				Got:  decoded,
+				Want: s.ContentMediaType.Name,
+				Err:  err,
+			})
+		}
+	}
+
+	if deserialized != nil && s.ContentSchema != nil {
+		sch, meta, resources := s.ContentSchema, vd.meta, vd.resources
+		res := vd.metaResource(sch)
+		if res != nil {
+			meta = res.dialect.getSchema(vd.assertVocabs, vd.vocabularies)
+			sch = meta
+		}
+		if err = sch.validate(*deserialized, vd.regexpEngine, meta, resources, vd.assertVocabs, vd.vocabularies); err != nil {
+			verr := err.(*ValidationError)
+			verr.SchemaURL = s.Location
+			verr.ErrorKind = &kind.ContentSchema{}
+			vd.addErr(verr)
+		}
+	}
+}
+
+func (vd *validator) numValidate(v any) {
+	s := vd.sch
+
+	var numVal *big.Rat
+	num := func() *big.Rat {
+		if numVal == nil {
+			numVal, _ = new(big.Rat).SetString(fmt.Sprintf("%v", v))
+		}
+		return numVal
+	}
+
+	// minimum --
+	if s.Minimum != nil && num().Cmp(s.Minimum) < 0 {
+		vd.addError(&kind.Minimum{Got: num(), Want: s.Minimum})
+	}
+
+	// maximum --
+	if s.Maximum != nil && num().Cmp(s.Maximum) > 0 {
+		vd.addError(&kind.Maximum{Got: num(), Want: s.Maximum})
+	}
+
+	// exclusiveMinimum
+	if s.ExclusiveMinimum != nil && num().Cmp(s.ExclusiveMinimum) <= 0 {
+		vd.addError(&kind.ExclusiveMinimum{Got: num(), Want: s.ExclusiveMinimum})
+	}
+
+	// exclusiveMaximum
+	if s.ExclusiveMaximum != nil && num().Cmp(s.ExclusiveMaximum) >= 0 {
+		vd.addError(&kind.ExclusiveMaximum{Got: num(), Want: s.ExclusiveMaximum})
+	}
+
+	// multipleOf
+	if s.MultipleOf != nil {
+		if q := new(big.Rat).Quo(num(), s.MultipleOf); !q.IsInt() {
+			vd.addError(&kind.MultipleOf{Got: num(), Want: s.MultipleOf})
+		}
+	}
+}
+
+func (vd *validator) condValidate() {
+	s := vd.sch
+
+	// not --
+	if s.Not != nil {
+		if vd.validateSelf(s.Not, "", true) == nil {
+			vd.addError(&kind.Not{})
+		}
+	}
+
+	// allOf --
+	if len(s.AllOf) > 0 {
+		var errors []*ValidationError
+		for _, sch := range s.AllOf {
+			if err := vd.validateSelf(sch, "", false); err != nil {
+				errors = append(errors, err.(*ValidationError))
+				if vd.boolResult {
+					break
+				}
+			}
+		}
+		if len(errors) != 0 {
+			vd.addErrors(errors, &kind.AllOf{})
+		}
+	}
+
+	// anyOf
+	if len(s.AnyOf) > 0 {
+		var matched bool
+		var errors []*ValidationError
+		for _, sch := range s.AnyOf {
+			if err := vd.validateSelf(sch, "", false); err != nil {
+				errors = append(errors, err.(*ValidationError))
+			} else {
+				matched = true
+				// for uneval, all schemas must be evaluated
+				if vd.uneval.isEmpty() {
+					break
+				}
+			}
+		}
+		if !matched {
+			vd.addErrors(errors, &kind.AnyOf{})
+		}
+	}
+
+	// oneOf
+	if len(s.OneOf) > 0 {
+		var matched = -1
+		var errors []*ValidationError
+		for i, sch := range s.OneOf {
+			if err := vd.validateSelf(sch, "", matched != -1); err != nil {
+				if matched == -1 {
+					errors = append(errors, err.(*ValidationError))
+				}
+			} else {
+				if matched == -1 {
+					matched = i
+				} else {
+					vd.addError(&kind.OneOf{Subschemas: []int{matched, i}})
+					break
+				}
+			}
+		}
+		if matched == -1 {
+			vd.addErrors(errors, &kind.OneOf{Subschemas: nil})
+		}
+	}
+
+	// if, then, else --
+	if s.If != nil {
+		if vd.validateSelf(s.If, "", true) == nil {
+			if s.Then != nil {
+				vd.addErr(vd.validateSelf(s.Then, "", false))
+			}
+		} else if s.Else != nil {
+			vd.addErr(vd.validateSelf(s.Else, "", false))
+		}
+	}
+}
+
+func (vd *validator) unevalValidate() {
+	s := vd.sch
+
+	// unevaluatedProperties
+	if obj, ok := vd.v.(map[string]any); ok && s.UnevaluatedProperties != nil {
+		for pname := range vd.uneval.props {
+			if pvalue, ok := obj[pname]; ok {
+				vd.addErr(vd.validateVal(s.UnevaluatedProperties, pvalue, pname))
+			}
+		}
+		vd.uneval.props = nil
+	}
+
+	// unevaluatedItems
+	if arr, ok := vd.v.([]any); ok && s.UnevaluatedItems != nil {
+		for i := range vd.uneval.items {
+			vd.addErr(vd.validateVal(s.UnevaluatedItems, arr[i], strconv.Itoa(i)))
+		}
+		vd.uneval.items = nil
+	}
+}
+
+// validation helpers --
+
+func (vd *validator) validateSelf(sch *Schema, refKw string, boolResult bool) error {
+	scp := vd.scp.child(sch, refKw, vd.scp.vid)
+	uneval := unevalFrom(vd.v, sch, !vd.uneval.isEmpty())
+	subvd := validator{
+		v:            vd.v,
+		vloc:         vd.vloc,
+		sch:          sch,
+		scp:          scp,
+		uneval:       uneval,
+		errors:       nil,
+		boolResult:   vd.boolResult || boolResult,
+		regexpEngine: vd.regexpEngine,
+		meta:         vd.meta,
+		resources:    vd.resources,
+		assertVocabs: vd.assertVocabs,
+		vocabularies: vd.vocabularies,
+	}
+	subvd.handleMeta()
+	uneval, err := subvd.validate()
+	if err == nil {
+		vd.uneval.merge(uneval)
+	}
+	return err
+}
+
+func (vd *validator) validateVal(sch *Schema, v any, vtok string) error {
+	vloc := append(vd.vloc, vtok)
+	scp := vd.scp.child(sch, "", vd.scp.vid+1)
+	uneval := unevalFrom(v, sch, false)
+	subvd := validator{
+		v:            v,
+		vloc:         vloc,
+		sch:          sch,
+		scp:          scp,
+		uneval:       uneval,
+		errors:       nil,
+		boolResult:   vd.boolResult,
+		regexpEngine: vd.regexpEngine,
+		meta:         vd.meta,
+		resources:    vd.resources,
+		assertVocabs: vd.assertVocabs,
+		vocabularies: vd.vocabularies,
+	}
+	subvd.handleMeta()
+	_, err := subvd.validate()
+	return err
+}
+
+func (vd *validator) validateValue(sch *Schema, v any, vpath []string) error {
+	vloc := append(vd.vloc, vpath...)
+	scp := vd.scp.child(sch, "", vd.scp.vid+1)
+	uneval := unevalFrom(v, sch, false)
+	subvd := validator{
+		v:            v,
+		vloc:         vloc,
+		sch:          sch,
+		scp:          scp,
+		uneval:       uneval,
+		errors:       nil,
+		boolResult:   vd.boolResult,
+		regexpEngine: vd.regexpEngine,
+		meta:         vd.meta,
+		resources:    vd.resources,
+		assertVocabs: vd.assertVocabs,
+		vocabularies: vd.vocabularies,
+	}
+	subvd.handleMeta()
+	_, err := subvd.validate()
+	return err
+}
+
+func (vd *validator) metaResource(sch *Schema) *resource {
+	if sch != vd.meta {
+		return nil
+	}
+	ptr := ""
+	for _, tok := range vd.instanceLocation() {
+		ptr += "/"
+		ptr += escape(tok)
+	}
+	return vd.resources[jsonPointer(ptr)]
+}
+
+func (vd *validator) handleMeta() {
+	res := vd.metaResource(vd.sch)
+	if res == nil {
+		return
+	}
+	sch := res.dialect.getSchema(vd.assertVocabs, vd.vocabularies)
+	vd.meta = sch
+	vd.sch = sch
+}
+
+// reference validation --
+
+func (vd *validator) validateRef(sch *Schema, kw string) error {
+	err := vd.validateSelf(sch, kw, false)
+	if err != nil {
+		refErr := vd.error(&kind.Reference{Keyword: kw, URL: sch.Location})
+		verr := err.(*ValidationError)
+		if _, ok := verr.ErrorKind.(*kind.Group); ok {
+			refErr.Causes = verr.Causes
+		} else {
+			refErr.Causes = append(refErr.Causes, verr)
+		}
+		return refErr
+	}
+	return nil
+}
+
+func (vd *validator) resolveRecursiveAnchor(fallback *Schema) *Schema {
+	sch := fallback
+	scp := vd.scp
+	for scp != nil {
+		if scp.sch.resource.RecursiveAnchor {
+			sch = scp.sch
+		}
+		scp = scp.parent
+	}
+	return sch
+}
+
+func (vd *validator) resolveDynamicAnchor(name string, fallback *Schema) *Schema {
+	sch := fallback
+	scp := vd.scp
+	for scp != nil {
+		if dsch, ok := scp.sch.resource.dynamicAnchors[name]; ok {
+			sch = dsch
+		}
+		scp = scp.parent
+	}
+	return sch
+}
+
+func (vd *validator) validateRefs() {
+	// $recursiveRef --
+	if sch := vd.sch.RecursiveRef; sch != nil {
+		if sch.RecursiveAnchor {
+			sch = vd.resolveRecursiveAnchor(sch)
+		}
+		vd.addErr(vd.validateRef(sch, "$recursiveRef"))
+	}
+
+	// $dynamicRef --
+	if dref := vd.sch.DynamicRef; dref != nil {
+		sch := dref.Ref // initial target
+		if dref.Anchor != "" {
+			// $dynamicRef includes anchor
+			if sch.DynamicAnchor == dref.Anchor {
+				// initial target has matching $dynamicAnchor
+				sch = vd.resolveDynamicAnchor(dref.Anchor, sch)
+			}
+		}
+		vd.addErr(vd.validateRef(sch, "$dynamicRef"))
+	}
+}
+
+// error helpers --
+
+func (vd *validator) instanceLocation() []string {
+	return slices.Clone(vd.vloc)
+}
+
+func (vd *validator) error(kind ErrorKind) *ValidationError {
+	if vd.boolResult {
+		return &ValidationError{}
+	}
+	return &ValidationError{
+		SchemaURL:        vd.sch.Location,
+		InstanceLocation: vd.instanceLocation(),
+		ErrorKind:        kind,
+		Causes:           nil,
+	}
+}
+
+func (vd *validator) addErr(err error) {
+	if err != nil {
+		vd.errors = append(vd.errors, err.(*ValidationError))
+	}
+}
+
+func (vd *validator) addError(kind ErrorKind) {
+	vd.errors = append(vd.errors, vd.error(kind))
+}
+
+func (vd *validator) addErrors(errors []*ValidationError, kind ErrorKind) {
+	err := vd.error(kind)
+	err.Causes = errors
+	vd.errors = append(vd.errors, err)
+}
+
+func (vd *validator) findMissing(obj map[string]any, reqd []string) []string {
+	var missing []string
+	for _, pname := range reqd {
+		if _, ok := obj[pname]; !ok {
+			if vd.boolResult {
+				return []string{} // non-nil
+			}
+			missing = append(missing, pname)
+		}
+	}
+	return missing
+}
+
+// --
+
+type scope struct {
+	sch *Schema
+
+	// if empty, compute from self.sch and self.parent.sch.
+	// not empty, only when there is a jump i.e, $ref, $XXXRef
+	refKeyword string
+
+	// unique id of value being validated
+	// if two scopes validate same value, they will have
+	// same vid
+	vid int
+
+	parent *scope
+}
+
+func (sc *scope) child(sch *Schema, refKeyword string, vid int) *scope {
+	return &scope{sch, refKeyword, vid, sc}
+}
+
+func (sc *scope) checkCycle() *scope {
+	scp := sc.parent
+	for scp != nil {
+		if scp.vid != sc.vid {
+			break
+		}
+		if scp.sch == sc.sch {
+			return scp
+		}
+		scp = scp.parent
+	}
+	return nil
+}
+
+func (sc *scope) kwLoc() string {
+	var loc string
+	for sc.parent != nil {
+		if sc.refKeyword != "" {
+			loc = fmt.Sprintf("/%s%s", escape(sc.refKeyword), loc)
+		} else {
+			cur := sc.sch.Location
+			parent := sc.parent.sch.Location
+			loc = fmt.Sprintf("%s%s", cur[len(parent):], loc)
+		}
+		sc = sc.parent
+	}
+	return loc
+}
+
+// --
+
+type uneval struct {
+	props map[string]struct{}
+	items map[int]struct{}
+}
+
+func unevalFrom(v any, sch *Schema, callerNeeds bool) *uneval {
+	uneval := &uneval{}
+	switch v := v.(type) {
+	case map[string]any:
+		if !sch.allPropsEvaluated && (callerNeeds || sch.UnevaluatedProperties != nil) {
+			uneval.props = map[string]struct{}{}
+			for k := range v {
+				uneval.props[k] = struct{}{}
+			}
+		}
+	case []any:
+		if !sch.allItemsEvaluated && (callerNeeds || sch.UnevaluatedItems != nil) && sch.numItemsEvaluated < len(v) {
+			uneval.items = map[int]struct{}{}
+			for i := sch.numItemsEvaluated; i < len(v); i++ {
+				uneval.items[i] = struct{}{}
+			}
+		}
+	}
+	return uneval
+}
+
+func (ue *uneval) merge(other *uneval) {
+	for k := range ue.props {
+		if _, ok := other.props[k]; !ok {
+			delete(ue.props, k)
+		}
+	}
+	for i := range ue.items {
+		if _, ok := other.items[i]; !ok {
+			delete(ue.items, i)
+		}
+	}
+}
+
+func (ue *uneval) isEmpty() bool {
+	return len(ue.props) == 0 && len(ue.items) == 0
+}
+
+// --
+
+type ValidationError struct {
+	// absolute, dereferenced schema location.
+	SchemaURL string
+
+	// location of the JSON value within the instance being validated.
+	InstanceLocation []string
+
+	// kind of error
+	ErrorKind ErrorKind
+
+	// holds nested errors
+	Causes []*ValidationError
+}
+
+type ErrorKind interface {
+	KeywordPath() []string
+	LocalizedString(*message.Printer) string
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/vocab.go
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/vocab.go
@@ -1,0 +1,111 @@
+package jsonschema
+
+// CompilerContext provides helpers for
+// compiling a [Vocabulary].
+type CompilerContext struct {
+	c *objCompiler
+}
+
+func (ctx *CompilerContext) Enqueue(schPath []string) *Schema {
+	ptr := ctx.c.up.ptr
+	for _, tok := range schPath {
+		ptr = ptr.append(tok)
+	}
+	return ctx.c.enqueuePtr(ptr)
+}
+
+// Vocabulary defines a set of keywords, their syntax and
+// their semantics.
+type Vocabulary struct {
+	// URL identifier for this Vocabulary.
+	URL string
+
+	// Schema that is used to validate the keywords that is introduced by this
+	// vocabulary.
+	Schema *Schema
+
+	// Subschemas lists the possible locations of subschemas introduced by
+	// this vocabulary.
+	Subschemas []SchemaPath
+
+	// Compile compiles the keywords(introduced by this vocabulary) in obj into [SchemaExt].
+	// If obj does not contain any keywords introduced by this vocabulary, nil SchemaExt must
+	// be returned.
+	Compile func(ctx *CompilerContext, obj map[string]any) (SchemaExt, error)
+}
+
+// --
+
+// SchemaExt is compled form of vocabulary.
+type SchemaExt interface {
+	// Validate validates v against and errors if any are reported
+	// to ctx.
+	Validate(ctx *ValidatorContext, v any)
+}
+
+// ValidatorContext provides helpers for
+// validating with [SchemaExt].
+type ValidatorContext struct {
+	vd *validator
+}
+
+// ValueLocation returns location of value as jsonpath token array.
+func (ctx *ValidatorContext) ValueLocation() []string {
+	return ctx.vd.vloc
+}
+
+// Validate validates v with sch. vpath gives path of v from current context value.
+func (ctx *ValidatorContext) Validate(sch *Schema, v any, vpath []string) error {
+	switch len(vpath) {
+	case 0:
+		return ctx.vd.validateSelf(sch, "", false)
+	case 1:
+		return ctx.vd.validateVal(sch, v, vpath[0])
+	default:
+		return ctx.vd.validateValue(sch, v, vpath)
+	}
+}
+
+// EvaluatedProp marks given property of current object as evaluated.
+func (ctx *ValidatorContext) EvaluatedProp(pname string) {
+	delete(ctx.vd.uneval.props, pname)
+}
+
+// EvaluatedItem marks items at given index of current array as evaluated.
+func (ctx *ValidatorContext) EvaluatedItem(index int) {
+	delete(ctx.vd.uneval.items, index)
+}
+
+// AddError reports validation-error of given kind.
+func (ctx *ValidatorContext) AddError(k ErrorKind) {
+	ctx.vd.addError(k)
+}
+
+// AddErrors reports validation-errors of given kind.
+func (ctx *ValidatorContext) AddErrors(errors []*ValidationError, k ErrorKind) {
+	ctx.vd.addErrors(errors, k)
+}
+
+// AddErr reports the given err. This is typically used to report
+// the error created by subschema validation.
+//
+// NOTE that err must be of type *ValidationError.
+func (ctx *ValidatorContext) AddErr(err error) {
+	ctx.vd.addErr(err)
+}
+
+func (ctx *ValidatorContext) Equals(v1, v2 any) (bool, error) {
+	b, k := equals(v1, v2)
+	if k != nil {
+		return false, ctx.vd.error(k)
+	}
+	return b, nil
+}
+
+func (ctx *ValidatorContext) Duplicates(arr []any) (int, int, error) {
+	i, j, k := duplicates(arr)
+	if k != nil {
+		return -1, -1, ctx.vd.error(k)
+	}
+	return i, j, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -209,6 +209,10 @@ github.com/digitorus/timestamp
 # github.com/distribution/reference v0.6.0
 ## explicit; go 1.20
 github.com/distribution/reference
+# github.com/dlclark/regexp2 v1.12.0
+## explicit; go 1.13
+github.com/dlclark/regexp2
+github.com/dlclark/regexp2/syntax
 # github.com/docker/cli v29.4.0+incompatible
 ## explicit
 github.com/docker/cli/cli/config
@@ -730,6 +734,10 @@ github.com/prometheus/procfs/internal/util
 # github.com/rivo/uniseg v0.4.7
 ## explicit; go 1.18
 github.com/rivo/uniseg
+# github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
+## explicit; go 1.21
+github.com/santhosh-tekuri/jsonschema/v6
+github.com/santhosh-tekuri/jsonschema/v6/kind
 # github.com/sassoftware/relic v7.2.1+incompatible
 ## explicit
 github.com/sassoftware/relic/lib/pkcs7


### PR DESCRIPTION
Extract the manifest schema from the target AIB image, and use it to validate the manifest before triggering the build

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [X] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local manifest schema validation for image builds using the resolved builder image, with on-disk caching to speed up repeat validations.
  * Build progress now reports “Pulling image” while pods are still pending.
* **Bug Fixes**
  * Invalid manifests are rejected during build creation with a clear client error.
  * Operator config responses now include the resolved automotive image builder image by default when config is missing.
* **Tests**
  * Expanded unit and E2E coverage for schema extraction/validation/caching, builder-image selection priority, and pending-pod progress.
* **Documentation**
  * Documented `CAIB_SKIP_MANIFEST_VALIDATION` to skip local validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->