### PR TITLE
feat: `caib image flash` to use OCI annotation by default

### DIFF
--- a/cmd/caib/common/manifest_annotations.go
+++ b/cmd/caib/common/manifest_annotations.go
@@ -1,0 +1,70 @@
+package caibcommon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/registryauth"
+	"github.com/containers/image/v5/docker"
+	"github.com/containers/image/v5/manifest"
+	"github.com/containers/image/v5/types"
+)
+
+// ReadManifestAnnotations fetches the OCI manifest for the given image reference
+// and returns its annotations map along with the manifest digest.
+func ReadManifestAnnotations(ociRef string, sysCtx *types.SystemContext) (map[string]string, string, error) {
+	ref, err := docker.ParseReference("//" + ociRef)
+	if err != nil {
+		return nil, "", fmt.Errorf("parse reference: %w", err)
+	}
+
+	ctx := context.Background()
+	src, err := ref.NewImageSource(ctx, sysCtx)
+	if err != nil {
+		return nil, "", fmt.Errorf("open image source: %w", err)
+	}
+	defer func() { _ = src.Close() }()
+
+	rawManifest, _, err := src.GetManifest(ctx, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("get manifest: %w", err)
+	}
+
+	digest, err := manifest.Digest(rawManifest)
+	if err != nil {
+		return nil, "", fmt.Errorf("compute digest: %w", err)
+	}
+
+	var parsed struct {
+		Annotations map[string]string `json:"annotations"`
+	}
+	if err := json.Unmarshal(rawManifest, &parsed); err != nil {
+		return nil, "", fmt.Errorf("parse manifest JSON: %w", err)
+	}
+
+	return parsed.Annotations, string(digest), nil
+}
+
+// NewRegistrySystemContext creates a containers/image SystemContext configured
+// with TLS settings, auth file path, and registry credentials extracted from
+// environment variables.
+func NewRegistrySystemContext(ociRef string, insecureSkipTLS bool, authFile string) *types.SystemContext {
+	sysCtx := &types.SystemContext{}
+	if insecureSkipTLS {
+		sysCtx.DockerInsecureSkipTLSVerify = types.OptionalBoolTrue
+	}
+
+	_, username, password := registryauth.ExtractRegistryCredentials(ociRef, "")
+	if authFile != "" {
+		sysCtx.AuthFilePath = authFile
+	}
+	if username != "" && password != "" {
+		sysCtx.DockerAuthConfig = &types.DockerAuthConfig{
+			Username: username,
+			Password: password,
+		}
+	}
+
+	return sysCtx
+}

--- a/cmd/caib/common/manifest_annotations_test.go
+++ b/cmd/caib/common/manifest_annotations_test.go
@@ -1,0 +1,51 @@
+package caibcommon
+
+import (
+	"testing"
+
+	"github.com/containers/image/v5/types"
+)
+
+func TestReadManifestAnnotations_InvalidRef(t *testing.T) {
+	_, _, err := ReadManifestAnnotations(":::invalid", &types.SystemContext{})
+	if err == nil {
+		t.Fatal("expected error for invalid reference")
+	}
+}
+
+func TestNewRegistrySystemContext_InsecureTLS(t *testing.T) {
+	sysCtx := NewRegistrySystemContext("quay.io/test/image:v1", true, "")
+	if sysCtx.DockerInsecureSkipTLSVerify != types.OptionalBoolTrue {
+		t.Error("expected InsecureSkipTLSVerify to be set")
+	}
+}
+
+func TestNewRegistrySystemContext_SecureTLS(t *testing.T) {
+	sysCtx := NewRegistrySystemContext("quay.io/test/image:v1", false, "")
+	if sysCtx.DockerInsecureSkipTLSVerify == types.OptionalBoolTrue {
+		t.Error("expected InsecureSkipTLSVerify to not be set")
+	}
+}
+
+func TestNewRegistrySystemContext_AuthFile(t *testing.T) {
+	sysCtx := NewRegistrySystemContext("quay.io/test/image:v1", false, "/tmp/auth.json")
+	if sysCtx.AuthFilePath != "/tmp/auth.json" {
+		t.Errorf("expected AuthFilePath = /tmp/auth.json, got %s", sysCtx.AuthFilePath)
+	}
+}
+
+func TestNewRegistrySystemContext_EnvCredentials(t *testing.T) {
+	t.Setenv("REGISTRY_USERNAME", "testuser")
+	t.Setenv("REGISTRY_PASSWORD", "testpass")
+
+	sysCtx := NewRegistrySystemContext("quay.io/test/image:v1", false, "")
+	if sysCtx.DockerAuthConfig == nil {
+		t.Fatal("expected DockerAuthConfig to be set from env")
+	}
+	if sysCtx.DockerAuthConfig.Username != "testuser" {
+		t.Errorf("expected username = testuser, got %s", sysCtx.DockerAuthConfig.Username)
+	}
+	if sysCtx.DockerAuthConfig.Password != "testpass" {
+		t.Errorf("expected password = testpass, got %s", sysCtx.DockerAuthConfig.Password)
+	}
+}

--- a/cmd/caib/flashcmd/flash.go
+++ b/cmd/caib/flashcmd/flash.go
@@ -14,11 +14,12 @@ import (
 	"time"
 
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
-	common "github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/common"
+	caibcommon "github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/common"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/logstream"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/registryauth"
 	buildapitypes "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi"
 	buildapiclient "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi/client"
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/oci"
 	"github.com/spf13/cobra"
 )
 
@@ -46,7 +47,8 @@ type Options struct {
 	InsecureSkipTLS   *bool
 	RegistryAuthFile  *string
 
-	HandleError func(error)
+	HandleError      func(error)
+	AnnotationReader func(imageRef string) (map[string]string, error)
 }
 
 // Handler implements flash-related Cobra run functions.
@@ -64,8 +66,32 @@ func (h *Handler) handleError(err error) {
 		h.opts.HandleError(err)
 		return
 	}
-	fmt.Fprintln(os.Stderr, common.FormatError(err))
+	fmt.Fprintln(os.Stderr, caibcommon.FormatError(err))
 	os.Exit(1)
+}
+
+func (h *Handler) resolveTargetFromAnnotations(imageRef string) string {
+	var annotations map[string]string
+	var err error
+
+	if h.opts.AnnotationReader != nil {
+		annotations, err = h.opts.AnnotationReader(imageRef)
+	} else {
+		insecure := h.opts.InsecureSkipTLS != nil && *h.opts.InsecureSkipTLS
+		authFile := ""
+		if h.opts.RegistryAuthFile != nil {
+			authFile = *h.opts.RegistryAuthFile
+		}
+		sysCtx := caibcommon.NewRegistrySystemContext(imageRef, insecure, authFile)
+		annotations, _, err = caibcommon.ReadManifestAnnotations(imageRef, sysCtx)
+	}
+
+	if err != nil {
+		clilog.Warnf("Could not read image manifest for target auto-detection: %v\n", err)
+		return ""
+	}
+
+	return annotations[oci.Get().AnnotationKey("target")]
 }
 
 func (h *Handler) applyWaitFollowDefaults(cmd *cobra.Command, defaultWait, defaultFollow bool) {
@@ -91,17 +117,22 @@ func (h *Handler) RunFlash(cmd *cobra.Command, args []string) {
 	}
 
 	// Resolve Jumpstarter client config (explicit path or auto-detect)
-	clientInfo, err := common.ResolveJumpstarterClient(strings.TrimSpace(*h.opts.JumpstarterClient))
+	clientInfo, err := caibcommon.ResolveJumpstarterClient(strings.TrimSpace(*h.opts.JumpstarterClient))
 	if err != nil {
 		h.handleError(err)
 		return
 	}
 	clilog.Infof("Using Jumpstarter client %q (endpoint: %s)\n", clientInfo.Name, clientInfo.Endpoint)
 
-	// Validate that either target or exporter is specified.
+	// Auto-detect target from OCI annotations if neither --target nor --exporter specified.
 	if strings.TrimSpace(*h.opts.Target) == "" && strings.TrimSpace(*h.opts.ExporterSelector) == "" {
-		h.handleError(fmt.Errorf("either --target or --exporter is required"))
-		return
+		if detected := h.resolveTargetFromAnnotations(imageRef); detected != "" {
+			*h.opts.Target = detected
+			clilog.Infof("Auto-detected target from image annotations: %s\n", detected)
+		} else {
+			h.handleError(fmt.Errorf("either --target or --exporter is required (target auto-detection from image annotations failed or annotation not present)"))
+			return
+		}
 	}
 
 	// Validate mutual exclusivity of --lease and --lease-duration
@@ -110,7 +141,7 @@ func (h *Handler) RunFlash(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	api, err := common.CreateBuildAPIClient(server, h.opts.AuthToken, *h.opts.InsecureSkipTLS)
+	api, err := caibcommon.CreateBuildAPIClient(server, h.opts.AuthToken, *h.opts.InsecureSkipTLS)
 	if err != nil {
 		h.handleError(err)
 		return
@@ -229,7 +260,7 @@ func (h *Handler) waitForFlashCompletion(ctx context.Context, _ *buildapiclient.
 		case <-ticker.C:
 			reqCtx, cancelReq := context.WithTimeout(timeoutCtx, 2*time.Minute)
 			var st *buildapitypes.FlashResponse
-			err := common.ExecuteWithReauth(*h.opts.ServerURL, h.opts.AuthToken, *h.opts.InsecureSkipTLS, func(api *buildapiclient.Client) error {
+			err := caibcommon.ExecuteWithReauth(*h.opts.ServerURL, h.opts.AuthToken, *h.opts.InsecureSkipTLS, func(api *buildapiclient.Client) error {
 				var getErr error
 				st, getErr = api.GetFlash(reqCtx, name)
 				return getErr

--- a/cmd/caib/flashcmd/resolve_target_test.go
+++ b/cmd/caib/flashcmd/resolve_target_test.go
@@ -1,0 +1,71 @@
+package flashcmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/oci"
+)
+
+func TestResolveTargetFromAnnotations_Found(t *testing.T) {
+	targetKey := oci.Get().AnnotationKey("target")
+	target := ""
+	h := NewHandler(Options{
+		Target: &target,
+		AnnotationReader: func(_ string) (map[string]string, error) {
+			return map[string]string{targetKey: "rcar_s4"}, nil
+		},
+	})
+
+	got := h.resolveTargetFromAnnotations("quay.io/test/image:v1")
+	if got != "rcar_s4" {
+		t.Errorf("expected rcar_s4, got %q", got)
+	}
+}
+
+func TestResolveTargetFromAnnotations_NotPresent(t *testing.T) {
+	target := ""
+	h := NewHandler(Options{
+		Target: &target,
+		AnnotationReader: func(_ string) (map[string]string, error) {
+			return map[string]string{}, nil
+		},
+	})
+
+	got := h.resolveTargetFromAnnotations("quay.io/test/image:v1")
+	if got != "" {
+		t.Errorf("expected empty string, got %q", got)
+	}
+}
+
+func TestResolveTargetFromAnnotations_FetchError(t *testing.T) {
+	target := ""
+	h := NewHandler(Options{
+		Target: &target,
+		AnnotationReader: func(_ string) (map[string]string, error) {
+			return nil, fmt.Errorf("network error")
+		},
+	})
+
+	got := h.resolveTargetFromAnnotations("quay.io/test/image:v1")
+	if got != "" {
+		t.Errorf("expected empty string on error, got %q", got)
+	}
+}
+
+func TestResolveTargetFromAnnotations_PassesImageRef(t *testing.T) {
+	target := ""
+	var receivedRef string
+	h := NewHandler(Options{
+		Target: &target,
+		AnnotationReader: func(imageRef string) (map[string]string, error) {
+			receivedRef = imageRef
+			return map[string]string{}, nil
+		},
+	})
+
+	h.resolveTargetFromAnnotations("quay.io/org/specific:tag")
+	if receivedRef != "quay.io/org/specific:tag" {
+		t.Errorf("expected imageRef passed through, got %q", receivedRef)
+	}
+}

--- a/cmd/caib/image/image.go
+++ b/cmd/caib/image/image.go
@@ -429,8 +429,14 @@ This command connects to a Jumpstarter exporter to flash the specified disk imag
 onto physical hardware. The Jumpstarter client config is auto-detected from
 ~/.config/jumpstarter/ (or $JMP_CLIENT_CONFIG_HOME), or can be specified with --client.
 
+If --target and --exporter are both omitted, the target is auto-detected from the
+OCI image manifest annotations (set by the operator during image push).
+
 Examples:
-  # Flash using auto-detected client config
+  # Flash with auto-detected target (from image annotations)
+  caib image flash quay.io/org/disk:v1
+
+  # Flash with explicit target
   caib image flash quay.io/org/disk:v1 --target j784s4evm
 
   # Flash with explicit client config

--- a/cmd/caib/inspectcmd/inspect.go
+++ b/cmd/caib/inspectcmd/inspect.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
-	"github.com/containers/image/v5/docker"
-	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/types"
 	"github.com/fatih/color"
 	godigest "github.com/opencontainers/go-digest"
@@ -93,23 +91,14 @@ func (h *Handler) supportsColor() bool {
 func (h *Handler) RunInspect(_ *cobra.Command, args []string) {
 	ociRef := args[0]
 
-	sysCtx := &types.SystemContext{}
-	if h.opts.InsecureSkipTLS != nil && *h.opts.InsecureSkipTLS {
-		sysCtx.DockerInsecureSkipTLSVerify = types.OptionalBoolTrue
+	insecure := h.opts.InsecureSkipTLS != nil && *h.opts.InsecureSkipTLS
+	authFile := ""
+	if h.opts.RegistryAuthFile != nil {
+		authFile = *h.opts.RegistryAuthFile
 	}
+	sysCtx := caibcommon.NewRegistrySystemContext(ociRef, insecure, authFile)
 
-	_, username, password := registryauth.ExtractRegistryCredentials(ociRef, "")
-	if h.opts.RegistryAuthFile != nil && *h.opts.RegistryAuthFile != "" {
-		sysCtx.AuthFilePath = *h.opts.RegistryAuthFile
-	}
-	if username != "" && password != "" {
-		sysCtx.DockerAuthConfig = &types.DockerAuthConfig{
-			Username: username,
-			Password: password,
-		}
-	}
-
-	annotations, digest, err := readManifestAnnotations(ociRef, sysCtx)
+	annotations, digest, err := caibcommon.ReadManifestAnnotations(ociRef, sysCtx)
 	if err != nil {
 		h.handleError(fmt.Errorf("read manifest from %s: %w", ociRef, err))
 		return
@@ -138,11 +127,8 @@ func (h *Handler) RunInspect(_ *cobra.Command, args []string) {
 	}
 
 	if h.opts.OutputDir != nil && *h.opts.OutputDir != "" {
-		authFile := ""
-		if h.opts.RegistryAuthFile != nil {
-			authFile = *h.opts.RegistryAuthFile
-		}
-		h.downloadReferrers(ociRef, digest, referrers, *h.opts.OutputDir, username, password, authFile)
+		_, dlUsername, dlPassword := registryauth.ExtractRegistryCredentials(ociRef, "")
+		h.downloadReferrers(ociRef, digest, referrers, *h.opts.OutputDir, dlUsername, dlPassword, authFile)
 	}
 }
 
@@ -174,39 +160,6 @@ func (h *Handler) printStructured(format, ociRef, digest string, annotations map
 		return
 	}
 	fmt.Println(string(data))
-}
-
-func readManifestAnnotations(ociRef string, sysCtx *types.SystemContext) (map[string]string, string, error) {
-	ref, err := docker.ParseReference("//" + ociRef)
-	if err != nil {
-		return nil, "", fmt.Errorf("parse reference: %w", err)
-	}
-
-	ctx := context.Background()
-	src, err := ref.NewImageSource(ctx, sysCtx)
-	if err != nil {
-		return nil, "", fmt.Errorf("open image source: %w", err)
-	}
-	defer func() { _ = src.Close() }()
-
-	rawManifest, _, err := src.GetManifest(ctx, nil)
-	if err != nil {
-		return nil, "", fmt.Errorf("get manifest: %w", err)
-	}
-
-	digest, err := manifest.Digest(rawManifest)
-	if err != nil {
-		return nil, "", fmt.Errorf("compute digest: %w", err)
-	}
-
-	var parsed struct {
-		Annotations map[string]string `json:"annotations"`
-	}
-	if err := json.Unmarshal(rawManifest, &parsed); err != nil {
-		return nil, "", fmt.Errorf("parse manifest JSON: %w", err)
-	}
-
-	return parsed.Annotations, string(digest), nil
 }
 
 type referrerInfo struct {


### PR DESCRIPTION
By default lookup up the target OCI annotation for the flashing target

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [X] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic target detection for flash command from image annotations when `--target` and `--exporter` are unset.

* **Documentation**
  * Updated `caib image flash` command help text to document target auto-detection behavior and provide relevant examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->