### PR TITLE
hack: clean CSVs from namespace

### DIFF
--- a/hack/deploy-catalog.sh
+++ b/hack/deploy-catalog.sh
@@ -187,13 +187,8 @@ uninstall_operator() {
     echo "Deleting subscription (if exists)..."
     oc delete subscriptions.operators.coreos.com automotive-dev-operator -n ${NAMESPACE} --ignore-not-found=true
 
-    echo "Deleting CSVs (if exist)..."
-    oc delete csv -n ${NAMESPACE} -l operators.coreos.com/automotive-dev-operator.${NAMESPACE}= --ignore-not-found=true 2>/dev/null || true
-    # Also try by name pattern
-    CSVS=$(oc get csv -n ${NAMESPACE} -o name 2>/dev/null | grep automotive-dev-operator || true)
-    if [ -n "$CSVS" ]; then
-        echo "$CSVS" | xargs -r oc delete -n ${NAMESPACE} --ignore-not-found=true
-    fi
+    echo "Deleting all CSVs in namespace..."
+    oc delete csv --all -n ${NAMESPACE} --ignore-not-found=true 2>/dev/null || true
 
     echo "Deleting InstallPlans (if exist)..."
     oc delete installplan -n ${NAMESPACE} --all --ignore-not-found=true 2>/dev/null || true


### PR DESCRIPTION
To avoid conflicting openshift-pipelines installations

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)
