### PR TITLE
refactor: streamline container build auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,9 +117,10 @@ test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
 # E2E test targets. Use test-e2e to run everything, or pick a lane:
-#   test-e2e-operator  - operator health, Tekton tasks, Build API
-#   test-e2e-bootc     - bootc container build via caib
-#   test-e2e-auth      - OIDC authentication (OpenShift only)
+#   test-e2e-operator        - operator health, Tekton tasks, Build API
+#   test-e2e-bootc           - bootc container build via caib
+#   test-e2e-container-build - Shipwright container build via caib
+#   test-e2e-auth            - OIDC authentication (OpenShift only)
 .PHONY: test-e2e
 test-e2e:
 	go test ./test/e2e/ -v -ginkgo.v -timeout 45m
@@ -131,6 +132,10 @@ test-e2e-operator:
 .PHONY: test-e2e-bootc
 test-e2e-bootc:
 	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-bootc} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="bootc" -timeout 35m
+
+.PHONY: test-e2e-container-build
+test-e2e-container-build:
+	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-container-build} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="container-build" -timeout 45m
 
 .PHONY: test-e2e-auth
 test-e2e-auth:

--- a/cmd/caib/container/build.go
+++ b/cmd/caib/container/build.go
@@ -189,7 +189,7 @@ func runBuildContainer(_ *cobra.Command, args []string) {
 	}
 	clilog.Infoln("Creating container build...")
 	var createResp *buildapitypes.ContainerBuildResponse
-	err := executeWithReauth(serverURL, &authToken, func(client *buildapiclient.Client) error {
+	err := caibcommon.ExecuteWithReauth(serverURL, &authToken, insecureSkipTLS, func(client *buildapiclient.Client) error {
 		resp, cerr := client.CreateContainerBuild(ctx, buildapitypes.ContainerBuildRequest{
 			Name:                buildName,
 			Output:              containerBuildPush,
@@ -318,7 +318,7 @@ func waitForContainerBuildUploadReady(ctx context.Context, name string) {
 			handleError(fmt.Errorf("timed out waiting for build to reach Uploading phase"))
 		case <-ticker.C:
 			var status *buildapitypes.ContainerBuildResponse
-			err := executeWithReauth(serverURL, &authToken, func(client *buildapiclient.Client) error {
+			err := caibcommon.ExecuteWithReauth(serverURL, &authToken, insecureSkipTLS, func(client *buildapiclient.Client) error {
 				s, serr := client.GetContainerBuild(ctx, name)
 				if serr != nil {
 					return serr
@@ -358,7 +358,7 @@ func uploadContainerBuildContext(ctx context.Context, name string, tarballPath s
 			handleError(fmt.Errorf("failed to open tarball: %w", err))
 		}
 
-		err = executeWithReauth(serverURL, &authToken, func(client *buildapiclient.Client) error {
+		err = caibcommon.ExecuteWithReauth(serverURL, &authToken, insecureSkipTLS, func(client *buildapiclient.Client) error {
 			// Seek to beginning in case of auth retries
 			_, seekErr := tarball.Seek(0, io.SeekStart)
 			if seekErr != nil {
@@ -392,7 +392,7 @@ func isContainerBuildTerminal(phase string) bool {
 // getContainerBuildStatus retrieves the current build status.
 func getContainerBuildStatus(ctx context.Context, name string) (*buildapitypes.ContainerBuildResponse, error) {
 	var status *buildapitypes.ContainerBuildResponse
-	err := executeWithReauth(serverURL, &authToken, func(client *buildapiclient.Client) error {
+	err := caibcommon.ExecuteWithReauth(serverURL, &authToken, insecureSkipTLS, func(client *buildapiclient.Client) error {
 		s, serr := client.GetContainerBuild(ctx, name)
 		if serr != nil {
 			return serr

--- a/cmd/caib/container/container.go
+++ b/cmd/caib/container/container.go
@@ -17,6 +17,7 @@ limitations under the License.
 package container
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/config"
@@ -29,15 +30,18 @@ func NewContainerCmd() *cobra.Command {
 		Use:   "container",
 		Short: "Build container images using Shipwright",
 		Long:  `Build container images using Shipwright Build and push to registries.`,
-		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			if strings.TrimSpace(serverURL) == "" {
 				serverURL = config.DefaultServerWithDerive()
+			}
+			if flag := cmd.Root().PersistentFlags().Lookup("insecure"); flag != nil {
+				if val, err := strconv.ParseBool(flag.Value.String()); err == nil && val {
+					insecureSkipTLS = true
+				}
 			}
 			return nil
 		},
 	}
-
-	cmd.PersistentFlags().BoolVar(&insecureSkipTLS, "insecure-skip-tls-verify", false, "skip TLS certificate verification")
 
 	cmd.AddCommand(newBuildCmd())
 	cmd.AddCommand(newLogsCmd())

--- a/cmd/caib/container/utilities.go
+++ b/cmd/caib/container/utilities.go
@@ -17,175 +17,18 @@ limitations under the License.
 package container
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"regexp"
 	"strings"
 
-	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/auth"
-	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	caibcommon "github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/common"
-	buildapiclient "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi/client"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 // handleError prints an error and exits
 func handleError(err error) {
 	fmt.Fprintln(os.Stderr, caibcommon.FormatError(err))
 	os.Exit(1)
-}
-
-// executeWithReauth executes a function with authentication retry
-func executeWithReauth(serverURL string, authToken *string, fn func(*buildapiclient.Client) error) error {
-	ctx := context.Background()
-
-	client, err := createBuildAPIClient(serverURL, authToken)
-	if err != nil {
-		return err
-	}
-
-	err = fn(client)
-	if err == nil {
-		return nil
-	}
-
-	if !auth.IsAuthError(err) {
-		return err
-	}
-
-	// Auth error (401) - try re-authentication; token may be rejected, not necessarily expired
-	clilog.Infoln("Authentication failed (401), re-authenticating...")
-
-	newToken, _, err := auth.GetTokenWithReauth(ctx, serverURL, *authToken, insecureSkipTLS)
-	if err != nil {
-		return fmt.Errorf("re-authentication failed: %w", err)
-	}
-
-	*authToken = newToken
-	// If re-auth returned no token (API says OIDC not configured), try kubeconfig before retrying
-	if strings.TrimSpace(*authToken) == "" {
-		if tok, kerr := loadTokenFromKubeconfig(); kerr == nil && strings.TrimSpace(tok) != "" {
-			*authToken = tok
-			client, err = createBuildAPIClient(serverURL, authToken)
-			if err != nil {
-				return err
-			}
-			clilog.Infoln("Using kubeconfig token, retrying...")
-			return fn(client)
-		}
-	}
-
-	client, err = createBuildAPIClient(serverURL, authToken)
-	if err != nil {
-		return err
-	}
-
-	clilog.Infoln("Retrying request...")
-	err = fn(client)
-	if err == nil {
-		return nil
-	}
-
-	// Still 401 after OIDC re-auth (e.g. server OIDC broken, or wrong client/audience) - try kubeconfig fallback
-	if !auth.IsAuthError(err) {
-		return err
-	}
-	if tok, kerr := loadTokenFromKubeconfig(); kerr == nil && strings.TrimSpace(tok) != "" {
-		*authToken = tok
-		client, err = createBuildAPIClient(serverURL, authToken)
-		if err != nil {
-			return err
-		}
-		clilog.Infoln("Attempting kubeconfig fallback...")
-		return fn(client)
-	}
-
-	return err
-}
-
-// createBuildAPIClient creates a build API client with authentication token from flags or kubeconfig
-func createBuildAPIClient(serverURL string, authToken *string) (*buildapiclient.Client, error) {
-	ctx := context.Background()
-
-	explicitToken := strings.TrimSpace(*authToken) != "" || os.Getenv("CAIB_TOKEN") != ""
-
-	// If no explicit token, try OIDC if config is available
-	if !explicitToken {
-		token, didAuth, err := auth.GetTokenWithReauth(ctx, serverURL, "", insecureSkipTLS)
-		if err != nil {
-			// OIDC is configured but failed - don't silently fall back to kubeconfig
-			// This indicates a real authentication failure that should be reported
-			// Falling back could authenticate with an unexpected identity
-			oidcErr := err
-			fmt.Printf("Error: OIDC authentication failed: %v\n", oidcErr)
-			// Only try kubeconfig as last resort, but warn the user
-			clilog.Infoln("Attempting kubeconfig fallback (this may use a different identity)")
-			if tok, kerr := loadTokenFromKubeconfig(); kerr == nil && strings.TrimSpace(tok) != "" {
-				*authToken = tok
-			} else {
-				// No kubeconfig available either - return error
-				return nil, fmt.Errorf("OIDC authentication failed (%v) and no kubeconfig token available: %w", oidcErr, kerr)
-			}
-		} else if token != "" {
-			// OIDC succeeded
-			*authToken = token
-			if didAuth {
-				clilog.Infoln("OIDC authentication successful")
-			}
-		} else {
-			// OIDC not configured in OperatorConfig
-			if tok, err := loadTokenFromKubeconfig(); err == nil && strings.TrimSpace(tok) != "" {
-				*authToken = tok
-			}
-		}
-	} else {
-		// Token was explicitly provided, use it (but still try kubeconfig if empty)
-		if strings.TrimSpace(*authToken) == "" {
-			if tok, err := loadTokenFromKubeconfig(); err == nil && strings.TrimSpace(tok) != "" {
-				*authToken = tok
-			}
-		}
-	}
-
-	var opts []buildapiclient.Option
-	if strings.TrimSpace(*authToken) != "" {
-		opts = append(opts, buildapiclient.WithAuthToken(strings.TrimSpace(*authToken)))
-	}
-
-	// Configure TLS
-	if insecureSkipTLS {
-		opts = append(opts, buildapiclient.WithInsecureTLS())
-	}
-	// Check for custom CA certificate
-	if caCertFile := os.Getenv("SSL_CERT_FILE"); caCertFile != "" {
-		opts = append(opts, buildapiclient.WithCACertificate(caCertFile))
-	} else if caCertFile := os.Getenv("REQUESTS_CA_BUNDLE"); caCertFile != "" {
-		opts = append(opts, buildapiclient.WithCACertificate(caCertFile))
-	}
-
-	return buildapiclient.New(serverURL, opts...)
-}
-
-// loadTokenFromKubeconfig loads a bearer token from kubeconfig
-func loadTokenFromKubeconfig() (string, error) {
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	// First, ask client-go to build a client config. This will execute any exec credential plugins
-	// (e.g., OpenShift login) and populate a usable BearerToken.
-	deferred := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{})
-	if restCfg, err := deferred.ClientConfig(); err == nil && restCfg != nil {
-		if t := strings.TrimSpace(restCfg.BearerToken); t != "" {
-			return t, nil
-		}
-		if f := strings.TrimSpace(restCfg.BearerTokenFile); f != "" {
-			if b, rerr := os.ReadFile(f); rerr == nil {
-				if t := strings.TrimSpace(string(b)); t != "" {
-					return t, nil
-				}
-			}
-		}
-	}
-	return "", fmt.Errorf("no token found in kubeconfig")
 }
 
 // sanitizeBuildName sanitizes a build name

--- a/hack/crc/02-deploy-operator.sh
+++ b/hack/crc/02-deploy-operator.sh
@@ -29,7 +29,7 @@ fail()  { echo -e "${RED}❌  $*${NC}"; exit 1; }
 line()  { echo "========================================="; }
 
 STEP=0
-TOTAL_STEPS=6
+TOTAL_STEPS=7
 step()  { STEP=$((STEP + 1)); info "[Step ${STEP}/${TOTAL_STEPS}] $*"; }
 
 ###############################################################################
@@ -134,7 +134,69 @@ EOF
 fi
 
 ###############################################################################
-# Step 3 — Build & deploy the operator via OLM catalog
+# Step 3 — Install OpenShift Builds (Shipwright)
+###############################################################################
+step "Installing OpenShift Builds (Shipwright)..."
+
+SHIPWRIGHT_READY=true
+for crd in builds.shipwright.io buildruns.shipwright.io; do
+    if ! oc get crd "$crd" &>/dev/null; then
+        SHIPWRIGHT_READY=false
+        break
+    fi
+done
+
+if [[ "$SHIPWRIGHT_READY" == true ]]; then
+    ok "OpenShift Builds already installed (Shipwright CRDs present)."
+else
+    cat <<EOF | oc apply -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-builds-operator
+  namespace: openshift-operators
+spec:
+  channel: latest
+  name: openshift-builds-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+
+    info "Waiting for OpenShift Builds CSV to succeed..."
+    CSV_PHASE=""
+    for _ in {1..90}; do
+        CSV_PHASE=$(oc get csv -n openshift-operators \
+            -l operators.coreos.com/openshift-builds-operator.openshift-operators= \
+            -o jsonpath='{.items[0].status.phase}' 2>/dev/null || true)
+        [[ "$CSV_PHASE" == "Succeeded" ]] && break
+        sleep 10
+    done
+    [[ "$CSV_PHASE" == "Succeeded" ]] \
+        || fail "OpenShift Builds CSV not ready after 15 minutes (phase: ${CSV_PHASE:-unknown})."
+
+    info "Creating ShipwrightBuild CR..."
+    cat <<EOF | oc apply -f -
+apiVersion: operator.shipwright.io/v1alpha1
+kind: ShipwrightBuild
+metadata:
+  name: openshift-builds
+spec:
+  targetNamespace: openshift-builds
+EOF
+
+    info "Waiting for Shipwright CRDs to be available..."
+    for crd in builds.shipwright.io buildruns.shipwright.io; do
+        for _ in {1..60}; do
+            oc get crd "$crd" &>/dev/null && break
+            sleep 5
+        done
+        oc get crd "$crd" &>/dev/null || fail "Shipwright CRD $crd not found after 5 minutes."
+    done
+    ok "OpenShift Builds ready (Shipwright CRDs installed)."
+fi
+
+###############################################################################
+# Step 4 — Build & deploy the operator via OLM catalog
 ###############################################################################
 step "Building and deploying the operator..."
 
@@ -157,14 +219,14 @@ if ! oc policy add-role-to-user system:image-puller "system:serviceaccount:${NAM
 fi
 
 ###############################################################################
-# Step 4 — Label nodes for build scheduling
+# Step 5 — Label nodes for build scheduling
 ###############################################################################
 step "Labeling nodes for build pod scheduling..."
 oc label nodes --all aib=true --overwrite || fail "Failed to label nodes."
 ok "Nodes labeled with aib=true."
 
 ###############################################################################
-# Step 5 — Patch OperatorConfig and wait for Ready
+# Step 6 — Patch OperatorConfig and wait for Ready
 ###############################################################################
 step "Patching OperatorConfig to use internal registry..."
 oc patch operatorconfig config -n "$NAMESPACE" --type=merge \
@@ -183,7 +245,7 @@ done
 ok "OperatorConfig reconciled (phase: Ready)."
 
 ###############################################################################
-# Step 6 — Verify
+# Step 7 — Verify
 ###############################################################################
 step "Verifying deployment..."
 BUILD_API_ROUTE=$(oc get route ado-build-api -n "$NAMESPACE" -o jsonpath='{.spec.host}' 2>/dev/null || echo "")

--- a/hack/crc/03-crc-operator-sanity.sh
+++ b/hack/crc/03-crc-operator-sanity.sh
@@ -113,6 +113,17 @@ echo ""
 echo -e "${CYAN}=== OpenShift Pipelines Operator ===${NC}"
 check "Pipelines operator CSV succeeded" test "$(oc get csv -n openshift-operators -l operators.coreos.com/openshift-pipelines-operator-rh.openshift-operators= -o jsonpath='{.items[0].status.phase}' 2>/dev/null)" = "Succeeded"
 
+echo ""
+echo -e "${CYAN}=== OpenShift Builds (Shipwright) ===${NC}"
+if oc get crd builds.shipwright.io &>/dev/null; then
+    check "Shipwright CRD: builds.shipwright.io" oc get crd builds.shipwright.io
+    check "Shipwright CRD: buildruns.shipwright.io" oc get crd buildruns.shipwright.io
+    check "ShipwrightBuild CR exists" oc get shipwrightbuild openshift-builds
+    check "Builds operator CSV succeeded" test "$(oc get csv -n openshift-operators -l operators.coreos.com/openshift-builds-operator.openshift-operators= -o jsonpath='{.items[0].status.phase}' 2>/dev/null)" = "Succeeded"
+else
+    echo -e "  ${CYAN}SKIP${NC}  OpenShift Builds not installed (optional)"
+fi
+
 ###############################################################################
 # End-to-end build test (optional, pass --sanity to enable)
 ###############################################################################

--- a/hack/run-e2e-local.sh
+++ b/hack/run-e2e-local.sh
@@ -15,10 +15,11 @@ usage() {
   printf 'Usage: %s [OPTIONS] [LANE]\n\n' "$(basename "$0")"
   printf 'Run e2e tests against a local CRC/OpenShift cluster.\n\n'
   printf 'Lanes:\n'
-  printf '  operator  - operator health, Tekton tasks, Build API\n'
-  printf '  bootc     - bootc container build via caib\n'
-  printf '  auth      - OIDC authentication (OpenShift or Kind+Dex)\n'
-  printf '  all       - run all tests (default)\n\n'
+  printf '  operator        - operator health, Tekton tasks, Build API\n'
+  printf '  bootc           - bootc container build via caib\n'
+  printf '  container-build - Shipwright container build via caib\n'
+  printf '  auth            - OIDC authentication (OpenShift or Kind+Dex)\n'
+  printf '  all             - run all tests (default)\n\n'
   printf 'Options:\n'
   printf '  -h, --help    Show this help message and exit\n\n'
   printf 'Environment variables:\n'
@@ -37,7 +38,7 @@ esac
 
 E2E_LANE="${1:-}"
 case "$E2E_LANE" in
-  operator|bootc|auth)
+  operator|bootc|auth|container-build)
     E2E_MAKE_TARGET="test-e2e-${E2E_LANE}"
     ;;
   ""|all)
@@ -144,6 +145,80 @@ EOF
   info "OpenShift Pipelines is ready."
 }
 
+ensure_shipwright() {
+  local crds_ready=true
+  local crd
+
+  for crd in builds.shipwright.io buildruns.shipwright.io; do
+    if ! oc get crd "$crd" >/dev/null 2>&1; then
+      crds_ready=false
+      break
+    fi
+  done
+
+  if [[ "$crds_ready" == "true" ]]; then
+    info "OpenShift Builds (Shipwright) already installed."
+    return
+  fi
+
+  info "Installing OpenShift Builds (Shipwright)..."
+
+  cat <<EOF | oc apply -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-builds-operator
+  namespace: openshift-operators
+spec:
+  channel: latest
+  name: openshift-builds-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+
+  info "Waiting for OpenShift Builds CSV to be Succeeded..."
+  local csv_name=""
+  local csv_phase=""
+  local csv_snapshot=""
+  for _ in {1..90}; do
+    csv_name="$(oc get csv -n openshift-operators \
+      -o jsonpath='{range .items[?(@.status.phase=="Succeeded")]}{.metadata.name}{"\n"}{end}' 2>/dev/null \
+      | awk '/^openshift-builds-operator/{print; exit}' || true)"
+    if [[ -n "$csv_name" ]]; then
+      csv_phase="Succeeded"
+      break
+    fi
+
+    csv_snapshot="$(oc get csv -n openshift-operators \
+      -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.phase}{"\n"}{end}' 2>/dev/null || true)"
+    csv_name="$(printf '%s\n' "$csv_snapshot" | awk -F'\t' '$1 ~ /^openshift-builds-operator/ {print $1; exit}')"
+    csv_phase="$(printf '%s\n' "$csv_snapshot" | awk -F'\t' '$1 ~ /^openshift-builds-operator/ {print $2; exit}')"
+    [[ "$csv_phase" == "Succeeded" ]] && break
+    sleep 10
+  done
+  [[ "$csv_phase" == "Succeeded" ]] || fail "OpenShift Builds CSV not ready (csv: ${csv_name:-unknown}, phase: ${csv_phase:-unknown})."
+
+  info "Creating ShipwrightBuild CR..."
+  cat <<EOF | oc apply -f -
+apiVersion: operator.shipwright.io/v1alpha1
+kind: ShipwrightBuild
+metadata:
+  name: openshift-builds
+spec:
+  targetNamespace: openshift-builds
+EOF
+
+  info "Waiting for Shipwright CRDs to be available..."
+  for crd in builds.shipwright.io buildruns.shipwright.io; do
+    for _ in {1..60}; do
+      oc get crd "$crd" >/dev/null 2>&1 && break
+      sleep 5
+    done
+    oc get crd "$crd" >/dev/null 2>&1 || fail "Shipwright CRD $crd not found after 5 minutes."
+  done
+  info "OpenShift Builds (Shipwright) is ready."
+}
+
 set_build_platform() {
   local cluster_arch
   cluster_arch="$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.architecture}')"
@@ -209,6 +284,7 @@ info "Ensuring external registry route and client trust are configured..."
 bash hack/crc/04-expose-default-registry.sh
 
 ensure_tekton
+ensure_shipwright
 set_build_platform
 
 info "Building caib CLI..."

--- a/internal/buildapi/container_builds.go
+++ b/internal/buildapi/container_builds.go
@@ -597,12 +597,19 @@ func (a *APIServer) uploadContainerBuildContext(c *gin.Context, name string) {
 	}
 
 	// Phase 2: Signal completion to the waiter.
-	// Retry with backoff: the waiter's "start" command may not have created the lock file yet
-	// when the tar extraction completes quickly (race between Tekton entrypoint and our exec).
-	doneCmd := []string{"waiter", "done"}
-	if lockFile, ok := getWaiterLockFileFromPodSpec(buildPod, waiterContainer); ok {
-		doneCmd = append(doneCmd, "--lock-file="+lockFile)
+	// The waiter's "start" command may not have created the lock file yet when the
+	// tar extraction completes quickly (race between Tekton entrypoint and our exec).
+	// Wait for the lock file inside the container to avoid SPDY reconnection overhead.
+	lockFile := "/shp-tmp/waiter.lock"
+	if lf, ok := getWaiterLockFileFromPodSpec(buildPod, waiterContainer); ok {
+		lockFile = lf
 	}
+
+	waitAndDoneScript := fmt.Sprintf(
+		`for i in $(seq 1 60); do [ -f %[1]s ] && exec waiter done --lock-file=%[1]s; sleep 1; done; echo "timeout waiting for lock file %[1]s" >&2; exit 1`,
+		lockFile,
+	)
+	doneCmd := []string{"sh", "-c", waitAndDoneScript}
 
 	doneExecReq := clientset.CoreV1().RESTClient().Post().
 		Resource("pods").
@@ -624,41 +631,21 @@ func (a *APIServer) uploadContainerBuildContext(c *gin.Context, name string) {
 		return
 	}
 
-	const maxDoneRetries = 5
-	var lastErr error
-	var lastDetail string
-	for attempt := range maxDoneRetries {
-		var doneStdout strings.Builder
-		var doneStderr strings.Builder
-		err := doneExecutor.StreamWithContext(ctx, remotecommand.StreamOptions{
-			Stdout: &doneStdout,
-			Stderr: &doneStderr,
-		})
-		if err == nil {
-			break
+	var doneStdout strings.Builder
+	var doneStderr strings.Builder
+	if err := doneExecutor.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdout: &doneStdout,
+		Stderr: &doneStderr,
+	}); err != nil {
+		detail := strings.TrimSpace(doneStderr.String())
+		if detail == "" {
+			detail = strings.TrimSpace(doneStdout.String())
 		}
-		lastDetail = strings.TrimSpace(doneStderr.String())
-		if lastDetail == "" {
-			lastDetail = strings.TrimSpace(doneStdout.String())
-		}
-		lastErr = err
-		if !strings.Contains(lastDetail, "no such file or directory") || attempt >= maxDoneRetries-1 {
-			break
-		}
-		select {
-		case <-time.After(time.Duration(attempt+1) * time.Second):
-		case <-ctx.Done():
-			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "request cancelled during retry"})
+		if detail != "" {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("error signaling completion: %v: %s", err, detail)})
 			return
 		}
-	}
-
-	if lastErr != nil {
-		if lastDetail != "" {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("error signaling completion: %v: %s", lastErr, lastDetail)})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("error signaling completion: %v", lastErr)})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("error signaling completion: %v", err)})
 		return
 	}
 

--- a/internal/controller/containerbuild/controller.go
+++ b/internal/controller/containerbuild/controller.go
@@ -465,6 +465,16 @@ func (r *ContainerBuildReconciler) buildShipwrightBuildRun(
 		Values: buildArgValues,
 	})
 
+	if cb.Spec.UseServiceAccountAuth {
+		registryHost := extractRegistryHost(cb.Spec.Output)
+		if registryHost != "" {
+			paramValues = append(paramValues, shipwrightv1beta1.ParamValue{
+				Name:   "registries-insecure",
+				Values: []shipwrightv1beta1.SingleValue{{Value: &registryHost}},
+			})
+		}
+	}
+
 	// Build output
 	output := shipwrightv1beta1.Image{
 		Image: cb.Spec.Output,
@@ -509,6 +519,19 @@ func (r *ContainerBuildReconciler) buildShipwrightBuildRun(
 	}
 
 	return buildRun
+}
+
+func extractRegistryHost(imageRef string) string {
+	ref := strings.TrimPrefix(imageRef, "docker://")
+	slashIdx := strings.IndexByte(ref, '/')
+	if slashIdx < 0 {
+		return ""
+	}
+	host := ref[:slashIdx]
+	if strings.ContainsAny(host, ".:") {
+		return host
+	}
+	return ""
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/containerbuild/controller_test.go
+++ b/internal/controller/containerbuild/controller_test.go
@@ -275,3 +275,67 @@ func TestBuildRunNamespacedStrategy(t *testing.T) {
 		t.Errorf("strategy kind = %v, want NamespacedBuildStrategy", *br.Spec.Build.Spec.Strategy.Kind)
 	}
 }
+
+func TestExtractRegistryHost(t *testing.T) {
+	tests := []struct {
+		imageRef string
+		want     string
+	}{
+		{"image-registry.openshift-image-registry.svc:5000/ns/img:tag", "image-registry.openshift-image-registry.svc:5000"},
+		{"quay.io/org/image:latest", "quay.io"},
+		{"registry.example.com/image:v1", "registry.example.com"},
+		{"docker://registry.example.com/image:v1", "registry.example.com"},
+		{"ubuntu:latest", ""},
+		{"localhost:5000/myimg:latest", "localhost:5000"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.imageRef, func(t *testing.T) {
+			got := extractRegistryHost(tt.imageRef)
+			if got != tt.want {
+				t.Errorf("extractRegistryHost(%q) = %q, want %q", tt.imageRef, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildRunInsecureRegistryForInternalPush(t *testing.T) {
+	r := &ContainerBuildReconciler{}
+	cb := newTestContainerBuild("test", automotivev1alpha1.ContainerBuildSpec{
+		Output:                "image-registry.openshift-image-registry.svc:5000/ns/img:latest",
+		UseServiceAccountAuth: true,
+		Timeout:               15,
+	})
+
+	br := r.buildShipwrightBuildRun(cb, "test-br", 5*time.Minute)
+
+	var insecureVals []string
+	for _, pv := range br.Spec.Build.Spec.ParamValues {
+		if pv.Name == "registries-insecure" {
+			for _, sv := range pv.Values {
+				if sv.Value != nil {
+					insecureVals = append(insecureVals, *sv.Value)
+				}
+			}
+		}
+	}
+	if len(insecureVals) != 1 || insecureVals[0] != "image-registry.openshift-image-registry.svc:5000" {
+		t.Errorf("registries-insecure = %v, want [image-registry.openshift-image-registry.svc:5000]", insecureVals)
+	}
+}
+
+func TestBuildRunNoInsecureRegistryForExternalPush(t *testing.T) {
+	r := &ContainerBuildReconciler{}
+	cb := newTestContainerBuild("test", automotivev1alpha1.ContainerBuildSpec{
+		Output:  "quay.io/org/image:latest",
+		Timeout: 15,
+	})
+
+	br := r.buildShipwrightBuildRun(cb, "test-br", 5*time.Minute)
+
+	for _, pv := range br.Spec.Build.Spec.ParamValues {
+		if pv.Name == "registries-insecure" {
+			t.Error("registries-insecure should not be set for external registry push")
+		}
+	}
+}

--- a/test/config/container-build-context/Containerfile
+++ b/test/config/container-build-context/Containerfile
@@ -1,0 +1,4 @@
+FROM registry.access.redhat.com/ubi9-minimal:latest
+ARG VERSION=latest
+LABEL version="${VERSION}"
+RUN echo "e2e container build test"

--- a/test/e2e/container_build_test.go
+++ b/test/e2e/container_build_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // Dot import is standard for Ginkgo
+	. "github.com/onsi/gomega"    //nolint:revive // Dot import is standard for Gomega
+
+	utils "github.com/centos-automotive-suite/automotive-dev-operator/test/utils"
+)
+
+const (
+	containerBuildTimeout = 15 * time.Minute
+	containerBuildContext = "test/config/container-build-context"
+)
+
+func dumpContainerBuildLogs(buildName string) {
+	// Dump BuildRun paramValues to verify registries-insecure is set
+	brJSON, _ := utils.Run(exec.Command("kubectl", "get", "buildruns.shipwright.io",
+		"-n", testNamespace,
+		"-o", "jsonpath={.items[-1].spec.build.spec.paramValues}"))
+	_, _ = fmt.Fprintf(GinkgoWriter, "\n--- BuildRun paramValues for %s ---\n%s\n", buildName, string(brJSON))
+
+	// Dump ContainerBuild spec
+	cbJSON, _ := utils.Run(exec.Command("kubectl", "get", "containerbuilds.automotive.sdv.cloud.redhat.com",
+		"-n", testNamespace, buildName,
+		"-o", "jsonpath={.spec}"))
+	_, _ = fmt.Fprintf(GinkgoWriter, "\n--- ContainerBuild spec for %s ---\n%s\n", buildName, string(cbJSON))
+
+	pods, _ := utils.Run(exec.Command("kubectl", "get", "pods",
+		"-n", testNamespace,
+		"-l", "buildrun.shipwright.io/name",
+		"--sort-by=.metadata.creationTimestamp",
+		"-o", "jsonpath={.items[-1].metadata.name}"))
+	podName := string(pods)
+	if podName == "" {
+		_, _ = fmt.Fprintf(GinkgoWriter, "\n--- no build pod found for %s ---\n", buildName)
+		return
+	}
+	for _, container := range []string{"step-source-local", "step-build-and-push"} {
+		logs, _ := utils.Run(exec.Command("kubectl", "logs", podName,
+			"-n", testNamespace, "--container="+container))
+		_, _ = fmt.Fprintf(GinkgoWriter, "\n--- %s / %s ---\n%s\n", podName, container, string(logs))
+	}
+
+	// Dump operator controller logs for reconciliation debugging
+	opLogs, _ := utils.Run(exec.Command("kubectl", "logs",
+		"-n", testNamespace, "deployment/ado-operator",
+		"--tail=50"))
+	_, _ = fmt.Fprintf(GinkgoWriter, "\n--- operator controller logs (last 50 lines) ---\n%s\n", string(opLogs))
+}
+
+// isShipwrightInstalled checks if Shipwright CRDs are present on the cluster.
+func isShipwrightInstalled() bool {
+	cmd := exec.Command("kubectl", "api-resources", "--api-group=shipwright.io", "--no-headers")
+	out, err := utils.Run(cmd)
+	return err == nil && len(out) > 0
+}
+
+var _ = Describe("Container Build (Shipwright)", Label("container-build"), Ordered, func() {
+
+	BeforeAll(func() {
+		ensureOperatorDeployed()
+		if !openShiftCluster {
+			Skip("container build tests require OpenShift")
+		}
+		if !isShipwrightInstalled() {
+			Skip("container build tests require Shipwright (OpenShift Builds)")
+		}
+		ensureRegistryConfigured()
+		ensureBuildAPIAccess()
+		ensureCaibCredentials()
+	})
+
+	It("should build and push to internal registry", func() {
+		buildName := "e2e-container-build"
+
+		ctx, cancel := context.WithTimeout(context.Background(), containerBuildTimeout)
+		defer cancel()
+
+		By("launching container build with --internal-registry")
+		cmd := utils.NewCaibCommand(ctx, caibEnv,
+			"container", "build",
+			"--containerfile", containerBuildContext+"/Containerfile",
+			"--name", buildName,
+			"--internal-registry",
+			"--arch", arch,
+			containerBuildContext)
+		output, err := utils.RunSafe(cmd)
+
+		By("verifying container build completed successfully")
+		_, _ = fmt.Fprintf(GinkgoWriter, "\n--- caib container build (%s) ---\n%s\n",
+			buildName, string(output))
+		if err != nil {
+			dumpContainerBuildLogs(buildName)
+		}
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(),
+			fmt.Sprintf("container build failed:\n%sError: %v\n", string(output), err))
+	})
+
+	It("should build with --build-arg", func() {
+		buildName := "e2e-container-buildarg"
+
+		ctx, cancel := context.WithTimeout(context.Background(), containerBuildTimeout)
+		defer cancel()
+
+		By("launching container build with --build-arg and --internal-registry")
+		cmd := utils.NewCaibCommand(ctx, caibEnv,
+			"container", "build",
+			"--containerfile", containerBuildContext+"/Containerfile",
+			"--name", buildName,
+			"--internal-registry",
+			"--build-arg", "VERSION=1.0-e2e",
+			"--arch", arch,
+			containerBuildContext)
+		output, err := utils.RunSafe(cmd)
+
+		By("verifying build-arg container build completed successfully")
+		_, _ = fmt.Fprintf(GinkgoWriter, "\n--- caib container build with build-arg (%s) ---\n%s\n",
+			buildName, string(output))
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(),
+			fmt.Sprintf("build-arg container build failed:\n%sError: %v\n", string(output), err))
+	})
+})

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -156,7 +156,7 @@ func deployOperator() {
 		_, _ = utils.Run(cmd)
 	}
 
-	projectImage := "automotive-dev-operator:test"
+	projectImage := fmt.Sprintf("automotive-dev-operator:test-%d", time.Now().Unix())
 	deployedImage := utils.PrepareOperatorImage(projectImage, testNamespace)
 
 	By("installing CRDs")


### PR DESCRIPTION
Container builds used their own auth workflow instead of using the common one

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [X] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [X] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an end-to-end container build lane and `test-e2e-container-build` make target (label-filtered, longer timeout).
  * When service-account auth is enabled, Shipwright BuildRuns can include an insecure registry parameter for internal registries.
* **Tests**
  * Expanded container build E2E coverage with richer failure logging (and added scenarios for internal registry and build args).
  * Added Shipwright install/validation support in local E2E/CRC flows when required.
* **Bug Fixes**
  * Improved container build completion signaling by waiting for the in-pod waiter lock before finalizing.
  * Updated container-build API interactions to carry through the “insecure” setting during re-auth flows.
* **Chores**
  * Added container-build test Containerfile and improved operator secret cleanup for completed/failed/expired builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->