### PR TITLE
feat: integrate jumpstarter lease tags

### DIFF
--- a/api/v1alpha1/imagebuild_types.go
+++ b/api/v1alpha1/imagebuild_types.go
@@ -151,6 +151,10 @@ type FlashSpec struct {
 	// When set, the target-based lookup is skipped entirely
 	// +optional
 	ExporterSelector string `json:"exporterSelector,omitempty"`
+
+	// LeaseTags are additional key=value tags for the Jumpstarter lease (comma-separated)
+	// +optional
+	LeaseTags string `json:"leaseTags,omitempty"`
 }
 
 // AIBSpec defines the automotive-image-builder configuration
@@ -550,6 +554,14 @@ func (s *ImageBuildSpec) GetFlashLeaseDuration() string {
 func (s *ImageBuildSpec) GetFlashLeaseName() string {
 	if s.Flash != nil {
 		return s.Flash.LeaseName
+	}
+	return ""
+}
+
+// GetFlashLeaseTags returns the user-provided lease tags, or empty string
+func (s *ImageBuildSpec) GetFlashLeaseTags() string {
+	if s.Flash != nil {
+		return s.Flash.LeaseTags
 	}
 	return ""
 }

--- a/api/v1alpha1/imagebuild_types_test.go
+++ b/api/v1alpha1/imagebuild_types_test.go
@@ -4,6 +4,43 @@ import (
 	"testing"
 )
 
+func TestGetFlashLeaseTags(t *testing.T) {
+	tests := []struct {
+		name string
+		spec ImageBuildSpec
+		want string
+	}{
+		{
+			name: "returns tags when flash is set",
+			spec: ImageBuildSpec{
+				Flash: &FlashSpec{LeaseTags: "env=staging,team=platform"},
+			},
+			want: "env=staging,team=platform",
+		},
+		{
+			name: "returns empty when flash is nil",
+			spec: ImageBuildSpec{},
+			want: "",
+		},
+		{
+			name: "returns empty when tags are empty",
+			spec: ImageBuildSpec{
+				Flash: &FlashSpec{},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.spec.GetFlashLeaseTags()
+			if got != tt.want {
+				t.Errorf("GetFlashLeaseTags() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetManifest(t *testing.T) {
 	tests := []struct {
 		name string

--- a/api/v1alpha1/operatorconfig_types.go
+++ b/api/v1alpha1/operatorconfig_types.go
@@ -51,6 +51,9 @@ const (
 	// DefaultFlashLeaseDuration is the default Jumpstarter lease duration in HH:MM:SS format
 	DefaultFlashLeaseDuration = "03:00:00"
 
+	// DefaultFlashLeaseTags is the fallback lease tags when none configured in OperatorConfig
+	DefaultFlashLeaseTags = "platform=caib"
+
 	// DefaultToolchainImage is the default container image for workspace toolchains
 	DefaultToolchainImage = "quay.io/rh-sdv-cloud/autosd-toolchain:latest"
 
@@ -234,6 +237,11 @@ type JumpstarterConfig struct {
 	// +optional
 	DefaultLeaseDuration string `json:"defaultLeaseDuration,omitempty"`
 
+	// DefaultLeaseTags are key=value tags applied to all Jumpstarter leases created by the operator
+	// Format: comma-separated key=value pairs (e.g. "platform=caib,env=prod")
+	// +optional
+	DefaultLeaseTags string `json:"defaultLeaseTags,omitempty"`
+
 	// TargetMappings maps build targets to Jumpstarter exporter configurations
 	// +optional
 	TargetMappings map[string]JumpstarterTargetMapping `json:"targetMappings,omitempty"`
@@ -253,6 +261,14 @@ func (c *JumpstarterConfig) GetDefaultLeaseDuration() string {
 		return c.DefaultLeaseDuration
 	}
 	return DefaultFlashLeaseDuration
+}
+
+// GetDefaultLeaseTags returns the default lease tags, falling back to "platform=caib"
+func (c *JumpstarterConfig) GetDefaultLeaseTags() string {
+	if c != nil && c.DefaultLeaseTags != "" {
+		return c.DefaultLeaseTags
+	}
+	return DefaultFlashLeaseTags
 }
 
 // BuildAPIConfig defines configuration for the Build API server

--- a/api/v1alpha1/operatorconfig_types_test.go
+++ b/api/v1alpha1/operatorconfig_types_test.go
@@ -27,6 +27,27 @@ func TestGetUsePVCScratchVolumes_ExplicitFalse(t *testing.T) {
 	}
 }
 
+func TestGetDefaultLeaseTags_NilConfig(t *testing.T) {
+	var cfg *JumpstarterConfig
+	if cfg.GetDefaultLeaseTags() != DefaultFlashLeaseTags {
+		t.Fatal("nil JumpstarterConfig should return fallback")
+	}
+}
+
+func TestGetDefaultLeaseTags_EmptyDefault(t *testing.T) {
+	cfg := &JumpstarterConfig{}
+	if cfg.GetDefaultLeaseTags() != DefaultFlashLeaseTags {
+		t.Fatal("empty DefaultLeaseTags should return fallback")
+	}
+}
+
+func TestGetDefaultLeaseTags_ExplicitValue(t *testing.T) {
+	cfg := &JumpstarterConfig{DefaultLeaseTags: "platform=caib,cluster=prod"}
+	if cfg.GetDefaultLeaseTags() != "platform=caib,cluster=prod" {
+		t.Fatalf("got %q, want platform=caib,cluster=prod", cfg.GetDefaultLeaseTags())
+	}
+}
+
 func TestIsImageAllowed(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/cmd/caib/buildcmd/build.go
+++ b/cmd/caib/buildcmd/build.go
@@ -75,6 +75,7 @@ type Options struct {
 	LeaseName              *string
 	FlashCmd               *string
 	ExporterSelector       *string
+	LeaseTags              *[]string
 
 	UseInternalRegistry       *bool
 	InternalRegistryImageName *string
@@ -454,6 +455,10 @@ func (h *Handler) applyFlashOptions(req *buildapitypes.BuildRequest, pushRequire
 	}
 	req.FlashCmd = *h.opts.FlashCmd
 	req.FlashExporterSelector = *h.opts.ExporterSelector
+	req.FlashLeaseTags, err = common.ValidateAndJoinLeaseTags(h.opts.LeaseTags)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/cmd/caib/buildcmd/build_disk_test.go
+++ b/cmd/caib/buildcmd/build_disk_test.go
@@ -42,6 +42,7 @@ func newTestDiskOpts() Options {
 		jumpstarterClient    string
 		leaseDuration        = "03:00:00"
 		leaseName            string
+		leaseTags            []string
 		useInternalRegistry  bool
 		internalRegImageName string
 		internalRegTag       string
@@ -85,6 +86,7 @@ func newTestDiskOpts() Options {
 		JumpstarterClient:         &jumpstarterClient,
 		LeaseDuration:             &leaseDuration,
 		LeaseName:                 &leaseName,
+		LeaseTags:                 &leaseTags,
 		UseInternalRegistry:       &useInternalRegistry,
 		InternalRegistryImageName: &internalRegImageName,
 		InternalRegistryTag:       &internalRegTag,

--- a/cmd/caib/common/build_validation.go
+++ b/cmd/caib/common/build_validation.go
@@ -55,6 +55,34 @@ func ValidateReproducibleRequiresSecure(reproducible, secureBuild bool) error {
 	return nil
 }
 
+// ValidateLeaseTags checks that each tag is in key=value format with no commas.
+func ValidateLeaseTags(tags []string) error {
+	for _, tag := range tags {
+		if strings.Contains(tag, ",") {
+			return fmt.Errorf("lease tag %q must not contain commas", tag)
+		}
+		if !strings.Contains(tag, "=") {
+			return fmt.Errorf("lease tag %q must be in key=value format", tag)
+		}
+		key := tag[:strings.Index(tag, "=")]
+		if strings.TrimSpace(key) == "" {
+			return fmt.Errorf("lease tag %q has empty key", tag)
+		}
+	}
+	return nil
+}
+
+// ValidateAndJoinLeaseTags validates tags and returns a comma-separated string.
+func ValidateAndJoinLeaseTags(tags *[]string) (string, error) {
+	if tags == nil || len(*tags) == 0 {
+		return "", nil
+	}
+	if err := ValidateLeaseTags(*tags); err != nil {
+		return "", err
+	}
+	return strings.Join(*tags, ","), nil
+}
+
 // ValidateManifestSuffix validates the manifest file extension.
 func ValidateManifestSuffix(filename string) error {
 	for _, suffix := range validManifestSuffix {

--- a/cmd/caib/common/build_validation_test.go
+++ b/cmd/caib/common/build_validation_test.go
@@ -1,0 +1,146 @@
+package caibcommon
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateLeaseTags(t *testing.T) {
+	tests := []struct {
+		name    string
+		tags    []string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "valid single tag",
+			tags:    []string{"env=staging"},
+			wantErr: false,
+		},
+		{
+			name:    "valid multiple tags",
+			tags:    []string{"env=staging", "team=platform"},
+			wantErr: false,
+		},
+		{
+			name:    "empty value is valid",
+			tags:    []string{"key="},
+			wantErr: false,
+		},
+		{
+			name:    "value with equals sign is valid",
+			tags:    []string{"key=val=ue"},
+			wantErr: false,
+		},
+		{
+			name:    "empty slice is valid",
+			tags:    []string{},
+			wantErr: false,
+		},
+		{
+			name:    "missing equals sign",
+			tags:    []string{"invalid"},
+			wantErr: true,
+			errMsg:  "must be in key=value format",
+		},
+		{
+			name:    "contains comma",
+			tags:    []string{"key=val,ue"},
+			wantErr: true,
+			errMsg:  "must not contain commas",
+		},
+		{
+			name:    "empty key",
+			tags:    []string{"=value"},
+			wantErr: true,
+			errMsg:  "has empty key",
+		},
+		{
+			name:    "second tag invalid",
+			tags:    []string{"good=tag", "bad"},
+			wantErr: true,
+			errMsg:  "must be in key=value format",
+		},
+		{
+			name:    "whitespace-only key",
+			tags:    []string{" =value"},
+			wantErr: true,
+			errMsg:  "has empty key",
+		},
+		{
+			name:    "tab-only key",
+			tags:    []string{"\t=value"},
+			wantErr: true,
+			errMsg:  "has empty key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateLeaseTags(tt.tags)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("error %q should contain %q", err.Error(), tt.errMsg)
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateAndJoinLeaseTags(t *testing.T) {
+	tests := []struct {
+		name    string
+		tags    *[]string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "nil pointer",
+			tags: nil,
+			want: "",
+		},
+		{
+			name: "empty slice",
+			tags: &[]string{},
+			want: "",
+		},
+		{
+			name: "single tag",
+			tags: &[]string{"env=staging"},
+			want: "env=staging",
+		},
+		{
+			name: "multiple tags joined",
+			tags: &[]string{"env=staging", "team=platform"},
+			want: "env=staging,team=platform",
+		},
+		{
+			name:    "invalid tag propagates error",
+			tags:    &[]string{"bad"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ValidateAndJoinLeaseTags(tt.tags)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/caib/flashcmd/flash.go
+++ b/cmd/caib/flashcmd/flash.go
@@ -42,6 +42,7 @@ type Options struct {
 	LeaseDuration     *string
 	LeaseName         *string
 	FlashCmd          *string
+	LeaseTags         *[]string
 	WaitForBuild      *bool
 	FollowLogs        *bool
 	InsecureSkipTLS   *bool
@@ -149,6 +150,12 @@ func (h *Handler) RunFlash(cmd *cobra.Command, args []string) {
 
 	clientConfigB64 := base64.StdEncoding.EncodeToString(clientInfo.Data)
 
+	leaseTags, err := caibcommon.ValidateAndJoinLeaseTags(h.opts.LeaseTags)
+	if err != nil {
+		h.handleError(err)
+		return
+	}
+
 	req := buildapitypes.FlashRequest{
 		Name:             *h.opts.FlashName,
 		ImageRef:         imageRef,
@@ -157,6 +164,7 @@ func (h *Handler) RunFlash(cmd *cobra.Command, args []string) {
 		ClientConfig:     clientConfigB64,
 		LeaseName:        *h.opts.LeaseName,
 		FlashCmd:         *h.opts.FlashCmd,
+		LeaseTags:        leaseTags,
 	}
 	if req.LeaseName == "" {
 		req.LeaseDuration = *h.opts.LeaseDuration

--- a/cmd/caib/image/image.go
+++ b/cmd/caib/image/image.go
@@ -65,6 +65,7 @@ type Options struct {
 	LeaseDuration     *string
 	LeaseName         *string
 	FlashCmd          *string
+	LeaseTags         *[]string
 
 	UseInternalRegistry       *bool
 	InternalRegistryImageName *string
@@ -163,6 +164,7 @@ func NewImageCmd(opts Options) *cobra.Command {
 	buildCmd.Flags().StringVar(opts.LeaseName, "lease", "", "existing Jumpstarter lease name (mutually exclusive with --lease-duration)")
 	buildCmd.Flags().StringVar(opts.FlashCmd, "flash-cmd", "", "override flash command (default: from OperatorConfig target mapping)")
 	buildCmd.Flags().StringVar(opts.ExporterSelector, "exporter", "", "direct exporter selector for flash (alternative to --target lookup)")
+	buildCmd.Flags().StringArrayVar(opts.LeaseTags, "lease-tag", []string{}, "tag for Jumpstarter lease (key=value, can be repeated)")
 	// Secure build
 	buildCmd.Flags().BoolVar(opts.SecureBuild, "secure", false, "resolve tasks from signed Tekton Bundle (requires OperatorConfig taskBundleRef)")
 	buildCmd.Flags().StringVar(opts.TTL, "ttl", "", "time-to-live for the build (e.g. 24h, 72h, 168h); empty=server default, 0=no expiry")
@@ -224,6 +226,7 @@ func NewImageCmd(opts Options) *cobra.Command {
 	diskCmd.Flags().StringVar(opts.LeaseName, "lease", "", "existing Jumpstarter lease name (mutually exclusive with --lease-duration)")
 	diskCmd.Flags().StringVar(opts.FlashCmd, "flash-cmd", "", "override flash command (default: from OperatorConfig target mapping)")
 	diskCmd.Flags().StringVar(opts.ExporterSelector, "exporter", "", "direct exporter selector for flash (alternative to --target lookup)")
+	diskCmd.Flags().StringArrayVar(opts.LeaseTags, "lease-tag", []string{}, "tag for Jumpstarter lease (key=value, can be repeated)")
 	// Secure build
 	diskCmd.Flags().BoolVar(opts.SecureBuild, "secure", false, "resolve tasks from signed Tekton Bundle (requires OperatorConfig taskBundleRef)")
 	diskCmd.Flags().StringVar(opts.TTL, "ttl", "", "time-to-live for the build (e.g. 24h, 72h, 168h); empty=server default, 0=no expiry")
@@ -270,6 +273,7 @@ func NewImageCmd(opts Options) *cobra.Command {
 	buildDevCmd.Flags().StringVar(opts.LeaseName, "lease", "", "existing Jumpstarter lease name (mutually exclusive with --lease-duration)")
 	buildDevCmd.Flags().StringVar(opts.FlashCmd, "flash-cmd", "", "override flash command (default: from OperatorConfig target mapping)")
 	buildDevCmd.Flags().StringVar(opts.ExporterSelector, "exporter", "", "direct exporter selector for flash (alternative to --target lookup)")
+	buildDevCmd.Flags().StringArrayVar(opts.LeaseTags, "lease-tag", []string{}, "tag for Jumpstarter lease (key=value, can be repeated)")
 	// Secure build
 	buildDevCmd.Flags().BoolVar(opts.SecureBuild, "secure", false, "resolve tasks from signed Tekton Bundle (requires OperatorConfig taskBundleRef)")
 	buildDevCmd.Flags().StringVar(opts.TTL, "ttl", "", "time-to-live for the build (e.g. 24h, 72h, 168h); empty=server default, 0=no expiry")
@@ -314,6 +318,7 @@ func NewImageCmd(opts Options) *cobra.Command {
 	flashCmd.Flags().StringVar(opts.LeaseDuration, "lease-duration", "03:00:00", "device lease duration (HH:MM:SS)")
 	flashCmd.Flags().StringVar(opts.LeaseName, "lease", "", "existing Jumpstarter lease name (mutually exclusive with --lease-duration)")
 	flashCmd.Flags().StringVar(opts.FlashCmd, "flash-cmd", "", "override flash command (default: from OperatorConfig target mapping)")
+	flashCmd.Flags().StringArrayVar(opts.LeaseTags, "lease-tag", []string{}, "tag for Jumpstarter lease (key=value, can be repeated)")
 	flashCmd.Flags().StringVar(
 		opts.RegistryAuthFile,
 		"registry-auth-file",

--- a/cmd/caib/main.go
+++ b/cmd/caib/main.go
@@ -56,6 +56,7 @@ var (
 	leaseDuration     string
 	leaseName         string
 	flashCmdOverride  string
+	leaseTags         []string
 
 	// Internal registry options
 	useInternalRegistry       bool

--- a/cmd/caib/runtime_wiring.go
+++ b/cmd/caib/runtime_wiring.go
@@ -51,6 +51,7 @@ type runtimeState struct {
 	LeaseDuration     *string
 	LeaseName         *string
 	FlashCmd          *string
+	LeaseTags         *[]string
 
 	UseInternalRegistry       *bool
 	InternalRegistryImageName *string
@@ -116,6 +117,7 @@ func newRuntimeState() runtimeState {
 		LeaseDuration:     &leaseDuration,
 		LeaseName:         &leaseName,
 		FlashCmd:          &flashCmdOverride,
+		LeaseTags:         &leaseTags,
 
 		UseInternalRegistry:       &useInternalRegistry,
 		InternalRegistryImageName: &internalRegistryImageName,
@@ -189,6 +191,7 @@ func (s runtimeState) newHandlers() handlerSet {
 			LeaseName:                 s.LeaseName,
 			FlashCmd:                  s.FlashCmd,
 			ExporterSelector:          s.ExporterSelector,
+			LeaseTags:                 s.LeaseTags,
 			UseInternalRegistry:       s.UseInternalRegistry,
 			InternalRegistryImageName: s.InternalRegistryImageName,
 			InternalRegistryTag:       s.InternalRegistryTag,
@@ -224,6 +227,7 @@ func (s runtimeState) newHandlers() handlerSet {
 			LeaseDuration:     s.LeaseDuration,
 			LeaseName:         s.LeaseName,
 			FlashCmd:          s.FlashCmd,
+			LeaseTags:         s.LeaseTags,
 			WaitForBuild:      s.WaitForBuild,
 			FollowLogs:        s.FollowLogs,
 			InsecureSkipTLS:   s.InsecureSkipTLS,
@@ -321,6 +325,7 @@ func (s runtimeState) imageOptions(h handlerSet) image.Options {
 		LeaseDuration:     s.LeaseDuration,
 		LeaseName:         s.LeaseName,
 		FlashCmd:          s.FlashCmd,
+		LeaseTags:         s.LeaseTags,
 
 		UseInternalRegistry:       s.UseInternalRegistry,
 		InternalRegistryImageName: s.InternalRegistryImageName,

--- a/config/crd/bases/automotive.sdv.cloud.redhat.com_imagebuilds.yaml
+++ b/config/crd/bases/automotive.sdv.cloud.redhat.com_imagebuilds.yaml
@@ -184,6 +184,10 @@ spec:
                       LeaseName is an existing Jumpstarter lease name to use instead of creating a new one
                       Mutually exclusive with LeaseDuration
                     type: string
+                  leaseTags:
+                    description: LeaseTags are additional key=value tags for the Jumpstarter
+                      lease (comma-separated)
+                    type: string
                 type: object
               pushSecretRef:
                 description: |-

--- a/config/crd/bases/automotive.sdv.cloud.redhat.com_operatorconfigs.yaml
+++ b/config/crd/bases/automotive.sdv.cloud.redhat.com_operatorconfigs.yaml
@@ -676,6 +676,11 @@ spec:
                       Can be overridden per-ImageBuild via FlashSpec.LeaseDuration
                       Default: "03:00:00"
                     type: string
+                  defaultLeaseTags:
+                    description: |-
+                      DefaultLeaseTags are key=value tags applied to all Jumpstarter leases created by the operator
+                      Format: comma-separated key=value pairs (e.g. "platform=caib,env=prod")
+                    type: string
                   image:
                     default: quay.io/jumpstarter-dev/jumpstarter:latest
                     description: Image is the container image for Jumpstarter CLI

--- a/internal/buildapi/flash.go
+++ b/internal/buildapi/flash.go
@@ -134,6 +134,8 @@ func (a *APIServer) createFlash(c *gin.Context) {
 		}
 	}
 
+	leaseTags := BuildLeaseTags(operatorConfig.Spec.Jumpstarter.GetDefaultLeaseTags(), req.Name, req.LeaseTags)
+
 	// Build workspace bindings
 	workspaces := []tektonv1.WorkspaceBinding{
 		{
@@ -177,6 +179,7 @@ func (a *APIServer) createFlash(c *gin.Context) {
 				{Name: "flash-cmd", Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: flashCmd}},
 				{Name: "lease-duration", Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: leaseDuration}},
 				{Name: "lease-name", Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: req.LeaseName}},
+				{Name: "lease-tags", Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: leaseTags}},
 			},
 			Workspaces: workspaces,
 		},

--- a/internal/buildapi/flash_helpers.go
+++ b/internal/buildapi/flash_helpers.go
@@ -22,6 +22,19 @@ type httpError struct {
 	message string
 }
 
+// BuildLeaseTags merges OperatorConfig defaults, build name, and user-provided tags into a comma-separated string.
+func BuildLeaseTags(operatorConfigDefaults, buildName, userTags string) string {
+	parts := make([]string, 0, 3)
+	if operatorConfigDefaults != "" {
+		parts = append(parts, operatorConfigDefaults)
+	}
+	parts = append(parts, "build-name="+buildName)
+	if userTags != "" {
+		parts = append(parts, userTags)
+	}
+	return strings.Join(parts, ",")
+}
+
 // resolveFlashTargetConfig resolves exporter selector and flash command from request and OperatorConfig.
 func resolveFlashTargetConfig(req FlashRequest, operatorConfig *automotivev1alpha1.OperatorConfig) (string, string) {
 	exporterSelector := req.ExporterSelector

--- a/internal/buildapi/flash_helpers_test.go
+++ b/internal/buildapi/flash_helpers_test.go
@@ -1,0 +1,29 @@
+package buildapi
+
+import (
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // Dot import is standard for Ginkgo
+	. "github.com/onsi/gomega"    //nolint:revive // Dot import is standard for Gomega
+)
+
+var _ = Describe("BuildLeaseTags", func() {
+	DescribeTable("merges tags correctly",
+		func(defaults, buildName, userTags, expected string) {
+			Expect(BuildLeaseTags(defaults, buildName, userTags)).To(Equal(expected))
+		},
+		Entry("all parts present",
+			"platform=caib", "my-build", "env=staging,team=platform",
+			"platform=caib,build-name=my-build,env=staging,team=platform"),
+		Entry("no user tags",
+			"platform=caib", "my-build", "",
+			"platform=caib,build-name=my-build"),
+		Entry("no defaults",
+			"", "my-build", "env=staging",
+			"build-name=my-build,env=staging"),
+		Entry("only build name",
+			"", "my-build", "",
+			"build-name=my-build"),
+		Entry("multiple defaults",
+			"platform=caib,cluster=prod", "test-build", "team=eng",
+			"platform=caib,cluster=prod,build-name=test-build,team=eng"),
+	)
+})

--- a/internal/buildapi/server.go
+++ b/internal/buildapi/server.go
@@ -1260,6 +1260,7 @@ func (a *APIServer) createBuild(c *gin.Context) {
 			LeaseName:             req.FlashLeaseName,
 			FlashCmd:              req.FlashCmd,
 			ExporterSelector:      req.FlashExporterSelector,
+			LeaseTags:             req.FlashLeaseTags,
 		}
 	}
 

--- a/internal/buildapi/types.go
+++ b/internal/buildapi/types.go
@@ -207,6 +207,7 @@ type BuildRequest struct {
 	FlashLeaseName        string `json:"flashLeaseName,omitempty"`        // Existing lease name (mutually exclusive with FlashLeaseDuration)
 	FlashCmd              string `json:"flashCmd,omitempty"`              // Override flash command from OperatorConfig
 	FlashExporterSelector string `json:"flashExporterSelector,omitempty"` // Override exporter selector from OperatorConfig
+	FlashLeaseTags        string `json:"flashLeaseTags,omitempty"`        // Additional lease tags (comma-separated key=value)
 }
 
 // RegistryCredentials contains authentication details for container registries.
@@ -250,6 +251,8 @@ type FlashRequest struct {
 	LeaseDuration string `json:"leaseDuration,omitempty"`
 	// LeaseName is an existing Jumpstarter lease name (mutually exclusive with LeaseDuration)
 	LeaseName string `json:"leaseName,omitempty"`
+	// LeaseTags are additional key=value tags for the lease (comma-separated)
+	LeaseTags string `json:"leaseTags,omitempty"`
 	// RegistryCredentials contains OCI registry auth for pulling the flash image on the exporter
 	RegistryCredentials *RegistryCredentials `json:"registryCredentials,omitempty"`
 }

--- a/internal/common/tasks/scripts/flash_image.sh
+++ b/internal/common/tasks/scripts/flash_image.sh
@@ -31,6 +31,16 @@ FLASH_CMD=$(echo "${FLASH_CMD}" | sed "s|{image_uri}|${IMAGE_REF}|g")
 
 LEASE_DURATION="${LEASE_DURATION:-03:00:00}"
 EXISTING_LEASE="${EXISTING_LEASE:-}"
+LEASE_TAGS="${LEASE_TAGS:-}"
+
+TAG_ARGS=()
+if [[ -n "${LEASE_TAGS}" ]]; then
+    IFS=',' read -ra TAG_PAIRS <<< "${LEASE_TAGS}"
+    for pair in "${TAG_PAIRS[@]}"; do
+        [[ -z "${pair}" ]] && continue
+        TAG_ARGS+=(--tag "${pair}")
+    done
+fi
 
 echo "Flash command: ${FLASH_CMD}"
 
@@ -42,10 +52,14 @@ if [[ -n "${EXISTING_LEASE}" ]]; then
     USER_PROVIDED_LEASE=true
 else
     echo "Lease duration: ${LEASE_DURATION}"
+    if [[ -n "${LEASE_TAGS}" ]]; then
+        echo "Lease tags: ${LEASE_TAGS}"
+    fi
     echo ""
     echo "Creating lease on exporter matching: ${EXPORTER_SELECTOR}"
+    echo "Running: jmp create lease --client-config ${JMP_CLIENT_CONFIG} -l ${EXPORTER_SELECTOR} --duration ${LEASE_DURATION} ${TAG_ARGS[*]} -o name"
 
-    LEASE_NAME=$(jmp create lease --client-config "${JMP_CLIENT_CONFIG}" -l "${EXPORTER_SELECTOR}" --duration "${LEASE_DURATION}" -o name)
+    LEASE_NAME=$(jmp create lease --client-config "${JMP_CLIENT_CONFIG}" -l "${EXPORTER_SELECTOR}" --duration "${LEASE_DURATION}" "${TAG_ARGS[@]}" -o name)
 
     if [[ -z "${LEASE_NAME}" ]]; then
         echo "ERROR: Failed to create lease"

--- a/internal/common/tasks/tasks.go
+++ b/internal/common/tasks/tasks.go
@@ -1113,6 +1113,15 @@ func GenerateTektonPipeline(name, namespace string, buildConfig *BuildConfig) *t
 					},
 				},
 				{
+					Name:        "flash-lease-tags",
+					Type:        tektonv1.ParamTypeString,
+					Description: "Comma-separated key=value tags for the Jumpstarter lease",
+					Default: &tektonv1.ParamValue{
+						Type:      tektonv1.ParamTypeString,
+						StringVal: "",
+					},
+				},
+				{
 					Name:        "jumpstarter-image",
 					Type:        tektonv1.ParamTypeString,
 					Description: "Container image for Jumpstarter CLI operations",
@@ -1462,6 +1471,13 @@ func GenerateTektonPipeline(name, namespace string, buildConfig *BuildConfig) *t
 							Value: tektonv1.ParamValue{
 								Type:      tektonv1.ParamTypeString,
 								StringVal: "$(params.flash-lease-name)",
+							},
+						},
+						{
+							Name: "lease-tags",
+							Value: tektonv1.ParamValue{
+								Type:      tektonv1.ParamTypeString,
+								StringVal: "$(params.flash-lease-tags)",
 							},
 						},
 						{
@@ -1832,6 +1848,15 @@ func GenerateFlashTask(namespace string, buildConfig *BuildConfig) *tektonv1.Tas
 					},
 				},
 				{
+					Name:        "lease-tags",
+					Type:        tektonv1.ParamTypeString,
+					Description: "Comma-separated key=value tags for the Jumpstarter lease",
+					Default: &tektonv1.ParamValue{
+						Type:      tektonv1.ParamTypeString,
+						StringVal: "",
+					},
+				},
+				{
 					Name:        "jumpstarter-image",
 					Type:        tektonv1.ParamTypeString,
 					Description: "Container image for Jumpstarter CLI operations",
@@ -1887,6 +1912,10 @@ func GenerateFlashTask(namespace string, buildConfig *BuildConfig) *tektonv1.Tas
 						{
 							Name:  "EXISTING_LEASE",
 							Value: "$(params.lease-name)",
+						},
+						{
+							Name:  "LEASE_TAGS",
+							Value: "$(params.lease-tags)",
 						},
 						{
 							Name:  "JMP_CLIENT_CONFIG",

--- a/internal/controller/imagebuild/controller.go
+++ b/internal/controller/imagebuild/controller.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi"
 	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/bundleverify"
 	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/registryutil"
 	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/tasks"
@@ -1316,6 +1317,10 @@ func (r *ImageBuildReconciler) createBuildTaskRun(
 				Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: imageBuild.Spec.GetFlashLeaseName()},
 			},
 			tektonv1.Param{
+				Name:  "flash-lease-tags",
+				Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: buildapi.BuildLeaseTags(operatorConfig.Spec.Jumpstarter.GetDefaultLeaseTags(), imageBuild.Name, imageBuild.Spec.GetFlashLeaseTags())},
+			},
+			tektonv1.Param{
 				Name:  "jumpstarter-image",
 				Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: operatorConfig.Spec.Jumpstarter.GetJumpstarterImage()},
 			},
@@ -2039,6 +2044,10 @@ func (r *ImageBuildReconciler) createFlashTaskRun(
 		{
 			Name:  "lease-name",
 			Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: imageBuild.Spec.GetFlashLeaseName()},
+		},
+		{
+			Name:  "lease-tags",
+			Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: buildapi.BuildLeaseTags(operatorConfig.Spec.Jumpstarter.GetDefaultLeaseTags(), imageBuild.Name, imageBuild.Spec.GetFlashLeaseTags())},
 		},
 		{
 			Name:  "trace-id",

--- a/internal/controller/operatorconfig/controller.go
+++ b/internal/controller/operatorconfig/controller.go
@@ -1045,7 +1045,7 @@ func (r *OperatorConfigReconciler) cleanupWorkspaceInfra(ctx context.Context, co
 
 	scc := &securityv1.SecurityContextConstraints{}
 	scc.Name = workspaceSCCName
-	if err := r.Delete(ctx, scc); err != nil && !errors.IsNotFound(err) {
+	if err := r.Delete(ctx, scc); err != nil && !errors.IsNotFound(err) && !isNoMatchError(err) {
 		return fmt.Errorf("failed to delete workspace SCC: %w", err)
 	}
 


### PR DESCRIPTION

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Jumpstarter lease tags in flash build and flash operations.
  * Introduced optional `--lease-tag key=value` CLI flag for passing custom lease tags.
  * Added configurable default lease tags in Jumpstarter configuration.

* **Bug Fixes**
  * Improved error handling for SecurityContextConstraints cleanup during workspace operations.

* **Tests**
  * Added comprehensive unit tests for lease tag validation and formatting functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->