### PR TITLE
fix: drop storage-class flag from caib cli

### DIFF
--- a/cmd/caib/README.md
+++ b/cmd/caib/README.md
@@ -126,7 +126,6 @@ caib image build <manifest.aib.yml> [flags]
 | `-o`, `--output` | | Download disk image to local file (implies `--disk`) |
 | `--builder-image` | | Custom aib-build container |
 | `--aib-image` | `quay.io/.../automotive-image-builder:1.3.2` | AIB container image |
-| `--storage-class` | | Storage class for build workspace PVC |
 | `-D`, `--define` | | Custom definition `KEY=VALUE` (repeatable) |
 | `--timeout` | `60` | Timeout in minutes |
 | `-w`, `--wait` | `false` | Wait for build to complete |
@@ -210,7 +209,6 @@ caib image disk <container-ref> [flags]
 | `-t`, `--target` | `qemu` | Target platform |
 | `-a`, `--arch` | (current system) | Architecture (`amd64`, `arm64`) |
 | `--aib-image` | `quay.io/.../automotive-image-builder:1.3.2` | AIB container image |
-| `--storage-class` | | Kubernetes storage class |
 | `--extra-args` | | Extra arguments to pass to AIB (repeatable) |
 | `--timeout` | `60` | Timeout in minutes |
 | `-w`, `--wait` | `false` | Wait for build to complete |
@@ -270,7 +268,6 @@ caib image build-dev <manifest.aib.yml> [flags]
 | `--push` | | Push disk image as OCI artifact to registry |
 | `-o`, `--output` | | Download artifact to local file |
 | `--aib-image` | `quay.io/.../automotive-image-builder:1.3.2` | AIB container image |
-| `--storage-class` | | Storage class for build workspace PVC |
 | `-D`, `--define` | | Custom definition `KEY=VALUE` (repeatable) |
 | `--define-file` | | Load defines from YAML dictionary file (repeatable) |
 | `--extra-args` | | Extra arguments to pass to AIB (repeatable) |

--- a/cmd/caib/image/image.go
+++ b/cmd/caib/image/image.go
@@ -40,7 +40,6 @@ type Options struct {
 	ExportFormat           *string
 	Mode                   *string
 	AutomotiveImageBuilder *string
-	StorageClass           *string
 	OutputDir              *string
 	Timeout                *int
 	WaitForBuild           *bool
@@ -148,7 +147,6 @@ func NewImageCmd(opts Options) *cobra.Command {
 	)
 	buildCmd.Flags().StringVar(opts.BuilderImage, "builder-image", "", "custom builder container")
 	buildCmd.Flags().BoolVar(opts.RebuildBuilder, "rebuild-builder", false, "force rebuild of the bootc builder image")
-	buildCmd.Flags().StringVar(opts.StorageClass, "storage-class", "", "Kubernetes storage class for build workspace")
 	buildCmd.Flags().StringArrayVarP(opts.CustomDefs, "define", "D", []string{}, "custom definition KEY=VALUE")
 	buildCmd.Flags().StringArrayVar(opts.DefineFiles, "define-file", []string{}, "load defines from YAML dictionary file (can be repeated)")
 	buildCmd.Flags().StringArrayVar(opts.AIBExtraArgs, "extra-args", []string{}, "extra arguments to pass to AIB (can be repeated)")
@@ -215,7 +213,6 @@ func NewImageCmd(opts Options) *cobra.Command {
 		opts.AutomotiveImageBuilder, "aib-image",
 		automotivev1alpha1.DefaultAutomotiveImageBuilderImage, "AIB container image",
 	)
-	diskCmd.Flags().StringVar(opts.StorageClass, "storage-class", "", "Kubernetes storage class")
 	diskCmd.Flags().StringArrayVar(opts.AIBExtraArgs, "extra-args", []string{}, "extra arguments to pass to AIB (can be repeated)")
 	diskCmd.Flags().IntVar(opts.Timeout, "timeout", 60, "timeout in minutes")
 	diskCmd.Flags().BoolVarP(opts.WaitForBuild, "wait", "w", false, "wait for build to complete")
@@ -258,7 +255,6 @@ func NewImageCmd(opts Options) *cobra.Command {
 		opts.AutomotiveImageBuilder, "aib-image",
 		automotivev1alpha1.DefaultAutomotiveImageBuilderImage, "AIB container image",
 	)
-	buildDevCmd.Flags().StringVar(opts.StorageClass, "storage-class", "", "Kubernetes storage class")
 	buildDevCmd.Flags().StringArrayVarP(opts.CustomDefs, "define", "D", []string{}, "custom definition KEY=VALUE")
 	buildDevCmd.Flags().StringArrayVar(opts.DefineFiles, "define-file", []string{}, "load defines from YAML dictionary file (can be repeated)")
 	buildDevCmd.Flags().StringArrayVar(opts.AIBExtraArgs, "extra-args", []string{}, "extra arguments to pass to AIB (can be repeated)")

--- a/cmd/caib/runtime_wiring.go
+++ b/cmd/caib/runtime_wiring.go
@@ -296,7 +296,6 @@ func (s runtimeState) imageOptions(h handlerSet) image.Options {
 		ExportFormat:           s.ExportFormat,
 		Mode:                   s.Mode,
 		AutomotiveImageBuilder: s.AutomotiveImageBuilder,
-		StorageClass:           s.StorageClass,
 		OutputDir:              s.OutputDir,
 		Timeout:                s.Timeout,
 		WaitForBuild:           s.WaitForBuild,

--- a/internal/common/tasks/tasks.go
+++ b/internal/common/tasks/tasks.go
@@ -959,15 +959,6 @@ func GenerateTektonPipeline(name, namespace string, buildConfig *BuildConfig) *t
 					Description: "Compression algorithm for artifacts (lz4, gzip, xz)",
 				},
 				{
-					Name:        "storage-class",
-					Type:        tektonv1.ParamTypeString,
-					Description: "Storage class for the PVC to build on (optional, uses cluster default if not specified)",
-					Default: &tektonv1.ParamValue{
-						Type:      tektonv1.ParamTypeString,
-						StringVal: "",
-					},
-				},
-				{
 					Name: "automotive-image-builder",
 					Type: tektonv1.ParamTypeString,
 					Default: &tektonv1.ParamValue{


### PR DESCRIPTION
## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Removed Features**
  * Removed the `--storage-class` option from `caib image build`, `caib image disk`, and `caib image build-dev`.
* **Documentation**
  * Updated the CLI option tables in the command documentation to no longer list `--storage-class`.
* **Behavior Change**
  * The image build pipeline no longer includes a `storage-class` parameter, so builds use the default storage configuration instead of a user-specified storage class.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->