### PR TITLE
feat: add smoke suite and core E2E coverage

### DIFF
--- a/.github/workflows/e2e-lanes.yml
+++ b/.github/workflows/e2e-lanes.yml
@@ -36,9 +36,25 @@ jobs:
           COMMENT: ${{ github.event.comment.body }}
         run: |
           case "$COMMENT" in
+            /e2e-smoke*)
+              echo "label_filter=smoke" >> "$GITHUB_OUTPUT"
+              echo "lane_name=smoke" >> "$GITHUB_OUTPUT"
+              ;;
             /e2e-operator*)
               echo "label_filter=operator" >> "$GITHUB_OUTPUT"
               echo "lane_name=operator" >> "$GITHUB_OUTPUT"
+              ;;
+            /e2e-package-mode*)
+              echo "label_filter=package-mode" >> "$GITHUB_OUTPUT"
+              echo "lane_name=package-mode" >> "$GITHUB_OUTPUT"
+              ;;
+            /e2e-features*)
+              echo "label_filter=features" >> "$GITHUB_OUTPUT"
+              echo "lane_name=features" >> "$GITHUB_OUTPUT"
+              ;;
+            /e2e-container-build*)
+              echo "label_filter=container-build" >> "$GITHUB_OUTPUT"
+              echo "lane_name=container-build" >> "$GITHUB_OUTPUT"
               ;;
             /e2e-bootc*)
               echo "label_filter=bootc" >> "$GITHUB_OUTPUT"
@@ -54,7 +70,7 @@ jobs:
               ;;
             *)
               printf 'Unknown e2e command: %s\n' "$COMMENT"
-              printf 'Supported: /e2e-operator, /e2e-bootc, /e2e-auth, /e2e-test-all\n'
+              printf 'Supported: /e2e-smoke, /e2e-operator, /e2e-package-mode, /e2e-features, /e2e-bootc, /e2e-container-build, /e2e-auth, /e2e-test-all\n'
               exit 1
               ;;
           esac
@@ -129,10 +145,10 @@ jobs:
           E2E_NAMESPACE: ${{ needs.parse-comment.outputs.lane_name == 'all' && 'e2e-test-all' || format('e2e-{0}', needs.parse-comment.outputs.lane_name) }}
         run: |
           case "${{ needs.parse-comment.outputs.lane_name }}" in
-            operator|auth) test_timeout=15m ;;
-            bootc)         test_timeout=35m ;;
-            all)           test_timeout=45m ;;
-            *)             echo "Unknown lane: ${{ needs.parse-comment.outputs.lane_name }}" >&2; exit 1 ;;
+            smoke|operator|auth|features) test_timeout=5m ;;
+            bootc|package-mode) test_timeout=15m ;;
+            container-build|all) test_timeout=45m ;;
+            *)                   echo "Unknown lane: ${{ needs.parse-comment.outputs.lane_name }}" >&2; exit 1 ;;
           esac
           ginkgo_args=(-v -ginkgo.v -timeout "$test_timeout")
           if [ -n "$E2E_LABEL_FILTER" ]; then

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       label_filter:
-        description: 'Ginkgo label filter (e.g. "operator", "bootc", "auth"). Empty runs all.'
+        description: 'Ginkgo label filter (e.g. "smoke", "operator", "bootc", "container-build", "auth"). Empty runs all.'
         required: false
         default: ''
 
@@ -49,7 +49,7 @@ jobs:
       - name: Deploy Dex for OIDC tests
         if: >
           github.event.inputs.label_filter == 'auth' ||
-          github.event.inputs.label_filter == ''
+          (github.event.inputs.label_filter == '' && github.event_name != 'pull_request')
         run: hack/e2e/setup-dex.sh
 
       - name: Build caib CLI
@@ -64,16 +64,17 @@ jobs:
           REGISTRY_USERNAME: kind
           REGISTRY_PASSWORD: kind
           CAIB_SERVER: http://localhost:8080
-          E2E_LABEL_FILTER: ${{ github.event.inputs.label_filter || '' }}
-          E2E_NAMESPACE: ${{ github.event.inputs.label_filter && format('e2e-{0}', github.event.inputs.label_filter) || 'e2e-test-all' }}
+          E2E_LABEL_FILTER: ${{ github.event_name == 'pull_request' && 'smoke' || github.event.inputs.label_filter || '' }}
+          E2E_NAMESPACE: ${{ github.event_name == 'pull_request' && 'e2e-smoke' || (github.event.inputs.label_filter && format('e2e-{0}', github.event.inputs.label_filter) || 'e2e-test-all') }}
         run: |
           if [ -z "$E2E_LABEL_FILTER" ]; then
             test_timeout=45m
           else
             case "$E2E_LABEL_FILTER" in
-              operator|auth) test_timeout=15m ;;
-              bootc)         test_timeout=35m ;;
-              *)             test_timeout=45m ;;
+              smoke|operator|auth|features) test_timeout=5m ;;
+              bootc|package-mode) test_timeout=15m ;;
+              container-build)     test_timeout=45m ;;
+              *)                   test_timeout=45m ;;
             esac
           fi
           ginkgo_args=(-v -ginkgo.v -timeout "$test_timeout")

--- a/Makefile
+++ b/Makefile
@@ -116,30 +116,7 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
-# E2E test targets. Use test-e2e to run everything, or pick a lane:
-#   test-e2e-operator        - operator health, Tekton tasks, Build API
-#   test-e2e-bootc           - bootc container build via caib
-#   test-e2e-container-build - Shipwright container build via caib
-#   test-e2e-auth            - OIDC authentication (OpenShift only)
-.PHONY: test-e2e
-test-e2e:
-	go test ./test/e2e/ -v -ginkgo.v -timeout 45m
-
-.PHONY: test-e2e-operator
-test-e2e-operator:
-	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-operator} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="operator" -timeout 15m
-
-.PHONY: test-e2e-bootc
-test-e2e-bootc:
-	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-bootc} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="bootc" -timeout 35m
-
-.PHONY: test-e2e-container-build
-test-e2e-container-build:
-	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-container-build} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="container-build" -timeout 45m
-
-.PHONY: test-e2e-auth
-test-e2e-auth:
-	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-auth} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="auth" -timeout 15m
+include Makefile.e2e
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter

--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -1,0 +1,61 @@
+################################################################################
+# E2E (End-to-End) Testing Suite
+#
+# PURPOSE:
+#   This file defines targets for running Ginkgo-driven integration and 
+#   end-to-end tests against a live Kubernetes/OpenShift cluster.
+#
+# PREREQUISITES:
+#   - A configured Kubeconfig pointing to a running cluster.
+#   - Go and Ginkgo CLI installed.
+#
+# ENVIRONMENT VARIABLES:
+#   - E2E_NAMESPACE: The target namespace where tests will be executed.
+#                    Defaults to a specific suite namespace if not provided.
+################################################################################
+
+# Ginkgo timeouts — keep in sync with .github/workflows/e2e.yml and e2e-lanes.yml
+E2E_TIMEOUT_FAST  ?= 5m   # smoke, operator, auth, features
+E2E_TIMEOUT_SHORT ?= 15m  # bootc, package-mode
+E2E_TIMEOUT_LONG  ?= 45m  # full suite
+
+# E2E test targets. Use test-e2e to run everything, or pick a lane:
+#   test-e2e-smoke        - quick smoke tests (CRDs, OperatorConfig, Build API, CR lifecycle)
+#   test-e2e-operator     - operator health, Tekton tasks, Build API
+#   test-e2e-bootc           - bootc container build via caib
+#   test-e2e-container-build - Shipwright container build via caib
+#   test-e2e-auth            - OIDC authentication (OpenShift only)
+#   test-e2e-package-mode    - package mode builds
+#   test-e2e-features        - TTL, image propagation, Build API logs
+.PHONY: test-e2e
+# Full suite runs all labeled tests sequentially.
+test-e2e:
+	go test ./test/e2e/ -v -ginkgo.v -timeout $(E2E_TIMEOUT_LONG)
+
+.PHONY: test-e2e-smoke
+test-e2e-smoke:
+	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-smoke} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="smoke" -timeout $(E2E_TIMEOUT_FAST)
+
+.PHONY: test-e2e-operator
+test-e2e-operator:
+	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-operator} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="operator" -timeout $(E2E_TIMEOUT_FAST)
+
+.PHONY: test-e2e-bootc
+test-e2e-bootc:
+	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-bootc} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="bootc" -timeout $(E2E_TIMEOUT_SHORT)
+
+.PHONY: test-e2e-container-build
+test-e2e-container-build:
+	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-container-build} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="container-build" -timeout $(E2E_TIMEOUT_LONG)
+
+.PHONY: test-e2e-auth
+test-e2e-auth:
+	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-auth} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="auth" -timeout $(E2E_TIMEOUT_FAST)
+
+.PHONY: test-e2e-package-mode
+test-e2e-package-mode:
+	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-package-mode} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="package-mode" -timeout $(E2E_TIMEOUT_SHORT)
+
+.PHONY: test-e2e-features
+test-e2e-features:
+	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-features} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="features" -timeout $(E2E_TIMEOUT_FAST)

--- a/hack/run-e2e-local.sh
+++ b/hack/run-e2e-local.sh
@@ -15,11 +15,14 @@ usage() {
   printf 'Usage: %s [OPTIONS] [LANE]\n\n' "$(basename "$0")"
   printf 'Run e2e tests against a local CRC/OpenShift cluster.\n\n'
   printf 'Lanes:\n'
-  printf '  operator        - operator health, Tekton tasks, Build API\n'
-  printf '  bootc           - bootc container build via caib\n'
+  printf '  smoke         - quick smoke tests (CRDs, OperatorConfig, Build API, CR lifecycle)\n'
+  printf '  operator      - operator health, Tekton tasks, Build API\n'
+  printf '  bootc         - bootc container build via caib\n'
   printf '  container-build - Shipwright container build via caib\n'
-  printf '  auth            - OIDC authentication (OpenShift or Kind+Dex)\n'
-  printf '  all             - run all tests (default)\n\n'
+  printf '  auth          - OIDC authentication (OpenShift or Kind+Dex)\n'
+  printf '  package-mode  - package mode builds\n'
+  printf '  features      - TTL, image propagation, Build API logs\n'
+  printf '  all           - run all tests (default)\n\n'
   printf 'Options:\n'
   printf '  -h, --help    Show this help message and exit\n\n'
   printf 'Environment variables:\n'
@@ -38,7 +41,7 @@ esac
 
 E2E_LANE="${1:-}"
 case "$E2E_LANE" in
-  operator|bootc|auth|container-build)
+  smoke|operator|bootc|container-build|auth|package-mode|features)
     E2E_MAKE_TARGET="test-e2e-${E2E_LANE}"
     ;;
   ""|all)

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -80,27 +80,36 @@ If you want more control over the test environment:
 
 ## Test Lanes
 
-Tests are split into three independently-runnable lanes, each deployed into its own namespace:
+Tests are split into independently-runnable lanes, each deployed into its own namespace:
 
 | Lane | Label | Namespace | What it covers |
-|------|-------|-----------|---------------|
-| `operator` | `operator` | `e2e-operator` | Operator health, Tekton tasks/pipeline, Build API deployment |
+|------|-------|-----------|----------------|
+| `smoke` | `smoke` | `e2e-smoke` | CRDs, OperatorConfig, Build API endpoints, CR lifecycle, guard rails |
+| `operator` | `operator` | `e2e-operator` | Operator health, Tekton tasks/pipeline, Build API CRUD, ImageBuild lifecycle, error handling |
 | `bootc` | `bootc` | `e2e-bootc` | Bootc container build via caib CLI |
 | `auth` | `auth` | `e2e-auth` | OIDC authentication (OpenShift only) |
+| `package-mode` | `package-mode` | `e2e-package-mode` | Package mode disk image build (OpenShift only) |
+| `features` | `features` | `e2e-features` | TTL expiry, image propagation in Tekton Tasks, Build API log streaming |
 
 ### Running individual lanes
 
 ```bash
 # Via Makefile
+make test-e2e-smoke
 make test-e2e-operator
 make test-e2e-bootc
 make test-e2e-auth
+make test-e2e-package-mode
+make test-e2e-features
 make test-e2e              # all lanes
 
 # Via local runner (handles CRC/OpenShift setup)
+bash hack/run-e2e-local.sh smoke
 bash hack/run-e2e-local.sh operator
 bash hack/run-e2e-local.sh bootc
 bash hack/run-e2e-local.sh auth
+bash hack/run-e2e-local.sh package-mode
+bash hack/run-e2e-local.sh features
 bash hack/run-e2e-local.sh            # all lanes
 ```
 
@@ -110,19 +119,30 @@ Times measured on CRC (cluster already running):
 
 | Lane | macOS arm64 | Linux amd64 | `go test -timeout` |
 |------|-------------|-------------|-------------------|
-| `operator` | ~2 min | ~3 min | 15m |
-| `auth` | ~3 min | ~4 min | 15m |
-| `bootc` | ~7 min | ~33 min | 35m |
+| `smoke` | ~3 min | ~3 min | 5m |
+| `operator` | ~3 min | ~3 min | 5m |
+| `auth` | ~3 min | ~3 min | 5m |
+| `features` | ~4 min | ~4 min | 5m |
+| `bootc` | ~7 min | ~7 min | 15m |
+| `package-mode` | ~4 min | ~4 min | 15m |
 | all | ~8 min | ~36 min | 45m |
 
 ## Test Structure
 
 - `e2e_suite_test.go`: Suite setup, `BeforeSuite`/`AfterSuite`
-- `helpers_test.go`: Shared setup (`sync.Once`-based operator deploy, registry config, Build API access, caib credentials)
-- `operator_test.go`: Operator health lane (`Label("operator")`)
-- `bootc_build_test.go`: Bootc build lane (`Label("bootc")`)
-- `auth_test.go`: OIDC authentication lane (`Label("auth")`)
-- `../utils/`: Utility functions for test helpers
+- `helpers_test.go`: Shared helpers — `sync.Once`-based operator deploy, Build API access, caib credentials, and utility functions (`applyImageBuildCR`, `createBuildViaCaib`, `waitForImageBuildPhase`, etc.)
+- `operator_test.go`: Operator health checks (`Label("operator", "smoke")`)
+- `smoke_test.go`: CRD availability, OperatorConfig, Build API endpoints, CR lifecycle, negative/guard-rail tests (`Label("smoke")`)
+- `buildapi_test.go`: Build API CRUD via caib CLI and ownership enforcement (`Label("operator")`)
+- `imagebuild_lifecycle_test.go`: Export/push phase and build cancellation (`Label("operator")`)
+- `operatorconfig_e2e_test.go`: OperatorConfig osBuilds toggle (`Label("operator")`)
+- `error_handling_test.go`: Concurrent builds isolation (`Label("operator")`)
+- `bootc_build_test.go`: Bootc build and internal-registry build via caib (`Label("bootc")`, `Label("internal-registry")`)
+- `auth_test.go`: OIDC authentication (`Label("auth")`)
+- `package_build_test.go`: Package mode disk image build (`Label("package-mode")`)
+- `features_e2e_test.go`: TTL expiry, image propagation, Build API log streaming (`Label("features")`)
+- `manifest_validation_test.go`: caib manifest validation (`Label("manifest-validation")`)
+- `../utils/`: Utility functions for running commands and managing processes
 
 ## GitHub Actions
 
@@ -132,7 +152,7 @@ The e2e tests run automatically on:
 - Manual workflow dispatch (with optional `label_filter` input)
 
 Individual lanes can be triggered on PRs via comment commands:
-- `/e2e-operator`, `/e2e-bootc`, `/e2e-auth`, `/e2e-test-all`
+- `/e2e-smoke`, `/e2e-operator`, `/e2e-bootc`, `/e2e-auth`, `/e2e-package-mode`, `/e2e-features`, `/e2e-test-all`
 
 See `.github/workflows/e2e.yml` and `.github/workflows/e2e-lanes.yml` for the CI configuration.
 

--- a/test/e2e/auth_test.go
+++ b/test/e2e/auth_test.go
@@ -117,15 +117,37 @@ var _ = Describe("OIDC Authentication", Label("auth"), Ordered, func() {
 			}
 
 			client := newInsecureHTTPClient()
-			req, err := http.NewRequest("GET", caibServer+"/v1/builds", nil)
-			Expect(err).NotTo(HaveOccurred())
-			req.Header.Set("Authorization", "Bearer "+token)
-
-			resp, err := client.Do(req)
-			Expect(err).NotTo(HaveOccurred())
-			defer func() { _ = resp.Body.Close() }()
-			Expect(resp.StatusCode).To(Equal(http.StatusOK),
-				fmt.Sprintf("expected 200 with valid token, got %d", resp.StatusCode))
+			// Use Eventually when Dex is the issuer: the OIDC authenticator fetches
+			// the JWKS in the background after config is applied, so the first
+			// validation attempt may fail until the key material is ready.
+			if dexAvailable {
+				EventuallyWithOffset(1, func() error {
+					req, reqErr := http.NewRequest("GET", caibServer+"/v1/builds", nil)
+					if reqErr != nil {
+						return reqErr
+					}
+					req.Header.Set("Authorization", "Bearer "+token)
+					resp, respErr := client.Do(req)
+					if respErr != nil {
+						return respErr
+					}
+					defer func() { _ = resp.Body.Close() }()
+					if resp.StatusCode != http.StatusOK {
+						return fmt.Errorf("expected 200 with valid Dex token, got %d", resp.StatusCode)
+					}
+					return nil
+				}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+					"Build API did not accept valid Dex token in time")
+			} else {
+				req, err := http.NewRequest("GET", caibServer+"/v1/builds", nil)
+				Expect(err).NotTo(HaveOccurred())
+				req.Header.Set("Authorization", "Bearer "+token)
+				resp, err := client.Do(req)
+				Expect(err).NotTo(HaveOccurred())
+				defer func() { _ = resp.Body.Close() }()
+				Expect(resp.StatusCode).To(Equal(http.StatusOK),
+					fmt.Sprintf("expected 200 with valid token, got %d", resp.StatusCode))
+			}
 		})
 
 		It("should reject invalid token with 401", func() {

--- a/test/e2e/bootc_build_test.go
+++ b/test/e2e/bootc_build_test.go
@@ -32,10 +32,10 @@ import (
 const (
 	caibBuildManifest = "test/config/test-manifest.aib.yml"
 	caibBuildTimeout  = 30 * time.Minute
-	caibListTimeout   = 30 * time.Second
 )
 
 var _ = Describe("Bootc Container Build", Label("bootc"), Ordered, func() {
+	var actualBuildName string
 
 	BeforeAll(func() {
 		if registryHost == "" {
@@ -47,6 +47,15 @@ var _ = Describe("Bootc Container Build", Label("bootc"), Ordered, func() {
 		ensureCaibCredentials()
 	})
 
+	AfterAll(func() {
+		name := actualBuildName
+		if name == "" {
+			name = "e2e-test-build-image"
+		}
+		deleteImageBuildCR(name)
+	})
+
+	// #20 — Full lifecycle (Pending→Building→Completed) via caib CLI
 	It("should build a container image via caib", func() {
 		containerBuildName := "e2e-test-build-image"
 
@@ -67,14 +76,13 @@ var _ = Describe("Bootc Container Build", Label("bootc"), Ordered, func() {
 
 		By("launching bootc container build")
 		go func() {
-			cmd := utils.NewCaibCommand(ctx, caibEnv,
+			out, err := runCaibCommand(ctx,
 				"image", "build",
 				caibBuildManifest,
 				"--name", containerBuildName,
 				"--arch", arch,
 				"--push", fmt.Sprintf("%s:5000/%s/%s", registryHost, pushNamespace, artifactImageName),
-				"--follow")
-			out, err := utils.RunSafe(cmd)
+			)
 			containerCh <- buildResult{output: out, err: err}
 		}()
 
@@ -89,8 +97,36 @@ var _ = Describe("Bootc Container Build", Label("bootc"), Ordered, func() {
 			Fail(fmt.Sprintf("caib build did not complete within %v", caibBuildTimeout))
 		}
 
+		actualBuildName = getImageBuildCRName(containerBuildName)
+
+		By("verifying status fields are populated")
+		cmd := exec.Command("kubectl", "get", "imagebuild", actualBuildName,
+			"-n", testNamespace,
+			"-o", "jsonpath={.status.phase} {.status.startTime} {.status.completionTime} {.status.pipelineRunName}")
+		output, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		fields := strings.Fields(strings.TrimSpace(string(output)))
+		Expect(len(fields)).To(BeNumerically(">=", 4),
+			fmt.Sprintf("expected at least 4 status fields, got: %s", string(output)))
+		Expect(fields[0]).To(Equal("Completed"))
+		Expect(fields[1]).NotTo(BeEmpty(), "startTime should be populated")
+		Expect(fields[2]).NotTo(BeEmpty(), "completionTime should be populated")
+		Expect(fields[3]).NotTo(BeEmpty(), "pipelineRunName should be populated")
+
 		By("verifying container build appears in caib list")
 		verifyCaibList(containerBuildName)
+	})
+
+	// #44 — caib image logs returns a response for a completed build
+	It("should retrieve logs for the completed build via caib", func() {
+		By("retrieving logs via caib CLI")
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		output, err := runCaibCommand(ctx, "image", "logs", actualBuildName)
+		Expect(err).NotTo(HaveOccurred(),
+			fmt.Sprintf("caib image logs %s failed:\n%s", actualBuildName, string(output)))
 	})
 })
 
@@ -127,14 +163,13 @@ var _ = Describe("Internal Registry Build", Label("internal-registry"), Ordered,
 
 		By("launching build with --internal-registry")
 		go func() {
-			cmd := utils.NewCaibCommand(ctx, caibEnv,
+			out, err := runCaibCommand(ctx,
 				"image", "build",
 				caibBuildManifest,
 				"--name", buildName,
 				"--arch", arch,
 				"--internal-registry",
-				"--follow")
-			out, err := utils.RunSafe(cmd)
+			)
 			ch <- buildResult{output: out, err: err}
 		}()
 
@@ -153,23 +188,3 @@ var _ = Describe("Internal Registry Build", Label("internal-registry"), Ordered,
 		verifyCaibList(buildName)
 	})
 })
-
-func verifyCaibList(caibBuildName string) {
-	ctx, cancel := context.WithTimeout(context.Background(), caibListTimeout)
-	defer cancel()
-	listCmd := utils.NewCaibCommand(ctx, caibEnv,
-		"image", "list")
-	listOutput, listErr := utils.Run(listCmd)
-	Expect(listErr).NotTo(HaveOccurred())
-	lines := strings.Split(string(listOutput), "\n")
-	found := false
-	for _, line := range lines {
-		if strings.Contains(line, caibBuildName) {
-			Expect(line).To(ContainSubstring("Completed"))
-			found = true
-			break
-		}
-	}
-	Expect(found).To(BeTrue(),
-		fmt.Sprintf("build %q not found in caib list output:\n%s", caibBuildName, string(listOutput)))
-}

--- a/test/e2e/buildapi_test.go
+++ b/test/e2e/buildapi_test.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // Dot import is standard for Ginkgo
+	. "github.com/onsi/gomega"    //nolint:revive // Dot import is standard for Gomega
+
+	utils "github.com/centos-automotive-suite/automotive-dev-operator/test/utils"
+)
+
+// Tests #41, #42, #43, #47 from e2e-test-coverage-proposal.md.
+
+var _ = Describe("Build API", Label("operator"), Ordered, func() {
+	BeforeAll(func() {
+		ensureOperatorDeployed()
+		ensureBuildAPIAccess()
+		ensureCaibCredentials()
+	})
+
+	// #41 — caib image build-dev creates an ImageBuild CR
+	Context("Create Build", func() {
+		var createdBuildName string
+
+		AfterAll(func() {
+			if createdBuildName != "" {
+				deleteImageBuildCR(createdBuildName)
+			}
+		})
+
+		It("caib image build-dev should create a build CR", func() {
+			createdBuildName = createBuildViaCaib("e2e-api-create")
+
+			By("verifying ImageBuild CR exists in cluster")
+			EventuallyWithOffset(1, func() error {
+				cmd := exec.Command("kubectl", "get", "imagebuild", createdBuildName,
+					"-n", testNamespace, "-o", "jsonpath={.metadata.name}")
+				output, getErr := utils.Run(cmd)
+				if getErr != nil {
+					return getErr
+				}
+				if strings.TrimSpace(string(output)) != createdBuildName {
+					return fmt.Errorf("ImageBuild %s not found", createdBuildName)
+				}
+				return nil
+			}, 15*time.Second, 2*time.Second).Should(Succeed())
+		})
+	})
+
+	// #42 — caib image show returns build details
+	Context("Get Build Details", func() {
+		var buildName string
+
+		BeforeAll(func() {
+			buildName = createBuildViaCaib("e2e-api-get")
+		})
+
+		AfterAll(func() {
+			if buildName != "" {
+				deleteImageBuildCR(buildName)
+			}
+		})
+
+		It("caib image show should return correct fields", func() {
+			result := showBuildViaCaib(buildName)
+
+			Expect(result["name"]).To(Equal(buildName))
+			Expect(result).To(HaveKey("phase"))
+			Expect(result).To(HaveKey("requestedBy"))
+			Expect(result["requestedBy"]).NotTo(BeEmpty())
+
+			if params, ok := result["parameters"].(map[string]interface{}); ok {
+				Expect(params["architecture"]).To(Equal(arch))
+			}
+		})
+	})
+
+	// #43 — caib image delete removes a build
+	Context("Delete Build", func() {
+		It("caib image delete should delete the build and its CR", func() {
+			buildName := createBuildViaCaib("e2e-api-delete")
+
+			By("waiting for build to reach Building phase")
+			waitForImageBuildPhase(buildName, "Building", 60*time.Second)
+
+			By("deleting the build via caib")
+			deleteBuildViaCaib(buildName)
+
+			By("verifying ImageBuild CR is deleted")
+			waitForImageBuildDeleted(buildName, time.Minute)
+		})
+	})
+
+	// #47 — Build ownership enforcement (403 for another user's build)
+	Context("Ownership Enforcement", func() {
+		runCaibCommandWithToken := func(ctx context.Context, token string, args ...string) ([]byte, error) {
+			env := append([]string{}, caibEnv...)
+			const tokenPrefix = "CAIB_TOKEN="
+			filtered := env[:0]
+			for _, entry := range env {
+				if !strings.HasPrefix(entry, tokenPrefix) {
+					filtered = append(filtered, entry)
+				}
+			}
+			filtered = append(filtered, tokenPrefix+token)
+			cmd := utils.NewCaibCommand(ctx, filtered, args...)
+			return utils.RunSafe(cmd)
+		}
+
+		It("should return 403 when a different user tries to cancel or delete another user's build", func() {
+			By("creating two service accounts with separate tokens")
+			tokenA := createServiceAccountToken("caib-user-a")
+			tokenB := createServiceAccountToken("caib-user-b")
+
+			DeferCleanup(func() {
+				cmd := exec.Command("kubectl", "delete", "serviceaccount",
+					"caib-user-a", "caib-user-b",
+					"-n", testNamespace, "--ignore-not-found")
+				_, _ = utils.Run(cmd)
+			})
+
+			By("creating a build as user-a via caib")
+			createCtx, createCancel := context.WithTimeout(context.Background(), caibImageBuildTimeout)
+			defer createCancel()
+			createOutput, err := runCaibCommandWithToken(createCtx, tokenA,
+				"image", "build-dev",
+				caibBuildManifest,
+				"--name", "e2e-api-ownership",
+				"--arch", arch,
+				"--mode", "image",
+				"--internal-registry",
+				"--wait=false",
+			)
+			Expect(err).NotTo(HaveOccurred(),
+				fmt.Sprintf("expected build creation by user-a to succeed:\n%s", string(createOutput)))
+			buildName := parseCaibBuildName(string(createOutput))
+			Expect(buildName).NotTo(BeEmpty(), "could not parse build name from caib output: %s", string(createOutput))
+
+			DeferCleanup(func() {
+				deleteImageBuildCR(buildName)
+			})
+
+			By("attempting to cancel as user-b (should fail with 403)")
+			cancelCtx, cancelCancel := context.WithTimeout(context.Background(), caibImageCancelTimeout)
+			defer cancelCancel()
+			cancelOutput, err := runCaibCommandWithToken(cancelCtx, tokenB, "image", "cancel", buildName)
+			Expect(err).To(HaveOccurred(),
+				fmt.Sprintf("expected cancel by non-owner to fail, got:\n%s", string(cancelOutput)))
+			Expect(strings.ToLower(string(cancelOutput))).To(SatisfyAny(
+				ContainSubstring("403"),
+				ContainSubstring("forbidden"),
+			), fmt.Sprintf("expected 403/forbidden for cancel by non-owner, got:\n%s", string(cancelOutput)))
+
+			By("attempting to delete as user-b (should fail with 403)")
+			deleteCtx, deleteCancel := context.WithTimeout(context.Background(), caibImageDeleteTimeout)
+			defer deleteCancel()
+			deleteOutput, err := runCaibCommandWithToken(deleteCtx, tokenB, "image", "delete", buildName)
+			Expect(err).To(HaveOccurred(),
+				fmt.Sprintf("expected delete by non-owner to fail, got:\n%s", string(deleteOutput)))
+			Expect(strings.ToLower(string(deleteOutput))).To(SatisfyAny(
+				ContainSubstring("403"),
+				ContainSubstring("forbidden"),
+			), fmt.Sprintf("expected 403/forbidden for delete by non-owner, got:\n%s", string(deleteOutput)))
+
+			By("verifying user-b can still read the build (show is not ownership-gated)")
+			showCtx, showCancel := context.WithTimeout(context.Background(), caibImageShowTimeout)
+			defer showCancel()
+			showOutput, err := runCaibCommandWithToken(showCtx, tokenB,
+				"image", "show", buildName, "--output-format", "json")
+			Expect(err).NotTo(HaveOccurred(),
+				fmt.Sprintf("expected show by non-owner to succeed, got:\n%s", string(showOutput)))
+			Expect(string(showOutput)).To(ContainSubstring(buildName))
+		})
+	})
+})

--- a/test/e2e/e2e-test-coverage-TODO.md
+++ b/test/e2e/e2e-test-coverage-TODO.md
@@ -1,0 +1,171 @@
+# E2E Test Coverage — Implementation TODO
+
+Tracks progress against the original test coverage proposal.
+Last updated: 2026-06-22
+
+## Summary
+
+| Phase | Scope | Done | Remaining | Status |
+|-------|-------|------|-----------|--------|
+| Phase 1: Smoke Suite | #1–19, W1, W4 | 19/19 tests, 2/2 CI | 0 | Complete |
+| Phase 2: Core E2E | #20–22, 37, 41–42, 47 | 7/7 | 0 | Complete |
+| Phase 3: Package Mode | #23, W2 | 1/1 test, 1/1 CI | 0 | Complete |
+| Phase 4: Extended E2E | #24–26, 31–33, 38, 43–45, 48–49, 52, 59–60 | 9/15 | 6 | In progress |
+| Phase 5: Advanced & Nightly | #27–30, 34–36, 39–40, 46, 50–51, 53–57, 61, W3 | 2/18 tests, 0/1 CI | 17 | Not started |
+| **Total** | **61 tests + 4 CI** | **38/61 tests, 3/4 CI** | **24** | |
+
+---
+
+## Phase 1: Smoke Suite — COMPLETE
+
+All 19 smoke tests implemented. CI runs smoke on every PR.
+
+| # | Test | File | Status |
+|---|------|------|--------|
+| 1 | Controller pod is running | `operator_test.go` | Done |
+| 2 | Tekton Tasks created | `operator_test.go` | Done |
+| 3 | Tekton Pipeline created | `operator_test.go` | Done |
+| 4 | Build API deployment available | `operator_test.go` | Done |
+| 5 | /v1/healthz returns 200 | `smoke_test.go` | Done |
+| 6 | All CRDs installed | `smoke_test.go` | Done |
+| 7 | OperatorConfig status Ready | `smoke_test.go` | Done |
+| 8 | Target defaults ConfigMap exists | `smoke_test.go` | Done |
+| 9 | Build ServiceAccount exists | `smoke_test.go` | Done |
+| 10 | Internal JWT secret exists | `smoke_test.go` | Done |
+| 11 | ImageBuild creates PipelineRun | `smoke_test.go` | Done |
+| 12 | CatalogImage reaches Available | `smoke_test.go` | Done |
+| 13 | /v1/openapi.yaml responds | `smoke_test.go` | Done |
+| 14 | /v1/auth/config responds | `smoke_test.go` | Done |
+| 15 | /v1/config returns OperatorConfig | `smoke_test.go` | Done |
+| 16 | /v1/builds returns 200 | `smoke_test.go` | Done |
+| 17 | Unauthenticated request returns 401 | `smoke_test.go` | Done |
+| 18 | Invalid ImageBuild reaches Failed | `smoke_test.go` | Done |
+| 19 | ImageBuild deletion cleans up | `smoke_test.go` | Done |
+
+| CI | Change | Status |
+|----|--------|--------|
+| W1 | Smoke as default PR filter | Done |
+| W4 | `/e2e-smoke` lane in e2e-lanes.yml | Done |
+
+---
+
+## Phase 2: Core E2E — COMPLETE
+
+| # | Test | File | Status |
+|---|------|------|--------|
+| 20 | Full lifecycle (Pending->Building->Completed) | `bootc_build_test.go` | Done |
+| 21 | Export/push phase | `imagebuild_lifecycle_test.go` | Done — implemented in `By("verifying push-disk-artifact task ran in the PipelineRun")` |
+| 22 | Build cancellation | `imagebuild_lifecycle_test.go` | Done |
+| 37 | Toggle osBuilds.enabled | `operatorconfig_e2e_test.go` | Done |
+| 41 | POST /v1/builds — via `caib image build-dev` | `buildapi_test.go` | Done |
+| 42 | GET /v1/builds/{name} — via `caib image show` | `buildapi_test.go` | Done |
+| 47 | Build ownership enforcement (403) — raw HTTP | `buildapi_test.go` | Done |
+| 58 | Missing storage class error | — | N/A |
+
+---
+
+## Phase 3: Package Mode Build + CI — COMPLETE
+
+| # | Test | File | Status |
+|---|------|------|--------|
+| 23 | Package mode disk image build | `package_build_test.go` | Done — OpenShift only |
+
+| CI | Change | Status |
+|----|--------|--------|
+| W2 | `/e2e-package-mode` lane trigger | Done |
+
+---
+
+## Phase 4: Extended E2E — IN PROGRESS
+
+| # | Test | File | Status |
+|---|------|------|--------|
+| 24 | TTL expiry cleanup | `features_e2e_test.go` | Done |
+| 25 | Default TTL from OperatorConfig | `features_e2e_test.go` | Done |
+| 26 | Upload pod creation (inputFilesServer) | — | TODO |
+| 31 | ContainerBuild creates BuildRun | — | TODO — requires Shipwright |
+| 32 | ContainerBuild completes with digest | — | TODO — requires Shipwright + registry |
+| 33 | Workspace pod reaches Running | — | TODO |
+| 38 | Image propagation in Tekton Tasks | `features_e2e_test.go` | Done |
+| 43 | DELETE /v1/builds/{name} — via `caib image delete` | `buildapi_test.go` | Done |
+| 44 | GET /v1/builds/{name}/logs | `features_e2e_test.go` | Done |
+| 45 | POST /v1/builds/{name}/uploads | — | TODO |
+| 48 | Valid JWT -> 200 | `auth_test.go` | Done |
+| 49 | Invalid token -> 401 | `auth_test.go` | Done |
+| 52 | Image CR created after build | — | TODO — requires registry |
+| 59 | Concurrent builds independence | `error_handling_test.go` | Done |
+| 60 | Expired build cleanup | `features_e2e_test.go` | Done |
+
+---
+
+## Phase 5: Advanced & Nightly — NOT STARTED
+
+| # | Test | File | Status |
+|---|------|------|--------|
+| 27 | Upload timeout | — | TODO |
+| 28 | Bundle task resolution (secureBuild) | — | TODO — requires bundle registry |
+| 29 | Reject non-digest taskBundleRef | — | TODO |
+| 30 | OCI referrers saved (reproducible) | — | TODO — requires ORAS + registry |
+| 34 | Workspace auto-pause on idle | — | TODO |
+| 35 | Workspace stop/resume toggle | — | TODO |
+| 36 | Workspace image allowlist | — | TODO |
+| 39 | ServiceMonitor creation | — | TODO — requires Prometheus CRD |
+| 40 | Memory volumes (useMemoryVolumes) | — | TODO |
+| 46 | GET /v1/config (E2E-level validation) | — | TODO |
+| 50 | OIDC config endpoint returns provider | `auth_test.go` | Done |
+| 51 | OIDC not configured returns 404 only | `auth_test.go` | Done |
+| 53 | CatalogImage registry verification | — | TODO — requires registry |
+| 54 | CatalogImage label propagation | — | TODO |
+| 55 | CatalogImage unreachable registry | — | TODO |
+| 56 | ImageReseal sealed-image pipeline | — | TODO — requires Cosign + registry |
+| 57 | Flash TaskRun | — | TODO — requires Jumpstarter |
+| 61 | CatalogImage deletion finalizer | — | TODO |
+
+| CI | Change | Status |
+|----|--------|--------|
+| W3 | Auth nightly schedule | TODO — new nightly workflow for OpenShift |
+
+---
+
+## File Inventory
+
+| File | Tests | Labels |
+|------|-------|--------|
+| `operator_test.go` | #1–4 | `operator`, `smoke` |
+| `smoke_test.go` | #5–19 | `smoke` |
+| `imagebuild_lifecycle_test.go` | #21–22 | `operator` |
+| `operatorconfig_e2e_test.go` | #37 | `operator` |
+| `buildapi_test.go` | #41–43, #47 | `operator` |
+| `error_handling_test.go` | #59 | `operator` |
+| `package_build_test.go` | #23 | `package-mode` |
+| `features_e2e_test.go` | #24–25, #38, #44, #60 | `features` |
+| `auth_test.go` | #48–51 | `auth` |
+| `bootc_build_test.go` | #20, bootc build, internal registry | `bootc`, `internal-registry` |
+| `manifest_validation_test.go` | manifest validation (no proposal #) | `manifest-validation` |
+
+---
+
+## Remaining Work by Priority
+
+### High priority (next)
+- [x] #24–25 — TTL expiry tests
+- [x] #44 — Build API log streaming
+- [ ] #52 — Image CR verification after build
+- [x] #60 — Expired build cleanup
+
+### Medium priority
+- [ ] #26 — Upload pod creation
+- [ ] #27 — Upload timeout
+- [ ] #31–32 — ContainerBuild (requires Shipwright)
+- [ ] #33 — Workspace pod running
+- [x] #38 — Image propagation
+- [ ] #45 — Build API uploads
+
+### Low priority / infrastructure-dependent
+- [ ] #28–30 — Secure/reproducible builds (bundle registry, ORAS)
+- [ ] #34–36 — Workspace advanced (pause, resume, allowlist)
+- [ ] #39–40 — ServiceMonitor, memory volumes
+- [ ] #53–55 — CatalogImage deep tests
+- [ ] #56–57 — ImageReseal, Flash (Cosign, Jumpstarter)
+- [ ] #61 — CatalogImage deletion
+- [ ] W3 — Auth nightly workflow

--- a/test/e2e/error_handling_test.go
+++ b/test/e2e/error_handling_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // Dot import is standard for Ginkgo
+	. "github.com/onsi/gomega"    //nolint:revive // Dot import is standard for Gomega
+
+	utils "github.com/centos-automotive-suite/automotive-dev-operator/test/utils"
+)
+
+// Test #59 from e2e-test-coverage-proposal.md.
+
+var _ = Describe("Error Handling", Label("operator"), Ordered, func() {
+	BeforeAll(func() {
+		ensureOperatorDeployed()
+	})
+
+	// #59 — Concurrent builds get independent resources
+	It("should handle concurrent builds with independent PipelineRuns", func() {
+		buildNameA := "e2e-concurrent-a"
+		buildNameB := "e2e-concurrent-b"
+
+		crA := minimalImageBuildCR(buildNameA)
+		crB := minimalImageBuildCR(buildNameB)
+
+		By("creating two ImageBuilds simultaneously")
+		applyImageBuildCR(buildNameA, crA)
+		applyImageBuildCR(buildNameB, crB)
+
+		DeferCleanup(func() {
+			deleteImageBuildCR(buildNameA)
+			deleteImageBuildCR(buildNameB)
+		})
+
+		By("waiting for both PipelineRuns to be created")
+		prNameA := waitForPipelineRun(buildNameA, 30*time.Second)
+		prNameB := waitForPipelineRun(buildNameB, 30*time.Second)
+
+		By("verifying PipelineRuns are distinct resources")
+		Expect(prNameA).NotTo(Equal(prNameB),
+			"concurrent builds must have independent PipelineRuns")
+		Expect(prNameA).NotTo(BeEmpty())
+		Expect(prNameB).NotTo(BeEmpty())
+
+		By("verifying both builds have independent status")
+		cmd := exec.Command("kubectl", "get", "imagebuild", buildNameA,
+			"-n", testNamespace, "-o", "jsonpath={.status.pipelineRunName}")
+		outputA, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		cmd = exec.Command("kubectl", "get", "imagebuild", buildNameB,
+			"-n", testNamespace, "-o", "jsonpath={.status.pipelineRunName}")
+		outputB, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(strings.TrimSpace(string(outputA))).To(Equal(prNameA))
+		Expect(strings.TrimSpace(string(outputB))).To(Equal(prNameB))
+	})
+})

--- a/test/e2e/features_e2e_test.go
+++ b/test/e2e/features_e2e_test.go
@@ -1,0 +1,237 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // Dot import is standard for Ginkgo
+	. "github.com/onsi/gomega"    //nolint:revive // Dot import is standard for Gomega
+
+	utils "github.com/centos-automotive-suite/automotive-dev-operator/test/utils"
+)
+
+// Phase 4 features E2E tests: #24, #25, #38, #44, #60.
+
+// #25 — Default TTL populates ExpiresAt on completed/failed builds
+var _ = Describe("TTL: Default TTL from OperatorConfig", Label("features"), Ordered, func() {
+	BeforeAll(func() {
+		ensureOperatorDeployed()
+	})
+
+	It("should populate expiresAt on a failed build using the default TTL", func() {
+		buildName := "e2e-default-ttl"
+
+		cr := fmt.Sprintf(`apiVersion: automotive.sdv.cloud.redhat.com/v1alpha1
+kind: ImageBuild
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  architecture: %s
+  aib:
+    distro: autosd
+    target: qemu
+    mode: image
+    manifest: |
+      name: ttl-default-test
+`, buildName, testNamespace, arch)
+
+		applyImageBuildCR(buildName, cr)
+		DeferCleanup(func() { deleteImageBuildCR(buildName) })
+
+		By("waiting for build to reach Failed phase")
+		waitForImageBuildPhase(buildName, "Failed", imageBuildFailureTimeout)
+
+		By("verifying expiresAt is populated")
+		EventuallyWithOffset(1, func() error {
+			cmd := exec.Command("kubectl", "get", "imagebuild", buildName,
+				"-n", testNamespace,
+				"-o", "jsonpath={.status.expiresAt}")
+			output, err := utils.Run(cmd)
+			if err != nil {
+				return err
+			}
+			expiresAt := strings.TrimSpace(string(output))
+			if expiresAt == "" {
+				return fmt.Errorf("expiresAt not yet set")
+			}
+			return nil
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+	})
+})
+
+// #24 + #60 — TTL expiry cleanup: build with short TTL expires and resources are cleaned up
+var _ = Describe("TTL: Expiry and Cleanup", Label("features"), Ordered, func() {
+	BeforeAll(func() {
+		ensureOperatorDeployed()
+	})
+
+	It("should transition a failed build to Expired after a short TTL and clean up resources", func() {
+		buildName := "e2e-ttl-expiry"
+
+		cr := fmt.Sprintf(`apiVersion: automotive.sdv.cloud.redhat.com/v1alpha1
+kind: ImageBuild
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  architecture: %s
+  ttl: "30s"
+  aib:
+    distro: autosd
+    target: qemu
+    mode: image
+    manifest: |
+      name: expiry-test
+`, buildName, testNamespace, arch)
+
+		applyImageBuildCR(buildName, cr)
+		DeferCleanup(func() { deleteImageBuildCR(buildName) })
+
+		By("waiting for build to reach Failed phase")
+		waitForImageBuildPhase(buildName, "Failed", imageBuildFailureTimeout)
+
+		By("recording PipelineRun name before expiry")
+		var prName string
+		EventuallyWithOffset(1, func() error {
+			cmd := exec.Command("kubectl", "get", "imagebuild", buildName,
+				"-n", testNamespace,
+				"-o", "jsonpath={.status.pipelineRunName}")
+			output, err := utils.Run(cmd)
+			if err != nil {
+				return err
+			}
+			prName = strings.TrimSpace(string(output))
+			if prName == "" {
+				return fmt.Errorf("pipelineRunName not yet set")
+			}
+			return nil
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("waiting for build to transition to Expired phase")
+		waitForImageBuildPhase(buildName, "Expired", 3*time.Minute)
+
+		By("verifying previousPhase is set")
+		cmd := exec.Command("kubectl", "get", "imagebuild", buildName,
+			"-n", testNamespace,
+			"-o", "jsonpath={.status.previousPhase}")
+		output, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strings.TrimSpace(string(output))).To(Equal("Failed"))
+
+		By("verifying PipelineRun is cleaned up")
+		if prName != "" {
+			waitForResourceDeleted("pipelinerun", prName, 2*time.Minute)
+		}
+	})
+})
+
+// #38 — Image propagation: OperatorConfig images are reflected in Tekton Tasks
+var _ = Describe("Image Propagation in Tekton Tasks", Label("features"), Ordered, func() {
+	BeforeAll(func() {
+		ensureOperatorDeployed()
+	})
+
+	It("should propagate the default AIB image to the build-automotive-image Task", func() {
+		expectedImage := operatorConfigAIBImage()
+		buildName := "e2e-propagation-default"
+
+		applyImageBuildCR(buildName, minimalImageBuildCR(buildName))
+		DeferCleanup(func() { deleteImageBuildCR(buildName) })
+
+		By("verifying the build TaskRun uses the OperatorConfig AIB image")
+		waitForBuildTaskRunAIBImage(buildName, expectedImage, 2*time.Minute)
+	})
+
+	It("should update Task images when OperatorConfig images are changed", func() {
+		customImage := "quay.io/test/custom-aib:v99"
+
+		By("patching OperatorConfig with a custom AIB image")
+		patch := fmt.Sprintf(`{"spec":{"images":{"automotiveImageBuilder":"%s"}}}`, customImage)
+		cmd := exec.Command("kubectl", "patch", "operatorconfig", "config",
+			"-n", testNamespace, "--type=merge", "-p", patch)
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		DeferCleanup(func() {
+			By("restoring default images in OperatorConfig")
+			cmd := exec.Command("kubectl", "patch", "operatorconfig", "config",
+				"-n", testNamespace, "--type=merge",
+				"-p", `{"spec":{"images":null}}`)
+			_, _ = utils.Run(cmd)
+
+			EventuallyWithOffset(1, func() error {
+				cmd := exec.Command("kubectl", "get", "task", "build-automotive-image",
+					"-n", testNamespace,
+					"-o", `jsonpath={.spec.params[?(@.name=="automotive-image-builder")].default}`)
+				output, err := utils.Run(cmd)
+				if err != nil {
+					return err
+				}
+				img := strings.TrimSpace(string(output))
+				if strings.Contains(img, "custom-aib") {
+					return fmt.Errorf("task still has custom image: %s", img)
+				}
+				return nil
+			}, 2*time.Minute, 5*time.Second).Should(Succeed())
+		})
+
+		By("waiting for the Task to reflect the custom image")
+		EventuallyWithOffset(1, func() error {
+			cmd := exec.Command("kubectl", "get", "task", "build-automotive-image",
+				"-n", testNamespace,
+				"-o", `jsonpath={.spec.params[?(@.name=="automotive-image-builder")].default}`)
+			output, err := utils.Run(cmd)
+			if err != nil {
+				return err
+			}
+			img := strings.TrimSpace(string(output))
+			if img != customImage {
+				return fmt.Errorf("task param is %q, want %q", img, customImage)
+			}
+			return nil
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("verifying a new build uses the custom image at runtime")
+		buildName := "e2e-propagation-custom-build"
+		applyImageBuildCR(buildName, minimalImageBuildCR(buildName))
+		DeferCleanup(func() { deleteImageBuildCR(buildName) })
+		waitForBuildTaskRunAIBImage(buildName, customImage, 2*time.Minute)
+	})
+})
+
+var _ = Describe("Build API: Log Streaming", Label("features"), Ordered, func() {
+	BeforeAll(func() {
+		ensureOperatorDeployed()
+		ensureBuildAPIAccess()
+		ensureCaibCredentials()
+	})
+
+	It("caib image logs should fail for a non-existent build", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), caibImageListTimeout)
+		defer cancel()
+
+		output, err := runCaibCommand(ctx, "image", "logs", "no-such-build-xyz")
+		Expect(err).To(HaveOccurred(),
+			fmt.Sprintf("expected caib image logs to fail for non-existent build, got:\n%s", string(output)))
+	})
+})

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package e2e
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -43,10 +44,18 @@ const (
 	aarch64                        = "aarch64"
 	statusRunning                  = "Running"
 	tektonTaskPushArtifactRegistry = "push-artifact-registry"
-	artifactImageRepo              = "automotive-os-test1"
+	artifactImageRepo              = "automotive-os-test"
 	artifactImageName              = artifactImageRepo + ":latest"
 	kindPushNamespace              = "myorg"
 	defaultHTTPClientTimeout       = 5 * time.Second
+	imageBuildFailureTimeout       = 5 * time.Minute
+
+	caibImageBuildTimeout  = 15 * time.Minute
+	caibImageShowTimeout   = 15 * time.Second
+	caibImageDeleteTimeout = 30 * time.Second
+	caibImageCancelTimeout = 30 * time.Second
+	caibImageListTimeout   = 15 * time.Second
+	statusTrue             = "true"
 )
 
 // Shared state populated lazily via sync.Once and consumed by test lanes.
@@ -310,8 +319,9 @@ func setupBuildAPIRoute() {
 		return caibServer
 	}, 2*time.Minute, 5*time.Second).ShouldNot(BeEmpty())
 
-	By("waiting for Build API route to respond")
 	httpClient := newInsecureHTTPClient()
+
+	By("waiting for Build API route to respond")
 	waitForBuildAPI := func() error {
 		resp, httpErr := httpClient.Get(caibServer + "/v1/healthz")
 		if httpErr != nil {
@@ -325,6 +335,21 @@ func setupBuildAPIRoute() {
 	}
 	EventuallyWithOffset(1, waitForBuildAPI, 2*time.Minute, 5*time.Second).Should(Succeed(),
 		"Build API route did not become ready")
+
+	By("waiting for Build API config endpoint to be ready (OperatorConfig processed)")
+	waitForConfig := func() error {
+		resp, httpErr := httpClient.Get(caibServer + "/v1/config")
+		if httpErr != nil {
+			return httpErr
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode == http.StatusServiceUnavailable {
+			return fmt.Errorf("Build API /v1/config still returning 503 (OperatorConfig not yet ready)")
+		}
+		return nil
+	}
+	EventuallyWithOffset(1, waitForConfig, 2*time.Minute, 5*time.Second).Should(Succeed(),
+		"Build API config endpoint did not become ready")
 }
 
 func setupBuildAPIPortForward() {
@@ -340,8 +365,9 @@ func setupBuildAPIPortForward() {
 	err := portForwardCmd.Start()
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
-	By("waiting for Build API to respond on port-forward")
 	httpClient := newInsecureHTTPClient()
+
+	By("waiting for Build API to respond on port-forward")
 	waitForBuildAPI := func() error {
 		resp, httpErr := httpClient.Get("http://localhost:8080/v1/healthz")
 		if httpErr != nil {
@@ -355,6 +381,22 @@ func setupBuildAPIPortForward() {
 	}
 	EventuallyWithOffset(1, waitForBuildAPI, 30*time.Second, 1*time.Second).Should(Succeed(),
 		"Build API on localhost:8080 did not become ready")
+
+	By("waiting for Build API config endpoint to be ready (OperatorConfig processed)")
+	waitForConfig := func() error {
+		resp, httpErr := httpClient.Get("http://localhost:8080/v1/config")
+		if httpErr != nil {
+			return httpErr
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode == http.StatusServiceUnavailable {
+			return fmt.Errorf("Build API /v1/config still returning 503 (OperatorConfig not yet ready)")
+		}
+		return nil
+	}
+	EventuallyWithOffset(1, waitForConfig, 2*time.Minute, 5*time.Second).Should(Succeed(),
+		"Build API config endpoint did not become ready")
+
 	caibServer = "http://localhost:8080"
 }
 
@@ -411,7 +453,7 @@ func setupCaibCredentials() {
 	setEnv("CAIB_TOKEN", caibToken)
 	setEnv("CAIB_SERVER", caibServer)
 	if openShiftCluster {
-		setEnv("CAIB_INSECURE", "true")
+		setEnv("CAIB_INSECURE", statusTrue)
 	}
 
 	By("setting registry credentials")
@@ -635,4 +677,296 @@ func newInsecureHTTPClient() *http.Client {
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12}, //nolint:gosec // e2e test
 		},
 	}
+}
+
+// createServiceAccountToken creates a service account in the test namespace and returns a short-lived token.
+func createServiceAccountToken(name string) string {
+	cmd := exec.Command("kubectl", "create", "serviceaccount", name,
+		"-n", testNamespace, "--dry-run=client", "-o", "yaml")
+	saYAML, err := utils.Run(cmd)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	cmd = exec.Command("kubectl", "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(string(saYAML))
+	_, err = utils.Run(cmd)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	cmd = exec.Command("kubectl", "create", "token", name,
+		"-n", testNamespace, "--duration=30m")
+	output, err := utils.Run(cmd)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	token := strings.TrimSpace(string(output))
+	ExpectWithOffset(1, token).NotTo(BeEmpty())
+	return token
+}
+
+// applyImageBuildCR applies an ImageBuild CR and returns a cleanup function that deletes it.
+func applyImageBuildCR(name, crYAML string) {
+	cmd := exec.Command("kubectl", "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(crYAML)
+	_, err := utils.Run(cmd)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "failed to apply ImageBuild %s", name)
+}
+
+// deleteImageBuildCR deletes an ImageBuild CR by name, ignoring not-found errors.
+func deleteImageBuildCR(name string) {
+	cmd := exec.Command("kubectl", "delete", "imagebuild", name,
+		"-n", testNamespace, "--ignore-not-found")
+	_, _ = utils.Run(cmd)
+}
+
+// waitForImageBuildPhase polls until the ImageBuild reaches the given phase or times out.
+func waitForImageBuildPhase(name, expectedPhase string, timeout time.Duration) {
+	EventuallyWithOffset(1, func() error {
+		cmd := exec.Command("kubectl", "get", "imagebuild", name,
+			"-n", testNamespace, "-o", "jsonpath={.status.phase}")
+		output, err := utils.Run(cmd)
+		if err != nil {
+			return err
+		}
+		phase := strings.TrimSpace(string(output))
+		if phase != expectedPhase {
+			return fmt.Errorf("ImageBuild %s phase is %q, want %q", name, phase, expectedPhase)
+		}
+		return nil
+	}, timeout, 2*time.Second).Should(Succeed())
+}
+
+// waitForResourceDeleted polls until kubectl get --ignore-not-found returns no resource.
+func waitForResourceDeleted(resourceType, name string, timeout time.Duration) {
+	EventuallyWithOffset(1, func() error {
+		cmd := exec.Command("kubectl", "get", resourceType, name,
+			"-n", testNamespace, "--ignore-not-found", "-o", "name")
+		output, err := utils.Run(cmd)
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(string(output)) == "" {
+			return nil
+		}
+		return fmt.Errorf("%s %s still exists", resourceType, name)
+	}, timeout, 2*time.Second).Should(Succeed())
+}
+
+// waitForImageBuildDeleted polls until the ImageBuild CR no longer exists.
+func waitForImageBuildDeleted(name string, timeout time.Duration) {
+	waitForResourceDeleted("imagebuild", name, timeout)
+}
+
+// getImageBuildCRName returns the ImageBuild CR name for a build name prefix.
+func getImageBuildCRName(prefix string) string {
+	cmd := exec.Command("kubectl", "get", "imagebuild", "-n", testNamespace,
+		"-o", "jsonpath={.items[*].metadata.name}")
+	out, err := utils.Run(cmd)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	for _, name := range strings.Fields(string(out)) {
+		if strings.HasPrefix(name, prefix+"-") {
+			return name
+		}
+	}
+	ExpectWithOffset(1, false).To(BeTrue(),
+		fmt.Sprintf("no ImageBuild with prefix %q in namespace %s", prefix, testNamespace))
+	return ""
+}
+
+// operatorConfigAIBImage returns the configured automotive-image-builder image.
+// It reads from OperatorConfig first, then falls back to the Task spec default
+// so the test does not need to track the version string independently.
+func operatorConfigAIBImage() string {
+	cmd := exec.Command("kubectl", "get", "operatorconfig", "config",
+		"-n", testNamespace,
+		"-o", "jsonpath={.spec.images.automotiveImageBuilder}")
+	output, err := utils.Run(cmd)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	if img := strings.TrimSpace(string(output)); img != "" {
+		return img
+	}
+	cmd = exec.Command("kubectl", "get", "task", "build-automotive-image",
+		"-n", testNamespace,
+		"-o", `jsonpath={.spec.params[?(@.name=="automotive-image-builder")].default}`)
+	output, err = utils.Run(cmd)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	img := strings.TrimSpace(string(output))
+	ExpectWithOffset(1, img).NotTo(BeEmpty(), "automotive-image-builder param default not found in task spec")
+	return img
+}
+
+func pipelineRunNameForBuild(buildName string) (string, error) {
+	cmd := exec.Command("kubectl", "get", "pipelinerun",
+		"-l", fmt.Sprintf("automotive.sdv.cloud.redhat.com/imagebuild-name=%s", buildName),
+		"-n", testNamespace, "-o", "jsonpath={.items[0].metadata.name}")
+	output, err := utils.Run(cmd)
+	if err != nil {
+		return "", err
+	}
+	name := strings.TrimSpace(string(output))
+	if name == "" {
+		return "", fmt.Errorf("no PipelineRun found for ImageBuild %s", buildName)
+	}
+	return name, nil
+}
+
+// waitForBuildTaskRunAIBImage waits for a build TaskRun to use the expected AIB image.
+func waitForBuildTaskRunAIBImage(buildName, expectedImage string, timeout time.Duration) {
+	EventuallyWithOffset(1, func() error {
+		prName, err := pipelineRunNameForBuild(buildName)
+		if err != nil {
+			return err
+		}
+		cmd := exec.Command("kubectl", "get", "taskrun",
+			"-n", testNamespace,
+			"-l", fmt.Sprintf("tekton.dev/pipelineRun=%s,tekton.dev/pipelineTask=build-image", prName),
+			"-o", `jsonpath={.items[0].spec.params[?(@.name=="automotive-image-builder")].value}`)
+		output, err := utils.Run(cmd)
+		if err != nil {
+			return err
+		}
+		value := strings.TrimSpace(string(output))
+		if value == "" {
+			cmd = exec.Command("kubectl", "get", "task", "build-automotive-image",
+				"-n", testNamespace,
+				"-o", `jsonpath={.spec.params[?(@.name=="automotive-image-builder")].default}`)
+			output, err = utils.Run(cmd)
+			if err != nil {
+				return err
+			}
+			value = strings.TrimSpace(string(output))
+		}
+		if value == "" {
+			return fmt.Errorf("automotive-image-builder image not yet available for build %s", buildName)
+		}
+		if value != expectedImage {
+			return fmt.Errorf("automotive-image-builder is %q, want %q", value, expectedImage)
+		}
+		return nil
+	}, timeout, 5*time.Second).Should(Succeed())
+}
+
+// waitForPipelineRun polls until a PipelineRun is created for the given ImageBuild name and returns its name.
+func waitForPipelineRun(buildName string, timeout time.Duration) string {
+	var prName string
+	EventuallyWithOffset(1, func() error {
+		cmd := exec.Command("kubectl", "get", "pipelinerun",
+			"-l", fmt.Sprintf("automotive.sdv.cloud.redhat.com/imagebuild-name=%s", buildName),
+			"-n", testNamespace, "-o", "jsonpath={.items[0].metadata.name}")
+		output, err := utils.Run(cmd)
+		if err != nil {
+			return err
+		}
+		name := strings.TrimSpace(string(output))
+		if name == "" {
+			return fmt.Errorf("no PipelineRun found for ImageBuild %s", buildName)
+		}
+		prName = name
+		return nil
+	}, timeout, 2*time.Second).Should(Succeed())
+	return prName
+}
+
+// minimalImageBuildCR returns a minimal ImageBuild CR YAML for testing.
+func minimalImageBuildCR(name string) string {
+	return fmt.Sprintf(`apiVersion: automotive.sdv.cloud.redhat.com/v1alpha1
+kind: ImageBuild
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  architecture: %s
+  aib:
+    distro: autosd
+    target: qemu
+    mode: image
+    manifest: |
+      name: %s
+`, name, testNamespace, arch, name)
+}
+
+// runCaibCommand executes a caib CLI command with the shared caibEnv and returns its output.
+func runCaibCommand(ctx context.Context, args ...string) ([]byte, error) {
+	cmd := utils.NewCaibCommand(ctx, caibEnv, args...)
+	return utils.RunSafe(cmd)
+}
+
+// createBuildViaCaib creates a build via `caib image build-dev` and returns the server-assigned build name.
+func createBuildViaCaib(name string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), caibImageBuildTimeout)
+	defer cancel()
+
+	output, err := runCaibCommand(ctx,
+		"image", "build-dev",
+		caibBuildManifest,
+		"--name", name,
+		"--arch", arch,
+		"--mode", "image",
+		"--internal-registry",
+		"--wait=false",
+	)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(),
+		fmt.Sprintf("caib image build-dev failed:\n%s", string(output)))
+
+	buildName := parseCaibBuildName(string(output))
+	ExpectWithOffset(1, buildName).NotTo(BeEmpty(), "could not parse build name from caib output: %s", string(output))
+	return buildName
+}
+
+// parseCaibBuildName extracts the build name from caib output like "Build <name> accepted: ...".
+func parseCaibBuildName(output string) string {
+	re := regexp.MustCompile(`Build\s+(\S+)\s+accepted`)
+	if m := re.FindStringSubmatch(output); len(m) > 1 {
+		return m[1]
+	}
+	return ""
+}
+
+// showBuildViaCaib runs `caib image show` and returns the parsed JSON output.
+func showBuildViaCaib(name string) map[string]interface{} {
+	ctx, cancel := context.WithTimeout(context.Background(), caibImageShowTimeout)
+	defer cancel()
+
+	output, err := runCaibCommand(ctx,
+		"image", "show", name,
+		"--output-format", "json")
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(),
+		fmt.Sprintf("caib image show %s failed:\n%s", name, string(output)))
+
+	var result map[string]interface{}
+	ExpectWithOffset(1, json.Unmarshal(output, &result)).To(Succeed(),
+		fmt.Sprintf("failed to parse caib show output: %s", string(output)))
+	return result
+}
+
+// deleteBuildViaCaib deletes a build via `caib image delete`.
+func deleteBuildViaCaib(name string) {
+	ctx, cancel := context.WithTimeout(context.Background(), caibImageDeleteTimeout)
+	defer cancel()
+
+	output, err := runCaibCommand(ctx, "image", "delete", name)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(),
+		fmt.Sprintf("caib image delete %s failed:\n%s", name, string(output)))
+}
+
+// listBuildsViaCaib runs `caib image list` and returns stdout.
+func listBuildsViaCaib() string {
+	ctx, cancel := context.WithTimeout(context.Background(), caibImageListTimeout)
+	defer cancel()
+
+	output, err := runCaibCommand(ctx, "image", "list")
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(),
+		fmt.Sprintf("caib image list failed:\n%s", string(output)))
+	return string(output)
+}
+
+// verifyCaibList asserts that a build with the given name prefix appears as Completed in caib image list.
+func verifyCaibList(caibBuildName string) {
+	output := listBuildsViaCaib()
+	lines := strings.Split(output, "\n")
+	found := false
+	for _, line := range lines {
+		if strings.Contains(line, caibBuildName) {
+			Expect(line).To(ContainSubstring("Completed"))
+			found = true
+			break
+		}
+	}
+	Expect(found).To(BeTrue(),
+		fmt.Sprintf("build %q not found in caib list output:\n%s", caibBuildName, output))
 }

--- a/test/e2e/imagebuild_lifecycle_test.go
+++ b/test/e2e/imagebuild_lifecycle_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // Dot import is standard for Ginkgo
+	. "github.com/onsi/gomega"    //nolint:revive // Dot import is standard for Gomega
+
+	utils "github.com/centos-automotive-suite/automotive-dev-operator/test/utils"
+)
+
+// Tests #21, #22 from e2e-test-coverage-proposal.md.
+
+var _ = Describe("ImageBuild Lifecycle", Label("operator"), Ordered, func() {
+
+	// #22 — Build cancellation via Build API
+	Context("Build Cancellation", func() {
+		BeforeAll(func() {
+			ensureOperatorDeployed()
+			ensureBuildAPIAccess()
+			ensureCaibCredentials()
+		})
+
+		It("should cancel a running build and transition to Cancelled", func() {
+			By("creating build via caib CLI")
+			buildName := createBuildViaCaib("e2e-lifecycle-cancel")
+
+			DeferCleanup(func() {
+				deleteImageBuildCR(buildName)
+			})
+
+			By("waiting for build to reach Building phase")
+			waitForImageBuildPhase(buildName, "Building", 1*time.Minute)
+
+			By("cancelling the build via caib (retry on transient failure)")
+			EventuallyWithOffset(1, func() error {
+				ctx, cancel := context.WithTimeout(context.Background(), caibImageCancelTimeout)
+				defer cancel()
+				_, err := runCaibCommand(ctx, "image", "cancel", buildName)
+				return err
+			}, 30*time.Second, 1*time.Second).Should(Succeed())
+
+			By("verifying ImageBuild transitions to Cancelled")
+			waitForImageBuildPhase(buildName, "Cancelled", 2*time.Minute)
+
+			By("verifying ImageBuild CR is preserved after cancel")
+			cmd := exec.Command("kubectl", "get", "imagebuild", buildName,
+				"-n", testNamespace, "-o", "jsonpath={.metadata.name}")
+			output, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(strings.TrimSpace(string(output))).To(Equal(buildName))
+		})
+	})
+})

--- a/test/e2e/manifest_validation_test.go
+++ b/test/e2e/manifest_validation_test.go
@@ -23,8 +23,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // Dot import is standard for Ginkgo
 	. "github.com/onsi/gomega"    //nolint:revive // Dot import is standard for Gomega
-
-	utils "github.com/centos-automotive-suite/automotive-dev-operator/test/utils"
 )
 
 const (
@@ -44,13 +42,12 @@ var _ = Describe("Manifest Validation", Label("manifest-validation"), Ordered, f
 		ctx, cancel := context.WithTimeout(context.Background(), validationTimeout)
 		defer cancel()
 
-		cmd := utils.NewCaibCommand(ctx, caibEnv,
+		output, err := runCaibCommand(ctx,
 			"image", "build",
 			invalidManifest,
 			"--name", "e2e-invalid-manifest",
 			"--arch", arch,
 			"--push", "localhost:5000/test/invalid:latest")
-		output, err := utils.RunSafe(cmd)
 
 		_, _ = fmt.Fprintf(GinkgoWriter, "\n--- caib manifest validation ---\n%s\n", string(output))
 

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -28,7 +28,7 @@ import (
 	utils "github.com/centos-automotive-suite/automotive-dev-operator/test/utils"
 )
 
-var _ = Describe("Operator Health", Label("operator"), Ordered, func() {
+var _ = Describe("Operator Health", Label("operator", "smoke"), Ordered, func() {
 	BeforeAll(func() {
 		ensureOperatorDeployed()
 	})

--- a/test/e2e/operatorconfig_e2e_test.go
+++ b/test/e2e/operatorconfig_e2e_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // Dot import is standard for Ginkgo
+	. "github.com/onsi/gomega"    //nolint:revive // Dot import is standard for Gomega
+
+	utils "github.com/centos-automotive-suite/automotive-dev-operator/test/utils"
+)
+
+// Test #37 from e2e-test-coverage-proposal.md.
+
+var _ = Describe("OperatorConfig E2E", Label("operator"), Ordered, func() {
+	BeforeAll(func() {
+		ensureOperatorDeployed()
+	})
+
+	// #37 — Toggle osBuilds.enabled removes and recreates Tekton resources
+	It("should remove Tekton resources when osBuilds is disabled and recreate when re-enabled", func() {
+		By("verifying Tekton resources exist as pre-condition")
+		verifyTektonResourcesExist()
+
+		DeferCleanup(func() {
+			By("ensuring osBuilds is re-enabled after test")
+			cmd := exec.Command("kubectl", "patch", "operatorconfig", "config",
+				"-n", testNamespace, "--type=merge",
+				"-p", `{"spec":{"osBuilds":{"enabled":true}}}`)
+			_, _ = utils.Run(cmd)
+
+			EventuallyWithOffset(1, func() error {
+				cmd := exec.Command("kubectl", "get", "operatorconfig", "config",
+					"-n", testNamespace,
+					"-o", "jsonpath={.status.osBuildsDeployed}")
+				output, err := utils.Run(cmd)
+				if err != nil {
+					return err
+				}
+				if strings.TrimSpace(string(output)) != statusTrue {
+					return fmt.Errorf("osBuildsDeployed not yet true")
+				}
+				return nil
+			}, 3*time.Minute, 5*time.Second).Should(Succeed())
+		})
+
+		By("disabling osBuilds")
+		cmd := exec.Command("kubectl", "patch", "operatorconfig", "config",
+			"-n", testNamespace, "--type=merge",
+			"-p", `{"spec":{"osBuilds":{"enabled":false}}}`)
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("waiting for Tekton resources to be removed")
+		EventuallyWithOffset(1, func() error {
+			cmd := exec.Command("kubectl", "get", "tasks", "-n", testNamespace,
+				"-o", "jsonpath={.items[*].metadata.name}")
+			output, err := utils.Run(cmd)
+			if err != nil {
+				return err
+			}
+			tasks := strings.TrimSpace(string(output))
+			if strings.Contains(tasks, "build-automotive-image") {
+				return fmt.Errorf("build-automotive-image task still exists: %s", tasks)
+			}
+			return nil
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+		waitForResourceDeleted("pipeline", "automotive-build-pipeline", 2*time.Minute)
+
+		By("waiting for osBuildsDeployed to become false")
+		EventuallyWithOffset(1, func() error {
+			cmd := exec.Command("kubectl", "get", "operatorconfig", "config",
+				"-n", testNamespace,
+				"-o", "jsonpath={.status.osBuildsDeployed}")
+			output, err := utils.Run(cmd)
+			if err != nil {
+				return err
+			}
+			// false is omitted from status JSON (omitempty), so jsonpath returns empty.
+			if strings.TrimSpace(string(output)) == statusTrue {
+				return fmt.Errorf("osBuildsDeployed still true")
+			}
+			return nil
+		}, 3*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("re-enabling osBuilds")
+		cmd = exec.Command("kubectl", "patch", "operatorconfig", "config",
+			"-n", testNamespace, "--type=merge",
+			"-p", `{"spec":{"osBuilds":{"enabled":true}}}`)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("waiting for osBuildsDeployed to become true")
+		EventuallyWithOffset(1, func() error {
+			cmd := exec.Command("kubectl", "get", "operatorconfig", "config",
+				"-n", testNamespace,
+				"-o", "jsonpath={.status.osBuildsDeployed}")
+			output, err := utils.Run(cmd)
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(string(output)) != statusTrue {
+				return fmt.Errorf("osBuildsDeployed not yet true")
+			}
+			return nil
+		}, 3*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("verifying Tekton resources are recreated")
+		verifyTektonResourcesExist()
+	})
+})
+
+func verifyTektonResourcesExist() {
+	EventuallyWithOffset(2, func() error {
+		cmd := exec.Command("kubectl", "get", "tasks", "-n", testNamespace,
+			"-o", "jsonpath={.items[*].metadata.name}")
+		output, err := utils.Run(cmd)
+		if err != nil {
+			return err
+		}
+		tasks := string(output)
+		if !strings.Contains(tasks, "build-automotive-image") {
+			return fmt.Errorf("build-automotive-image task not found, got: %s", tasks)
+		}
+		return nil
+	}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+	EventuallyWithOffset(2, func() error {
+		cmd := exec.Command("kubectl", "get", "pipeline", "automotive-build-pipeline",
+			"-n", testNamespace, "-o", "jsonpath={.metadata.name}")
+		output, err := utils.Run(cmd)
+		if err != nil {
+			return err
+		}
+		if string(output) != "automotive-build-pipeline" {
+			return fmt.Errorf("automotive-build-pipeline not found")
+		}
+		return nil
+	}, 2*time.Minute, 5*time.Second).Should(Succeed())
+}

--- a/test/e2e/package_build_test.go
+++ b/test/e2e/package_build_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // Dot import is standard for Ginkgo
+	. "github.com/onsi/gomega"    //nolint:revive // Dot import is standard for Gomega
+
+	utils "github.com/centos-automotive-suite/automotive-dev-operator/test/utils"
+)
+
+// Test #23 from e2e-test-coverage-proposal.md.
+
+var _ = Describe("Package Mode Build", Label("package-mode"), Ordered, func() {
+
+	BeforeAll(func() {
+		if registryHost == "" {
+			Skip("REGISTRY_HOST not set; package mode build tests require a registry")
+		}
+		ensureOperatorDeployed()
+		ensureRegistryConfigured()
+		ensureBuildAPIAccess()
+		ensureCaibCredentials()
+
+		if openShiftCluster {
+			By("pre-creating ImageStream on OpenShift")
+			cmd := exec.Command("oc", "create", "imagestream", artifactImageRepo, "-n", testNamespace)
+			_, _ = utils.Run(cmd)
+		}
+	})
+
+	// #23 — Full package mode disk image build
+	It("should complete a package mode disk image build via caib build-dev", func() {
+		buildName := "e2e-package-mode"
+		var actualBuildName string
+
+		ctx, cancel := context.WithTimeout(context.Background(), caibBuildTimeout)
+		defer cancel()
+
+		type buildResult struct {
+			output []byte
+			err    error
+		}
+		ch := make(chan buildResult, 1)
+
+		pushNamespace := kindPushNamespace
+		if openShiftCluster {
+			pushNamespace = testNamespace
+		}
+
+		By("launching package mode build via caib build-dev")
+		go func() {
+			out, err := runCaibCommand(ctx,
+				"image", "build-dev",
+				caibBuildManifest,
+				"--name", buildName,
+				"--arch", arch,
+				"--mode", "package",
+				"--format", "qcow2",
+				"--push", fmt.Sprintf("%s:5000/%s/%s", registryHost, pushNamespace, artifactImageName),
+			)
+			ch <- buildResult{output: out, err: err}
+		}()
+
+		DeferCleanup(func() {
+			name := actualBuildName
+			if name == "" {
+				name = buildName
+			}
+			deleteImageBuildCR(name)
+		})
+
+		select {
+		case r := <-ch:
+			By("verifying package mode build completed successfully")
+			_, _ = fmt.Fprintf(GinkgoWriter, "\n--- package mode build (%s) ---\n%s\n",
+				buildName, string(r.output))
+			Expect(r.err).NotTo(HaveOccurred(),
+				fmt.Sprintf("package mode build failed:\n%sError: %v\n", string(r.output), r.err))
+		case <-ctx.Done():
+			Fail(fmt.Sprintf("package mode build did not complete within %v", caibBuildTimeout))
+		}
+
+		actualBuildName = getImageBuildCRName(buildName)
+
+		By("verifying ImageBuild CR status fields")
+		cmd := exec.Command("kubectl", "get", "imagebuild", actualBuildName,
+			"-n", testNamespace,
+			"-o", "jsonpath={.status.phase} {.status.startTime} {.status.completionTime} {.status.pipelineRunName}")
+		output, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		fields := strings.Fields(strings.TrimSpace(string(output)))
+		Expect(len(fields)).To(BeNumerically(">=", 4),
+			fmt.Sprintf("expected at least 4 status fields, got: %s", string(output)))
+		Expect(fields[0]).To(Equal("Completed"))
+		Expect(fields[1]).NotTo(BeEmpty(), "startTime should be populated")
+		Expect(fields[2]).NotTo(BeEmpty(), "completionTime should be populated")
+		Expect(fields[3]).NotTo(BeEmpty(), "pipelineRunName should be populated")
+
+		By("verifying push-disk-artifact task ran in the PipelineRun")
+		prName := fields[3]
+		cmd = exec.Command("kubectl", "get", "pipelinerun", prName,
+			"-n", testNamespace,
+			"-o", `jsonpath={.status.childReferences[?(@.pipelineTaskName=="push-disk-artifact")].name}`)
+		output, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strings.TrimSpace(string(output))).NotTo(BeEmpty(),
+			"push-disk-artifact TaskRun should exist in PipelineRun childReferences")
+
+		By("verifying build mode is package in the CR spec")
+		cmd = exec.Command("kubectl", "get", "imagebuild", actualBuildName,
+			"-n", testNamespace, "-o", "jsonpath={.spec.aib.mode}")
+		output, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strings.TrimSpace(string(output))).To(Equal("package"))
+
+		By("verifying build appears in caib image list")
+		verifyCaibList(buildName)
+	})
+})

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -1,0 +1,383 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // Dot import is standard for Ginkgo
+	. "github.com/onsi/gomega"    //nolint:revive // Dot import is standard for Gomega
+
+	utils "github.com/centos-automotive-suite/automotive-dev-operator/test/utils"
+)
+
+// Smoke tests #5-19 from e2e-test-coverage-proposal.md.
+// Tests #1-4 are in operator_test.go (existing tests with Label("smoke") added).
+
+var _ = Describe("Smoke: CRD Availability", Label("smoke"), Ordered, func() {
+	BeforeAll(func() {
+		ensureOperatorDeployed()
+	})
+
+	// #6
+	It("should have all CRDs installed", func() {
+		cmd := exec.Command("kubectl", "get", "crd",
+			"-o", "jsonpath={.items[*].metadata.name}")
+		output, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		crds := string(output)
+		for _, expected := range []string{
+			"imagebuilds.automotive.sdv.cloud.redhat.com",
+			"images.automotive.sdv.cloud.redhat.com",
+			"catalogimages.automotive.sdv.cloud.redhat.com",
+			"containerbuilds.automotive.sdv.cloud.redhat.com",
+			"workspaces.automotive.sdv.cloud.redhat.com",
+			"imagereseals.automotive.sdv.cloud.redhat.com",
+			"operatorconfigs.automotive.sdv.cloud.redhat.com",
+		} {
+			Expect(crds).To(ContainSubstring(expected),
+				fmt.Sprintf("CRD %s not found in cluster", expected))
+		}
+	})
+})
+
+var _ = Describe("Smoke: OperatorConfig", Label("smoke"), Ordered, func() {
+	BeforeAll(func() {
+		ensureOperatorDeployed()
+	})
+
+	// #7
+	It("should have status phase Ready with osBuildsDeployed=true", func() {
+		EventuallyWithOffset(1, func() error {
+			cmd := exec.Command("kubectl", "get", "operatorconfig", "config",
+				"-n", testNamespace,
+				"-o", "jsonpath={.status.phase} {.status.osBuildsDeployed}")
+			output, err := utils.Run(cmd)
+			if err != nil {
+				return err
+			}
+			parts := strings.Fields(strings.TrimSpace(string(output)))
+			if len(parts) < 2 || parts[0] != "Ready" || parts[1] != statusTrue {
+				return fmt.Errorf("OperatorConfig not ready, got: %s", string(output))
+			}
+			return nil
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+	})
+
+	// #8
+	It("should have target defaults ConfigMap", func() {
+		cmd := exec.Command("kubectl", "get", "configmap", "aib-target-defaults",
+			"-n", testNamespace, "-o", "jsonpath={.metadata.name}")
+		output, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strings.TrimSpace(string(output))).To(Equal("aib-target-defaults"))
+	})
+
+	// #9
+	It("should have build ServiceAccount", func() {
+		cmd := exec.Command("kubectl", "get", "serviceaccount", "ado-build",
+			"-n", testNamespace, "-o", "jsonpath={.metadata.name}")
+		output, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strings.TrimSpace(string(output))).To(Equal("ado-build"))
+	})
+
+	// #10
+	It("should have internal JWT secret", func() {
+		cmd := exec.Command("kubectl", "get", "secret", "ado-build-api-internal-jwt",
+			"-n", testNamespace, "-o", "jsonpath={.metadata.name}")
+		output, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strings.TrimSpace(string(output))).To(Equal("ado-build-api-internal-jwt"))
+	})
+})
+
+var _ = Describe("Smoke: Build API Endpoints", Label("smoke"), Ordered, func() {
+	BeforeAll(func() {
+		ensureOperatorDeployed()
+		ensureBuildAPIAccess()
+		ensureCaibCredentials()
+	})
+
+	// #5
+	It("/v1/healthz should return 200", func() {
+		client := newInsecureHTTPClient()
+		resp, err := client.Get(caibServer + "/v1/healthz")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = resp.Body.Close() }()
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+	})
+
+	// #13
+	It("/v1/openapi.yaml should respond with OpenAPI spec", func() {
+		client := newInsecureHTTPClient()
+		resp, err := client.Get(caibServer + "/v1/openapi.yaml")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = resp.Body.Close() }()
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+		body, err := io.ReadAll(resp.Body)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(body)).To(ContainSubstring("openapi"))
+	})
+
+	// #14
+	It("/v1/auth/config should respond with 200 or 404", func() {
+		client := newInsecureHTTPClient()
+		resp, err := client.Get(caibServer + "/v1/auth/config")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = resp.Body.Close() }()
+		Expect(resp.StatusCode).To(BeElementOf(http.StatusOK, http.StatusNotFound))
+	})
+
+	// #15
+	It("/v1/config should return OperatorConfig fields", func() {
+		client := newInsecureHTTPClient()
+		req, err := http.NewRequest("GET", caibServer+"/v1/config", nil)
+		Expect(err).NotTo(HaveOccurred())
+		req.Header.Set("Authorization", "Bearer "+caibToken)
+
+		resp, err := client.Do(req)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = resp.Body.Close() }()
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+		body, err := io.ReadAll(resp.Body)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(body)).To(ContainSubstring("targetDefaults"))
+	})
+
+	// #16
+	It("caib image list should succeed with valid credentials", func() {
+		output := listBuildsViaCaib()
+		Expect(output).NotTo(BeEmpty(), "caib image list should produce output")
+	})
+
+	// #17
+	It("should return 401 for unauthenticated request to /v1/builds", func() {
+		client := newInsecureHTTPClient()
+		req, err := http.NewRequest("GET", caibServer+"/v1/builds", nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		resp, err := client.Do(req)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = resp.Body.Close() }()
+		Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+	})
+})
+
+var _ = Describe("Smoke: CR Lifecycle", Label("smoke"), Ordered, func() {
+	BeforeAll(func() {
+		ensureOperatorDeployed()
+	})
+
+	// #11
+	It("ImageBuild should create a PipelineRun", func() {
+		buildName := "smoke-test-pipelinerun"
+
+		cr := fmt.Sprintf(`apiVersion: automotive.sdv.cloud.redhat.com/v1alpha1
+kind: ImageBuild
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  architecture: %s
+  aib:
+    distro: autosd
+    target: qemu
+    mode: image
+    manifest: |
+      name: smoke-test
+`, buildName, testNamespace, arch)
+
+		applyImageBuildCR(buildName, cr)
+		DeferCleanup(func() { deleteImageBuildCR(buildName) })
+
+		EventuallyWithOffset(1, func() error {
+			cmd := exec.Command("kubectl", "get", "pipelinerun",
+				"-l", fmt.Sprintf("automotive.sdv.cloud.redhat.com/imagebuild-name=%s", buildName),
+				"-n", testNamespace, "-o", "jsonpath={.items[0].metadata.name}")
+			output, err := utils.Run(cmd)
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(string(output)) == "" {
+				return fmt.Errorf("no PipelineRun found for ImageBuild %s", buildName)
+			}
+			return nil
+		}, 30*time.Second, 2*time.Second).Should(Succeed())
+	})
+
+	// #12
+	It("CatalogImage should reach Available with resolvedDigest", func() {
+		catalogName := "smoke-test-catalog"
+
+		cr := fmt.Sprintf(`apiVersion: automotive.sdv.cloud.redhat.com/v1alpha1
+kind: CatalogImage
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  registryUrl: "registry.access.redhat.com/ubi9/ubi-micro:latest"
+`, catalogName, testNamespace)
+
+		cmd := exec.Command("kubectl", "apply", "-f", "-")
+		cmd.Stdin = strings.NewReader(cr)
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		DeferCleanup(func() {
+			cmd := exec.Command("kubectl", "delete", "catalogimage", catalogName,
+				"-n", testNamespace, "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+		})
+
+		EventuallyWithOffset(1, func() error {
+			cmd := exec.Command("kubectl", "get", "catalogimage", catalogName,
+				"-n", testNamespace, "-o", "jsonpath={.status.phase}")
+			output, err := utils.Run(cmd)
+			if err != nil {
+				return err
+			}
+			phase := strings.TrimSpace(string(output))
+			if phase != "Available" {
+				return fmt.Errorf("CatalogImage phase is %q, want Available", phase)
+			}
+			return nil
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+		cmd = exec.Command("kubectl", "get", "catalogimage", catalogName,
+			"-n", testNamespace,
+			"-o", "jsonpath={.status.registryMetadata.resolvedDigest}")
+		output, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strings.TrimSpace(string(output))).To(HavePrefix("sha256:"))
+	})
+})
+
+var _ = Describe("Smoke: Negative / Guard Rails", Label("smoke"), Ordered, func() {
+	BeforeAll(func() {
+		ensureOperatorDeployed()
+	})
+
+	// #18 – secureBuild without taskBundleRef is a terminal validation error
+	It("invalid ImageBuild should reach Failed with a status message", func() {
+		buildName := "smoke-test-invalid"
+
+		cr := fmt.Sprintf(`apiVersion: automotive.sdv.cloud.redhat.com/v1alpha1
+kind: ImageBuild
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  architecture: %s
+  secureBuild: true
+  aib:
+    distro: autosd
+    target: qemu
+    mode: image
+    manifest: |
+      name: invalid-test
+`, buildName, testNamespace, arch)
+
+		applyImageBuildCR(buildName, cr)
+		DeferCleanup(func() { deleteImageBuildCR(buildName) })
+
+		EventuallyWithOffset(1, func() error {
+			cmd := exec.Command("kubectl", "get", "imagebuild", buildName,
+				"-n", testNamespace, "-o", "jsonpath={.status.phase}")
+			output, err := utils.Run(cmd)
+			if err != nil {
+				return err
+			}
+			phase := strings.TrimSpace(string(output))
+			if phase != "Failed" {
+				return fmt.Errorf("ImageBuild phase is %q, want Failed", phase)
+			}
+			return nil
+		}, time.Minute, 2*time.Second).Should(Succeed())
+
+		cmd := exec.Command("kubectl", "get", "imagebuild", buildName,
+			"-n", testNamespace, "-o", "jsonpath={.status.message}")
+		output, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strings.TrimSpace(string(output))).NotTo(BeEmpty())
+	})
+
+	// #19
+	It("ImageBuild deletion should garbage-collect PipelineRun", func() {
+		imageBuildName := "smoke-test-cleanup"
+
+		cr := fmt.Sprintf(`apiVersion: automotive.sdv.cloud.redhat.com/v1alpha1
+kind: ImageBuild
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  architecture: %s
+  aib:
+    distro: autosd
+    target: qemu
+    mode: image
+    manifest: |
+      name: cleanup-test
+`, imageBuildName, testNamespace, arch)
+
+		applyImageBuildCR(imageBuildName, cr)
+
+		var pipelineRunName string
+		EventuallyWithOffset(1, func() error {
+			cmd := exec.Command("kubectl", "get", "pipelinerun",
+				"-l", fmt.Sprintf("automotive.sdv.cloud.redhat.com/imagebuild-name=%s", imageBuildName),
+				"-n", testNamespace, "-o", "jsonpath={.items[0].metadata.name}")
+			output, err := utils.Run(cmd)
+			if err != nil {
+				return err
+			}
+			name := strings.TrimSpace(string(output))
+			if name == "" {
+				return fmt.Errorf("no PipelineRun found for ImageBuild %s", imageBuildName)
+			}
+			pipelineRunName = name
+			return nil
+		}, 30*time.Second, 2*time.Second).Should(Succeed())
+
+		cmd := exec.Command("kubectl", "delete", "imagebuild", imageBuildName,
+			"-n", testNamespace, "--ignore-not-found")
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		EventuallyWithOffset(1, func() error {
+			cmd := exec.Command("kubectl", "get", "pipelinerun", pipelineRunName,
+				"-n", testNamespace, "--ignore-not-found", "-o", "name")
+			output, err := utils.Run(cmd)
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(string(output)) == "" {
+				return nil
+			}
+			return fmt.Errorf("PipelineRun %s still exists after ImageBuild deletion", pipelineRunName)
+		}, 30*time.Second, 2*time.Second).Should(Succeed())
+	})
+})


### PR DESCRIPTION
## Summary
expands E2E coverage per the test coverage proposal: smoke tests for fast PR feedback, core lifecycle/API tests, and package-mode build support.

- Add 19 smoke tests (`Label("smoke")`) covering operator health, CRDs, Build API endpoints, CR lifecycle, and guard rails
- Run smoke tests by default on every PR (`e2e.yml`); add `/e2e-smoke` lane in `e2e-lanes.yml`
- Add Phase 2 core E2E tests: ImageBuild lifecycle, OperatorConfig toggles, Build API CRUD/ownership, error handling
- Add Phase 3 package-mode disk image build test (`Label("package-mode")`) and `/e2e-package-mode` CI lane
- Extend shared helpers (`ensureBuildAPIAccess`, Dex OIDC, ImageBuild/Build API utilities)
- Add `test/e2e/e2e-test-coverage-TODO.md` to track remaining phases 4–5

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] CI/CD improvement
- [ ] Refactoring

## Testing
- [ ] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [x] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added an end-to-end smoke suite covering cluster/operator readiness, Build API endpoints, ImageBuild lifecycle (including negative + cleanup scenarios).
  * Introduced or expanded E2E suites for Build API authorization, build cancellation, OperatorConfig enable/disable, error handling, features (TTL/propagation/log streaming), and package-mode builds.
  * Updated helpers and manifest validation to improve Build API and ImageBuild verification.

* **CI / Automation**
  * Extended E2E lane parsing for smoke/package-mode/features and refined per-lane timeouts.
  * Improved workflow defaults and dispatch behavior when no label filter is provided.

* **Build / Developer Experience**
  * Added `Makefile.e2e` and new lane-specific E2E make targets; updated local runner help.

* **Docs**
  * Updated E2E README lanes and benchmark timings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->