### PR TITLE
ci: upload e2e logs as downloadable artifacts

### DIFF
--- a/.claude/skills/e2e/SKILL.md
+++ b/.claude/skills/e2e/SKILL.md
@@ -1,0 +1,272 @@
+---
+name: e2e
+description: >-
+  Scaffold a new Ginkgo e2e test suite: add CI lane wiring in e2e.yml and
+  e2e-lanes.yml, register timeout in hack/e2e/timeouts.env, add a Makefile.e2e
+  target, create a template test file under test/e2e, and update reference
+  docs. Use when the user invokes /e2e or asks to add a new e2e suite, lane, or
+  label.
+disable-model-invocation: true
+---
+
+# /e2e — Add E2E Test Suite
+
+Scaffold a new labeled Ginkgo suite so it runs locally, in CI (`e2e.yml`), and via PR comment lanes (`/e2e-<name>`).
+
+## Expectations
+
+- **Default PR CI runs `smoke` only** (`e2e.yml`). A new suite is not in the PR gate unless tests are added to the smoke label or the lane is triggered via `/e2e-<name>`.
+- **Every new lane needs full wiring**: timeout, workflows, Makefile, runners, README, and real tests. Do not stop at `timeouts.env` + a Ginkgo label alone (see incomplete suites below).
+
+## Input
+
+`$ARGUMENTS` is the suite **label** in kebab-case (e.g. `my-feature`, `package-mode`).
+
+If missing, ask for:
+1. Label name (kebab-case) — must not prefix or be prefixed by an existing lane (see pitfalls)
+2. Timeout tier: `10m` (fast), `15m` (medium), or `45m` (slow) — default `10m`
+3. Whether tests need Dex (`hack/e2e/setup-dex.sh`) — default no
+
+## Naming conventions
+
+| Concept | Example (`my-feature`) |
+|---------|------------------------|
+| Ginkgo label | `my-feature` |
+| Go test file | `test/e2e/my_feature_test.go` |
+| Timeout var | `E2E_TIMEOUT_my_feature` |
+| PR comment | `/e2e-my-feature` |
+| CI namespace | `e2e-my-feature` |
+| Make target | `test-e2e-my-feature` |
+
+Hyphens in the label become underscores in env vars and filenames (`${name//-/_}`).
+
+## Pitfalls
+
+- **`/e2e-*` prefix collisions**: `e2e-lanes.yml` matches with shell globs (`/e2e-bootc*`). Avoid lane names that are prefixes of existing lanes (e.g. `boot` vs `bootc`). Put more specific `case` arms before general ones.
+- **Dex on Kind**: CI workflows call `hack/e2e/setup-dex.sh`, but `hack/run-e2e-kind.sh` does not yet. When Dex is required, add a pre-test step to that script (and `run-e2e-local.sh` if applicable):
+
+  ```bash
+  if [[ "$E2E_LANE" == "my-feature" || "$E2E_LANE" == "all" ]]; then
+    bash hack/e2e/setup-dex.sh
+  fi
+  ```
+
+## Workflow
+
+Copy this checklist and track progress:
+
+```
+- [ ] 1. hack/e2e/timeouts.env
+- [ ] 2. .github/workflows/e2e.yml
+- [ ] 3. .github/workflows/e2e-lanes.yml
+- [ ] 4. Makefile.e2e
+- [ ] 5. test/e2e/<name>_test.go (real tests, not placeholder)
+- [ ] 6. Reference docs (README, runners)
+- [ ] 7. Verify (fmt, lint, compile, then cluster if available)
+```
+
+### 1. `hack/e2e/timeouts.env`
+
+Add one line in the appropriate tier section:
+
+```bash
+E2E_TIMEOUT_my_feature=10m
+```
+
+Place under the matching comment block (`# fast lanes`, `# medium lanes`, or `# slow lanes`).
+
+Update the file header if it still says "No other files need to change" — that is outdated; full lane wiring requires the steps below.
+
+### 2. `.github/workflows/e2e.yml`
+
+Add the label to the `workflow_dispatch.inputs.label_filter.description` string (keep alphabetical or grouped with similar suites).
+
+If the suite needs Dex (like `auth`), extend the **Deploy Dex for OIDC tests** `if:` condition:
+
+```yaml
+github.event.inputs.label_filter == 'my-feature' ||
+```
+
+### 3. `.github/workflows/e2e-lanes.yml`
+
+Add a `case` arm in **Parse lane from comment** (before the `*)` default). Place it so it does not shadow or get shadowed by existing prefix patterns:
+
+```bash
+/e2e-my-feature*)
+  echo "label_filter=my-feature" >> "$GITHUB_OUTPUT"
+  echo "lane_name=my-feature" >> "$GITHUB_OUTPUT"
+  ;;
+```
+
+Update the `Supported:` line in the `*)` branch to include `/e2e-my-feature`.
+
+If the suite needs Dex, extend **Deploy Dex for OIDC tests** `if:`:
+
+```yaml
+needs.parse-comment.outputs.lane_name == 'my-feature' ||
+```
+
+### 4. `Makefile.e2e`
+
+Add a one-line comment in the header block (after existing lane comments) and a target after the last lane target:
+
+```makefile
+#   test-e2e-my-feature     - short description of the suite
+.PHONY: test-e2e-my-feature
+test-e2e-my-feature:
+	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-my-feature} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="my-feature" -timeout $(E2E_TIMEOUT_my_feature)
+```
+
+### 5. `test/e2e/<name>_test.go`
+
+Create from this template (replace `my-feature`, `My Feature`, and implement real tests):
+
+```go
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // Dot import is standard for Ginkgo
+	. "github.com/onsi/gomega"    //nolint:revive // Dot import is standard for Gomega
+)
+
+var _ = Describe("My Feature", Label("my-feature"), Ordered, func() {
+	BeforeAll(func() {
+		ensureOperatorDeployed()
+	})
+
+	It("should …", func() { Fail("implement before merge") })
+})
+```
+
+**Do not merge** `Expect(true).To(BeTrue())` or other no-op assertions. Replace `Pending(...)` with real `It` blocks before opening a PR. Use `Skip(...)` only for environment-specific conditions (see `auth_test.go`).
+
+Adjust `BeforeAll` helpers to match suite needs (common: `ensureBuildAPIAccess()`, `ensureCaibCredentials()`).
+
+### 6. Reference docs
+
+Keep lane lists in sync wherever runners and docs enumerate suites. When editing, **scan and fix stale lists** for other lanes too (e.g. `container-build` missing from README tables, benchmark timeouts out of sync with `timeouts.env`).
+
+Search for gaps:
+
+```bash
+rg 'test-e2e-|/e2e-|Label\(\"' test/e2e hack .github/workflows
+```
+
+#### `test/e2e/README.md` (required)
+
+Update these sections:
+
+1. **Test Lanes** table — add a row:
+
+   ```markdown
+   | `my-feature` | `my-feature` | `e2e-my-feature` | Short description of what the suite covers |
+   ```
+
+2. **Running individual lanes** — add `make test-e2e-my-feature`, `bash hack/run-e2e-local.sh my-feature`, and `bash hack/run-e2e-kind.sh my-feature`.
+
+3. **Test Structure** — add the new file:
+
+   ```markdown
+   - `my_feature_test.go`: short description (`Label("my-feature")`)
+   ```
+
+4. **GitHub Actions** — add `/e2e-my-feature` to the PR comment command list.
+
+5. **Benchmarks** (optional) — add a row only after measuring runtime; copy the timeout value from `timeouts.env`, not from other README rows.
+
+#### `hack/run-e2e-local.sh` and `hack/run-e2e-kind.sh`
+
+Add the lane to the help text, the file header comment, and the `case` pattern:
+
+```bash
+# header / usage:
+printf '  my-feature      - short description\n'
+
+# case arm:
+smoke|operator|...|my-feature)
+```
+
+If Dex is required, add the `setup-dex.sh` hook described in **Pitfalls** above.
+
+#### Other docs (when relevant)
+
+- `test/e2e/e2e-test-coverage-TODO.md` — if the suite maps to tracked coverage items
+- `README.md` — only if the suite introduces user-facing behavior worth documenting outside e2e
+
+## Verify
+
+**1. Format and lint** (no cluster required). Fix any failures before proceeding:
+
+```bash
+make fmt
+make lint
+```
+
+If `make lint` fails, fix reported issues (or run `make lint-fix` when auto-fix applies), then re-run `make fmt` and `make lint` until both pass.
+
+**2. Compile** (no cluster required):
+
+```bash
+go test -c ./test/e2e/
+go vet ./test/e2e/
+```
+
+**3. Label filter** (no cluster required):
+
+```bash
+go test ./test/e2e/ -ginkgo.label-filter="my-feature" -ginkgo.dry-run -v -ginkgo.v -timeout 10m || \
+  go test ./test/e2e/ -ginkgo.label-filter="my-feature" -c -count=1
+```
+
+**4. Full lane** (cluster required):
+
+```bash
+make test-e2e-my-feature
+```
+
+Confirm:
+- `make fmt` and `make lint` pass
+- Label in the Go file matches `label_filter` / `lane_name` in workflows and `-ginkgo.label-filter` in Makefile.e2e
+- Timeout variable name matches lane name with hyphens → underscores
+- No duplicate labels or timeout vars
+- README, Makefile, and runner scripts list the new lane
+- No `Pending` or no-op tests remain
+
+## Reference — existing suites
+
+Fully wired lanes (use as models):
+
+| Label | File | Make / PR lane | Timeout |
+|-------|------|----------------|---------|
+| `smoke` | `smoke_test.go` | `test-e2e-smoke` / `/e2e-smoke` | 10m |
+| `operator` | `operator_test.go` | `test-e2e-operator` / `/e2e-operator` | 10m |
+| `auth` | `auth_test.go` | `test-e2e-auth` / `/e2e-auth` | 10m |
+| `features` | `features_e2e_test.go` | `test-e2e-features` / `/e2e-features` | 10m |
+| `bootc` | `bootc_build_test.go` | `test-e2e-bootc` / `/e2e-bootc` | 15m |
+| `package-mode` | `package_build_test.go` | `test-e2e-package-mode` / `/e2e-package-mode` | 15m |
+| `container-build` | `container_build_test.go` | `test-e2e-container-build` / `/e2e-container-build` | 45m |
+
+Incomplete (timeout + label only — do not copy this pattern):
+
+| Label | File | Missing wiring |
+|-------|------|----------------|
+| `manifest-validation` | `manifest_validation_test.go` | Makefile target, `/e2e-*` lane, README lane row |
+| `internal-registry` | `bootc_build_test.go` | Makefile target, `/e2e-*` lane, README lane row |
+
+Shared helpers live in `test/e2e/helpers_test.go`.

--- a/.github/actions/cleanup-kind-e2e/action.yml
+++ b/.github/actions/cleanup-kind-e2e/action.yml
@@ -1,7 +1,7 @@
 name: Cleanup Kind E2E Environment
 description: >
-  Delete the Kind cluster, remove the local registry container, and clean up
-  host-level configuration (DNS entries, container registry config).
+  Delete e2e test namespaces, the Kind cluster, the local registry container,
+  and host-level configuration (DNS entries, container registry config).
 
 inputs:
   cluster-name:
@@ -13,10 +13,32 @@ inputs:
   registry-host:
     description: Registry hostname to remove from /etc/hosts
     default: image-registry.openshift-image-registry.svc
+  namespaces:
+    description: >
+      Space-separated e2e test namespaces to delete before tearing down the
+      cluster. Pass the exact namespace used for E2E_NAMESPACE (e.g.
+      e2e-test-all for the all lane, e2e-smoke for smoke). Non-existent
+      namespaces are silently skipped.
+    default: ""
 
 runs:
   using: composite
   steps:
+    - name: Delete e2e test namespaces
+      if: inputs.namespaces != ''
+      shell: bash
+      env:
+        NAMESPACES: ${{ inputs.namespaces }}
+      run: |
+        read -r -a namespaces_array <<< "$NAMESPACES"
+        for NS in "${namespaces_array[@]}"; do
+          if ! kubectl get ns "$NS" &>/dev/null; then
+            continue
+          fi
+          echo "Deleting namespace $NS..."
+          kubectl delete ns "$NS" --ignore-not-found=true --timeout=60s || true
+        done
+
     - name: Cleanup Kind cluster and registry
       shell: bash
       run: |

--- a/.github/actions/collect-e2e-logs/action.yml
+++ b/.github/actions/collect-e2e-logs/action.yml
@@ -1,35 +1,95 @@
 name: Collect E2E Logs
 description: >
   Collect operator logs, pod status, TaskRuns, events, and custom resources
-  from e2e test namespaces for debugging failures.
+  from e2e test namespaces for debugging failures. Logs are written to files
+  and uploaded as a downloadable workflow artifact.
+  Always captures cluster-level state so at least one file is uploaded even
+  when tests fail before namespace creation.
 
 inputs:
   namespaces:
     description: >
-      Space-separated list of namespaces to collect logs from.
-      Non-existent namespaces are silently skipped.
-    default: e2e-test-all e2e-operator e2e-bootc e2e-auth
+      Space-separated e2e test namespaces to collect logs from. Pass the exact
+      namespace used for E2E_NAMESPACE (e.g. e2e-test-all for the all lane,
+      e2e-smoke for smoke). Non-existent namespaces are silently skipped.
+    default: ""
 
 runs:
   using: composite
   steps:
     - name: Collect logs from e2e namespaces
       shell: bash
+      env:
+        NAMESPACES: ${{ inputs.namespaces }}
       run: |
-        for NS in ${{ inputs.namespaces }}; do
-          if ! kubectl get ns "$NS" &>/dev/null; then continue; fi
-          echo "=== [$NS] Operator Logs ==="
-          kubectl logs -n "$NS" -l control-plane=operator --tail=200 || true
-          echo "=== [$NS] All Pods ==="
-          kubectl get pods -n "$NS" -o wide || true
-          echo "=== [$NS] TaskRuns ==="
-          kubectl get taskrun -n "$NS" -o yaml || true
-          echo "=== [$NS] PipelineRuns ==="
-          kubectl get pipelinerun -n "$NS" -o yaml || true
-          echo "=== [$NS] Events ==="
-          kubectl get events -n "$NS" --sort-by='.lastTimestamp' || true
-          echo "=== [$NS] OperatorConfig ==="
-          kubectl get operatorconfig -n "$NS" -o yaml || true
-          echo "=== [$NS] ImageBuilds ==="
-          kubectl get imagebuilds -n "$NS" -o yaml || true
-        done
+        LOG_DIR="${RUNNER_TEMP}/e2e-logs"
+        mkdir -p "$LOG_DIR"
+        echo "Collecting e2e logs into ${LOG_DIR}"
+
+        # Always collect cluster-level state so there is always at least one
+        # file to upload. This is especially useful when tests fail before the
+        # test namespace is created (e.g. a prior step like "Build caib CLI"
+        # fails, causing "Run E2E tests" to be skipped entirely).
+        kubectl get nodes -o wide > "$LOG_DIR/cluster-nodes.log" 2>&1 || true
+        kubectl get ns > "$LOG_DIR/cluster-namespaces.log" 2>&1 || true
+        kubectl get pods -n tekton-pipelines -o wide > "$LOG_DIR/tekton-pipelines-pods.log" 2>&1 || true
+        kubectl get events -n kube-system --sort-by='.lastTimestamp' > "$LOG_DIR/kube-system-events.log" 2>&1 || true
+
+        # Collect Dex logs when present (auth/all lanes deploy Dex via setup-dex.sh).
+        # Captured unconditionally so failures in the Dex setup step are diagnosable
+        # even when the test namespace was never created.
+        if kubectl get ns dex &>/dev/null; then
+          DEX_DIR="$LOG_DIR/dex"
+          mkdir -p "$DEX_DIR"
+          kubectl get pods -n dex -o wide > "$DEX_DIR/pods.log" 2>&1 || true
+          kubectl get events -n dex --sort-by='.lastTimestamp' > "$DEX_DIR/events.log" 2>&1 || true
+          kubectl get deployment dex -n dex -o yaml > "$DEX_DIR/deployment.yaml" 2>&1 || true
+          for POD in $(kubectl get pods -n dex -o name 2>/dev/null | cut -d/ -f2); do
+            kubectl logs -n dex "$POD" --all-containers=true --tail=-1 \
+              > "$DEX_DIR/${POD}.log" 2>&1 || true
+          done
+        fi
+
+        if [ -n "$NAMESPACES" ]; then
+          MISSING_NS=()
+          read -r -a namespaces_array <<< "$NAMESPACES"
+          for NS in "${namespaces_array[@]}"; do
+            if ! kubectl get ns "$NS" &>/dev/null; then
+              MISSING_NS+=("$NS")
+              continue
+            fi
+            NS_DIR="$LOG_DIR/$NS"
+            mkdir -p "$NS_DIR" "$NS_DIR/pod-logs"
+            # caib.log is written during tests when E2E_LOG_DIR is set.
+            kubectl logs -n "$NS" -l control-plane=operator --all-containers=true --tail=-1 \
+              > "$NS_DIR/operator.log" 2>&1 || true
+            kubectl logs -n "$NS" -l app.kubernetes.io/component=build-api --all-containers=true --tail=-1 \
+              > "$NS_DIR/build-api.log" 2>&1 || true
+            kubectl get pods -n "$NS" -o wide > "$NS_DIR/pods.log" 2>&1 || true
+            kubectl get taskrun -n "$NS" -o yaml > "$NS_DIR/taskruns.yaml" 2>&1 || true
+            kubectl get pipelinerun -n "$NS" -o yaml > "$NS_DIR/pipelineruns.yaml" 2>&1 || true
+            kubectl get events -n "$NS" --sort-by='.lastTimestamp' > "$NS_DIR/events.log" 2>&1 || true
+            kubectl get operatorconfig -n "$NS" -o yaml > "$NS_DIR/operatorconfig.yaml" 2>&1 || true
+            kubectl get imagebuild -n "$NS" > "$NS_DIR/imagebuilds.log" 2>&1 || true
+            kubectl get imagebuild -n "$NS" -o yaml > "$NS_DIR/imagebuilds.yaml" 2>&1 || true
+            for POD in $(kubectl get pods -n "$NS" -o name 2>/dev/null | cut -d/ -f2); do
+              kubectl logs -n "$NS" "$POD" --all-containers=true --tail=-1 \
+                > "$NS_DIR/pod-logs/${POD}.log" 2>&1 || true
+            done
+          done
+
+          if [ ${#MISSING_NS[@]} -gt 0 ]; then
+            printf '%s\n' "${MISSING_NS[@]}" > "$LOG_DIR/missing-namespaces.txt"
+            echo "Namespaces not found (tests may not have started): ${MISSING_NS[*]}"
+          fi
+        fi
+
+        echo "E2E log collection complete"
+
+    - name: Upload E2E logs as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: e2e-logs
+        path: ${{ runner.temp }}/e2e-logs
+        if-no-files-found: warn
+        compression-level: 9

--- a/.github/actions/setup-kind-e2e/action.yml
+++ b/.github/actions/setup-kind-e2e/action.yml
@@ -4,6 +4,9 @@ description: >
   and an NGINX ingress controller for running E2E tests.
 
 inputs:
+  helm-version:
+    description: Helm version to install
+    default: v3.17.0
   kind-version:
     description: Kind version to install
     default: v0.24.0
@@ -40,6 +43,29 @@ runs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libgpgme-dev jq
+
+    - name: Install Helm
+      shell: bash
+      run: |
+        HELM_REQUESTED="${{ inputs.helm-version }}"
+        install_helm() {
+          curl -fsSL https://get.helm.sh/helm-${{ inputs.helm-version }}-linux-${{ inputs.arch }}.tar.gz \
+            | tar xz --strip-components=1 -C /tmp linux-${{ inputs.arch }}/helm
+          sudo mv /tmp/helm /usr/local/bin/helm
+          echo "Installed Helm ${{ inputs.helm-version }}"
+        }
+        if command -v helm &>/dev/null; then
+          HELM_CURRENT=$(helm version --short 2>/dev/null | cut -d: -f2 | xargs)
+          if [ "$HELM_CURRENT" = "$HELM_REQUESTED" ]; then
+            echo "Helm $HELM_REQUESTED already installed"
+          else
+            echo "Helm version mismatch (current: $HELM_CURRENT, requested: $HELM_REQUESTED); installing requested version..."
+            install_helm
+          fi
+        else
+          install_helm
+        fi
+        helm version --short
 
     - name: Install kubectl
       shell: bash

--- a/.github/workflows/e2e-lanes.yml
+++ b/.github/workflows/e2e-lanes.yml
@@ -35,6 +35,7 @@ jobs:
         env:
           COMMENT: ${{ github.event.comment.body }}
         run: |
+          COMMENT="$(echo "$COMMENT" | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')"
           case "$COMMENT" in
             /e2e-smoke*)
               echo "label_filter=smoke" >> "$GITHUB_OUTPUT"
@@ -141,15 +142,19 @@ jobs:
           REGISTRY_USERNAME: kind
           REGISTRY_PASSWORD: kind
           CAIB_SERVER: http://localhost:8080
+          E2E_SKIP_CLEANUP: "true"
           E2E_LABEL_FILTER: ${{ needs.parse-comment.outputs.label_filter }}
           E2E_NAMESPACE: ${{ needs.parse-comment.outputs.lane_name == 'all' && 'e2e-test-all' || format('e2e-{0}', needs.parse-comment.outputs.lane_name) }}
+          E2E_LOG_DIR: ${{ runner.temp }}/e2e-logs
         run: |
-          case "${{ needs.parse-comment.outputs.lane_name }}" in
-            smoke|operator|auth|features) test_timeout=10m ;;
-            bootc|package-mode) test_timeout=15m ;;
-            container-build|all) test_timeout=45m ;;
-            *)                   echo "Unknown lane: ${{ needs.parse-comment.outputs.lane_name }}" >&2; exit 1 ;;
-          esac
+          source hack/e2e/timeouts.env
+          mkdir -p "${E2E_LOG_DIR}/${E2E_NAMESPACE}"
+          _lane="${{ needs.parse-comment.outputs.lane_name }}"
+          _key="E2E_TIMEOUT_${_lane//-/_}"
+          test_timeout="${!_key}"
+          if [ -z "$test_timeout" ]; then
+            echo "Unknown lane: $_lane" >&2; exit 1
+          fi
           ginkgo_args=(-v -ginkgo.v -timeout "$test_timeout")
           if [ -n "$E2E_LABEL_FILTER" ]; then
             ginkgo_args+=(-ginkgo.label-filter="$E2E_LABEL_FILTER")
@@ -199,3 +204,4 @@ jobs:
           cluster-name: ${{ env.CLUSTER_NAME }}
           registry-name: ${{ env.REGISTRY_NAME }}
           registry-host: ${{ env.REGISTRY_HOST }}
+          namespaces: ${{ needs.parse-comment.outputs.lane_name == 'all' && 'e2e-test-all' || format('e2e-{0}', needs.parse-comment.outputs.lane_name) }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       label_filter:
-        description: 'Ginkgo label filter (e.g. "smoke", "operator", "bootc", "container-build", "auth"). Empty runs all.'
+        description: 'Ginkgo label filter (e.g. "smoke", "operator", "bootc", "internal-registry", "package-mode", "container-build", "features", "manifest-validation", "auth"). Empty runs all.'
         required: false
         default: ''
 
@@ -64,18 +64,18 @@ jobs:
           REGISTRY_USERNAME: kind
           REGISTRY_PASSWORD: kind
           CAIB_SERVER: http://localhost:8080
+          E2E_SKIP_CLEANUP: "true"
           E2E_LABEL_FILTER: ${{ github.event_name == 'pull_request' && 'smoke' || github.event.inputs.label_filter || '' }}
           E2E_NAMESPACE: ${{ github.event_name == 'pull_request' && 'e2e-smoke' || (github.event.inputs.label_filter && format('e2e-{0}', github.event.inputs.label_filter) || 'e2e-test-all') }}
+          E2E_LOG_DIR: ${{ runner.temp }}/e2e-logs
         run: |
+          source hack/e2e/timeouts.env
+          mkdir -p "${E2E_LOG_DIR}/${E2E_NAMESPACE}"
           if [ -z "$E2E_LABEL_FILTER" ]; then
-            test_timeout=45m
+            test_timeout=$E2E_TIMEOUT_all
           else
-            case "$E2E_LABEL_FILTER" in
-              smoke|operator|auth|features) test_timeout=10m ;;
-              bootc|package-mode) test_timeout=15m ;;
-              container-build)     test_timeout=45m ;;
-              *)                   test_timeout=45m ;;
-            esac
+            _key="E2E_TIMEOUT_${E2E_LABEL_FILTER//-/_}"
+            test_timeout="${!_key:-$E2E_TIMEOUT_all}"
           fi
           ginkgo_args=(-v -ginkgo.v -timeout "$test_timeout")
           if [ -n "$E2E_LABEL_FILTER" ]; then
@@ -86,6 +86,8 @@ jobs:
       - name: Collect logs on failure
         if: failure()
         uses: ./.github/actions/collect-e2e-logs
+        with:
+          namespaces: ${{ github.event_name == 'pull_request' && 'e2e-smoke' || (github.event.inputs.label_filter != '' && format('e2e-{0}', github.event.inputs.label_filter) || 'e2e-test-all') }}
 
       - name: Cleanup
         if: always()
@@ -94,3 +96,4 @@ jobs:
           cluster-name: ${{ env.CLUSTER_NAME }}
           registry-name: ${{ env.REGISTRY_NAME }}
           registry-host: ${{ env.REGISTRY_HOST }}
+          namespaces: ${{ github.event_name == 'pull_request' && 'e2e-smoke' || (github.event.inputs.label_filter != '' && format('e2e-{0}', github.event.inputs.label_filter) || 'e2e-test-all') }}

--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -14,10 +14,8 @@
 #                    Defaults to a specific suite namespace if not provided.
 ################################################################################
 
-# Ginkgo timeouts — keep in sync with .github/workflows/e2e.yml and e2e-lanes.yml
-E2E_TIMEOUT_FAST  ?= 10m   # smoke, operator, auth, features
-E2E_TIMEOUT_SHORT ?= 15m  # bootc, package-mode
-E2E_TIMEOUT_LONG  ?= 45m  # full suite
+# Ginkgo timeouts — sourced from hack/e2e/timeouts.env (single source of truth)
+include hack/e2e/timeouts.env
 
 # E2E test targets. Use test-e2e to run everything, or pick a lane:
 #   test-e2e-smoke        - quick smoke tests (CRDs, OperatorConfig, Build API, CR lifecycle)
@@ -30,32 +28,32 @@ E2E_TIMEOUT_LONG  ?= 45m  # full suite
 .PHONY: test-e2e
 # Full suite runs all labeled tests sequentially.
 test-e2e:
-	go test ./test/e2e/ -v -ginkgo.v -timeout $(E2E_TIMEOUT_LONG)
+	go test ./test/e2e/ -v -ginkgo.v -timeout $(E2E_TIMEOUT_all)
 
 .PHONY: test-e2e-smoke
 test-e2e-smoke:
-	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-smoke} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="smoke" -timeout $(E2E_TIMEOUT_FAST)
+	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-smoke} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="smoke" -timeout $(E2E_TIMEOUT_smoke)
 
 .PHONY: test-e2e-operator
 test-e2e-operator:
-	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-operator} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="operator" -timeout $(E2E_TIMEOUT_FAST)
+	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-operator} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="operator" -timeout $(E2E_TIMEOUT_operator)
 
 .PHONY: test-e2e-bootc
 test-e2e-bootc:
-	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-bootc} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="bootc" -timeout $(E2E_TIMEOUT_SHORT)
+	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-bootc} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="bootc" -timeout $(E2E_TIMEOUT_bootc)
 
 .PHONY: test-e2e-container-build
 test-e2e-container-build:
-	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-container-build} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="container-build" -timeout $(E2E_TIMEOUT_LONG)
+	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-container-build} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="container-build" -timeout $(E2E_TIMEOUT_container_build)
 
 .PHONY: test-e2e-auth
 test-e2e-auth:
-	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-auth} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="auth" -timeout $(E2E_TIMEOUT_FAST)
+	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-auth} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="auth" -timeout $(E2E_TIMEOUT_auth)
 
 .PHONY: test-e2e-package-mode
 test-e2e-package-mode:
-	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-package-mode} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="package-mode" -timeout $(E2E_TIMEOUT_SHORT)
+	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-package-mode} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="package-mode" -timeout $(E2E_TIMEOUT_package_mode)
 
 .PHONY: test-e2e-features
 test-e2e-features:
-	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-features} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="features" -timeout $(E2E_TIMEOUT_FAST)
+	E2E_NAMESPACE=$${E2E_NAMESPACE:-e2e-features} go test ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="features" -timeout $(E2E_TIMEOUT_features)

--- a/hack/e2e/setup-dex.sh
+++ b/hack/e2e/setup-dex.sh
@@ -83,12 +83,12 @@ deploy_dex() {
 
     helm repo add dex https://charts.dexidp.io 2>/dev/null || true
     helm repo update dex
-    helm upgrade --install --namespace dex --wait --version 0.21.0 \
+    helm upgrade --install --namespace dex --wait --timeout 5m0s --version 0.21.0 \
         -f "$SCRIPT_DIR/dex.values.yaml" dex dex/dex
 
     log_info "Waiting for Dex to be ready..."
     kubectl wait --namespace dex --for=condition=available \
-        deployment/dex --timeout=120s
+        deployment/dex --timeout=5m
 
     log_info "Dex deployed successfully"
 }

--- a/hack/e2e/timeouts.env
+++ b/hack/e2e/timeouts.env
@@ -1,0 +1,22 @@
+# E2E suite timeouts — single source of truth.
+# Sourced by .github/workflows/e2e*.yml (via `source`) and Makefile.e2e (via `include`).
+# To add a new timeout: add one line here.
+# For full lane wiring, see .cursor/skills/e2e/SKILL.md.
+#
+# Variable names use underscores; scripts convert hyphens with: ${suite//-/_}
+
+# fast lanes (~10m)
+E2E_TIMEOUT_smoke=10m
+E2E_TIMEOUT_operator=10m
+E2E_TIMEOUT_auth=10m
+E2E_TIMEOUT_features=10m
+E2E_TIMEOUT_manifest_validation=10m
+
+# medium lanes (~15m)
+E2E_TIMEOUT_bootc=15m
+E2E_TIMEOUT_internal_registry=15m
+E2E_TIMEOUT_package_mode=15m
+
+# slow lanes (~45m)
+E2E_TIMEOUT_container_build=45m
+E2E_TIMEOUT_all=45m

--- a/hack/run-e2e-local.sh
+++ b/hack/run-e2e-local.sh
@@ -27,6 +27,7 @@ usage() {
   printf '  -h, --help    Show this help message and exit\n\n'
   printf 'Environment variables:\n'
   printf '  E2E_NAMESPACE          Override the test namespace (default: e2e-<lane> or e2e-test-all)\n'
+  printf '  E2E_LOG_DIR            Directory for caib CLI logs (default: ${TMPDIR:-/tmp}/e2e-logs)\n'
   printf '  CONTAINER_TOOL         Container runtime (default: podman)\n'
   printf '  REGISTRY_TLS_VERIFY    TLS verification for registry (default: false)\n'
   printf '  REGISTRY_HOST          Registry host (default: image-registry.openshift-image-registry.svc)\n'
@@ -305,6 +306,9 @@ if [ "$E2E_LANE" = "all" ]; then
 else
   export E2E_NAMESPACE="${E2E_NAMESPACE:-e2e-${E2E_LANE}}"
 fi
+export E2E_LOG_DIR="${E2E_LOG_DIR:-${TMPDIR:-/tmp}/e2e-logs}"
+mkdir -p "${E2E_LOG_DIR}/${E2E_NAMESPACE}"
+info "Caib command logs: ${E2E_LOG_DIR}/${E2E_NAMESPACE}/caib.log"
 unset KIND_CLUSTER
 make "${E2E_MAKE_TARGET}"
 

--- a/internal/buildapi/registry.go
+++ b/internal/buildapi/registry.go
@@ -10,6 +10,7 @@ import (
 	authnv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -56,7 +57,7 @@ func getExternalRegistryRoute(ctx context.Context, k8sClient client.Client, name
 		Name:      "default-route",
 		Namespace: "openshift-image-registry",
 	}, route); err != nil {
-		if k8serrors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) || apimeta.IsNoMatchError(err) {
 			return "", fmt.Errorf("cannot determine external registry route: set clusterRegistryRoute in OperatorConfig or expose default-route in openshift-image-registry")
 		}
 		return "", fmt.Errorf("cannot determine external registry route: %w", err)
@@ -139,6 +140,9 @@ func ensureImageStream(ctx context.Context, k8sClient client.Client, namespace, 
 	err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, is)
 	if err == nil {
 		return false, nil // already exists
+	}
+	if apimeta.IsNoMatchError(err) {
+		return false, nil // not an OpenShift cluster; ImageStreams are not needed
 	}
 	if !k8serrors.IsNotFound(err) {
 		return false, fmt.Errorf("error checking ImageStream %s: %w", name, err)

--- a/internal/controller/imagebuild/controller.go
+++ b/internal/controller/imagebuild/controller.go
@@ -308,7 +308,7 @@ func (r *ImageBuildReconciler) ensureImageStreamOwnerRef(
 		Name:      streamName,
 		Namespace: imageBuild.Namespace,
 	}, is); err != nil {
-		if errors.IsNotFound(err) {
+		if errors.IsNotFound(err) || meta.IsNoMatchError(err) {
 			log.Info("ImageStream not found, skipping owner ref", "imageStream", streamName)
 			return nil
 		}

--- a/internal/controller/imagebuild/controller_test.go
+++ b/internal/controller/imagebuild/controller_test.go
@@ -6,15 +6,19 @@ import (
 	"testing"
 
 	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/tasks"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	knativev1 "knative.dev/pkg/apis/duck/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 func TestPipelineRunFailureMessage(t *testing.T) {
@@ -574,5 +578,63 @@ func TestSetImageBuildConditionsTransition(t *testing.T) {
 
 	if len(ib.Status.Conditions) != 2 {
 		t.Errorf("Expected 2 conditions after transitions, got %d", len(ib.Status.Conditions))
+	}
+}
+
+func TestEnsureImageStreamOwnerRefNoMatch(t *testing.T) {
+	testNS := "test-ns"
+	testBuildName := "test-build"
+	testStreamName := "test-stream"
+	imageStreamURL := tasks.DefaultInternalRegistryURL + "/" + testNS + "/" + testStreamName + ":latest"
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(automotivev1alpha1.AddToScheme(scheme))
+
+	imageBuild := &automotivev1alpha1.ImageBuild{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testBuildName,
+			Namespace: testNS,
+		},
+		Spec: automotivev1alpha1.ImageBuildSpec{
+			Export: &automotivev1alpha1.ExportSpec{
+				Container:             imageStreamURL,
+				UseServiceAccountAuth: true,
+			},
+		},
+	}
+
+	noMatchErr := &meta.NoKindMatchError{
+		GroupKind: schema.GroupKind{Group: "image.openshift.io", Kind: "ImageStream"},
+	}
+
+	getCalled := false
+	// Create a fake client that will return a NoMatch error for ImageStream lookups
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Group == "image.openshift.io" &&
+					obj.GetObjectKind().GroupVersionKind().Kind == "ImageStream" {
+					getCalled = true
+					return noMatchErr
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	reconciler := &ImageBuildReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+	}
+
+	// ensureImageStreamOwnerRef should return nil when encountering a NotFound/NoMatch error
+	// (which occurs when ImageStream is not found or the CRD is not available)
+	err := reconciler.ensureImageStreamOwnerRef(context.Background(), imageBuild)
+	if err != nil {
+		t.Errorf("ensureImageStreamOwnerRef returned error: %v, want nil", err)
+	}
+	if !getCalled {
+		t.Fatal("expected ImageStream lookup to be attempted")
 	}
 }

--- a/test/e2e/bootc_build_test.go
+++ b/test/e2e/bootc_build_test.go
@@ -73,6 +73,7 @@ var _ = Describe("Bootc Container Build", Label("bootc"), Ordered, func() {
 		if openShiftCluster {
 			pushNamespace = testNamespace
 		}
+		pushURL := fmt.Sprintf("%s:5000/%s/%s", registryHost, pushNamespace, artifactImageName)
 
 		By("launching bootc container build")
 		go func() {
@@ -81,7 +82,8 @@ var _ = Describe("Bootc Container Build", Label("bootc"), Ordered, func() {
 				caibBuildManifest,
 				"--name", containerBuildName,
 				"--arch", arch,
-				"--push", fmt.Sprintf("%s:5000/%s/%s", registryHost, pushNamespace, artifactImageName),
+				"--push", pushURL,
+				"--follow",
 			)
 			containerCh <- buildResult{output: out, err: err}
 		}()
@@ -169,6 +171,7 @@ var _ = Describe("Internal Registry Build", Label("internal-registry"), Ordered,
 				"--name", buildName,
 				"--arch", arch,
 				"--internal-registry",
+				"--follow",
 			)
 			ch <- buildResult{output: out, err: err}
 		}()

--- a/test/e2e/buildapi_test.go
+++ b/test/e2e/buildapi_test.go
@@ -36,6 +36,7 @@ var _ = Describe("Build API", Label("operator"), Ordered, func() {
 		ensureOperatorDeployed()
 		ensureBuildAPIAccess()
 		ensureCaibCredentials()
+		ensureRegistryConfigured()
 	})
 
 	// #41 — caib image build-dev creates an ImageBuild CR
@@ -124,7 +125,9 @@ var _ = Describe("Build API", Label("operator"), Ordered, func() {
 			}
 			filtered = append(filtered, tokenPrefix+token)
 			cmd := utils.NewCaibCommand(ctx, filtered, args...)
-			return utils.RunSafe(cmd)
+			output, err := utils.RunSafe(cmd)
+			appendCaibCommandLog(args, output, err)
+			return output, err
 		}
 
 		It("should return 403 when a different user tries to cancel or delete another user's build", func() {

--- a/test/e2e/container_build_test.go
+++ b/test/e2e/container_build_test.go
@@ -98,14 +98,14 @@ var _ = Describe("Container Build (Shipwright)", Label("container-build"), Order
 		defer cancel()
 
 		By("launching container build with --internal-registry")
-		cmd := utils.NewCaibCommand(ctx, caibEnv,
+		output, err := runCaibCommand(ctx,
 			"container", "build",
 			"--containerfile", containerBuildContext+"/Containerfile",
 			"--name", buildName,
 			"--internal-registry",
 			"--arch", arch,
-			containerBuildContext)
-		output, err := utils.RunSafe(cmd)
+			containerBuildContext,
+		)
 
 		By("verifying container build completed successfully")
 		_, _ = fmt.Fprintf(GinkgoWriter, "\n--- caib container build (%s) ---\n%s\n",
@@ -124,15 +124,15 @@ var _ = Describe("Container Build (Shipwright)", Label("container-build"), Order
 		defer cancel()
 
 		By("launching container build with --build-arg and --internal-registry")
-		cmd := utils.NewCaibCommand(ctx, caibEnv,
+		output, err := runCaibCommand(ctx,
 			"container", "build",
 			"--containerfile", containerBuildContext+"/Containerfile",
 			"--name", buildName,
 			"--internal-registry",
 			"--build-arg", "VERSION=1.0-e2e",
 			"--arch", arch,
-			containerBuildContext)
-		output, err := utils.RunSafe(cmd)
+			containerBuildContext,
+		)
 
 		By("verifying build-arg container build completed successfully")
 		_, _ = fmt.Fprintf(GinkgoWriter, "\n--- caib container build with build-arg (%s) ---\n%s\n",

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -27,6 +27,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -56,6 +57,10 @@ const (
 	caibImageCancelTimeout = 30 * time.Second
 	caibImageListTimeout   = 15 * time.Second
 	statusTrue             = "true"
+
+	caibLogFileName = "caib.log"
+
+	healthzPath = "/v1/healthz"
 )
 
 // Shared state populated lazily via sync.Once and consumed by test lanes.
@@ -74,6 +79,7 @@ var (
 	registryOnce  sync.Once
 	caibCredsOnce sync.Once
 	dexOnce       sync.Once
+	caibLogMu     sync.Mutex
 
 	// Error flags: set when a setup panic is caught so subsequent lanes fail fast.
 	operatorSetupErr  error
@@ -276,6 +282,23 @@ func patchForOpenShift() {
 	_, _ = utils.Run(cmd)
 }
 
+// repatchTasks re-applies the environment-specific Tekton Task overrides.
+// Call this after any operation that recreates the Tekton Tasks (e.g., toggling osBuilds).
+func repatchTasks() {
+	By("waiting for " + tektonTaskPushArtifactRegistry + " Task to exist before re-patching")
+	EventuallyWithOffset(1, func() error {
+		cmd := exec.Command("kubectl", "get", "task", tektonTaskPushArtifactRegistry, "-n", testNamespace)
+		_, err := utils.Run(cmd)
+		return err
+	}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+	if openShiftCluster {
+		patchForOpenShift()
+	} else {
+		patchForKind()
+	}
+}
+
 func patchForKind() {
 	var err error
 
@@ -292,7 +315,8 @@ func patchForKind() {
 }
 
 // ensureBuildAPIAccess sets up access to the Build API (route on OpenShift,
-// port-forward on Kind). Runs once per test run.
+// port-forward on Kind). Initial setup runs once; subsequent calls re-establish
+// the port-forward on Kind if it has died (e.g. after a Build API pod restart).
 func ensureBuildAPIAccess() {
 	buildAPIOnce.Do(func() {
 		defer func() {
@@ -310,20 +334,81 @@ func ensureBuildAPIAccess() {
 	if buildAPISetupErr != nil {
 		Fail("Build API access setup failed in a previous step; cannot proceed")
 	}
+	// On Kind the port-forward may have died (e.g. after a Build API pod restart
+	// triggered by an OperatorConfig change). Re-establish it if needed so every
+	// test suite starts with a working connection.
+	if !openShiftCluster {
+		ensurePortForwardAlive()
+	}
+}
+
+// ensurePortForwardAlive verifies the Build API port-forward is healthy and
+// restarts it if not. Safe to call from every test suite's BeforeAll.
+func ensurePortForwardAlive() {
+	httpClient := newInsecureHTTPClient()
+	resp, err := httpClient.Get("http://localhost:8080" + healthzPath)
+	if err == nil {
+		_ = resp.Body.Close()
+		if resp.StatusCode == http.StatusOK {
+			return
+		}
+	}
+
+	By("restarting port-forward to Build API (previous instance is unresponsive)")
+	killPortForwardCmd(&portForwardCmd)
+	time.Sleep(1 * time.Second)
+
+	portForwardCmd = exec.Command("kubectl", "port-forward",
+		"-n", testNamespace, "svc/ado-build-api", "8080:8080")
+	ExpectWithOffset(1, portForwardCmd.Start()).NotTo(HaveOccurred())
+
+	By("waiting for Build API to respond after port-forward restart")
+	EventuallyWithOffset(1, func() error {
+		r, hErr := httpClient.Get("http://localhost:8080" + healthzPath)
+		if hErr != nil {
+			return hErr
+		}
+		_ = r.Body.Close()
+		if r.StatusCode != http.StatusOK {
+			return fmt.Errorf("unexpected status %d from %s", r.StatusCode, healthzPath)
+		}
+		return nil
+	}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+		"Build API did not recover after port-forward restart")
+
+	By("waiting for Build API config endpoint to be ready after port-forward restart")
+	EventuallyWithOffset(1, func() error {
+		r, hErr := httpClient.Get("http://localhost:8080/v1/config")
+		if hErr != nil {
+			return hErr
+		}
+		_ = r.Body.Close()
+		if r.StatusCode == http.StatusServiceUnavailable {
+			return fmt.Errorf("Build API /v1/config still returning 503 (OperatorConfig not yet ready)")
+		}
+		return nil
+	}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+		"Build API config endpoint did not recover after port-forward restart")
+
+	caibServer = "http://localhost:8080"
 }
 
 func setupBuildAPIRoute() {
 	By("waiting for Build API route")
-	EventuallyWithOffset(1, func() string {
-		caibServer = utils.GetBuildAPIURL(testNamespace)
-		return caibServer
-	}, 2*time.Minute, 5*time.Second).ShouldNot(BeEmpty())
+	EventuallyWithOffset(1, func() error {
+		url := utils.GetBuildAPIURL(testNamespace)
+		if url == "" {
+			return fmt.Errorf("Build API route URL not yet available")
+		}
+		caibServer = url
+		return nil
+	}, 2*time.Minute, 5*time.Second).Should(Succeed())
 
 	httpClient := newInsecureHTTPClient()
 
 	By("waiting for Build API route to respond")
 	waitForBuildAPI := func() error {
-		resp, httpErr := httpClient.Get(caibServer + "/v1/healthz")
+		resp, httpErr := httpClient.Get(caibServer + healthzPath)
 		if httpErr != nil {
 			return httpErr
 		}
@@ -331,7 +416,7 @@ func setupBuildAPIRoute() {
 		if resp.StatusCode == http.StatusOK {
 			return nil
 		}
-		return fmt.Errorf("unexpected status %d from Build API /v1/healthz", resp.StatusCode)
+		return fmt.Errorf("unexpected status %d from Build API %s", resp.StatusCode, healthzPath)
 	}
 	EventuallyWithOffset(1, waitForBuildAPI, 2*time.Minute, 5*time.Second).Should(Succeed(),
 		"Build API route did not become ready")
@@ -369,7 +454,7 @@ func setupBuildAPIPortForward() {
 
 	By("waiting for Build API to respond on port-forward")
 	waitForBuildAPI := func() error {
-		resp, httpErr := httpClient.Get("http://localhost:8080/v1/healthz")
+		resp, httpErr := httpClient.Get("http://localhost:8080" + healthzPath)
 		if httpErr != nil {
 			return httpErr
 		}
@@ -377,7 +462,7 @@ func setupBuildAPIPortForward() {
 		if resp.StatusCode == http.StatusOK {
 			return nil
 		}
-		return fmt.Errorf("unexpected status %d from Build API /v1/healthz", resp.StatusCode)
+		return fmt.Errorf("unexpected status %d from Build API %s", resp.StatusCode, healthzPath)
 	}
 	EventuallyWithOffset(1, waitForBuildAPI, 30*time.Second, 1*time.Second).Should(Succeed(),
 		"Build API on localhost:8080 did not become ready")
@@ -659,10 +744,15 @@ func killPortForwardCmd(cmd **exec.Cmd) {
 }
 
 // teardownOperator cleans up all test resources. Called from AfterSuite.
+// When E2E_SKIP_CLEANUP=true the port-forwards and namespace are kept alive so
+// subsequent suites (e.g. in the /e2e-test-all lane) can still reach the API,
+// and CI can collect logs before the cluster is torn down.
 func teardownOperator() {
+	if os.Getenv("E2E_SKIP_CLEANUP") == "true" {
+		return
+	}
 	killPortForwardCmd(&portForwardCmd)
 	killPortForwardCmd(&dexPortFwdCmd)
-
 	if testNamespace != "" {
 		By("removing test namespace")
 		utils.CleanupNamespace(testNamespace)
@@ -883,7 +973,44 @@ spec:
 // runCaibCommand executes a caib CLI command with the shared caibEnv and returns its output.
 func runCaibCommand(ctx context.Context, args ...string) ([]byte, error) {
 	cmd := utils.NewCaibCommand(ctx, caibEnv, args...)
-	return utils.RunSafe(cmd)
+	output, err := utils.RunSafe(cmd)
+	appendCaibCommandLog(args, output, err)
+	return output, err
+}
+
+// appendCaibCommandLog records caib stdout/stderr when E2E_LOG_DIR is set so the
+// collect-e2e-logs workflow action can upload it with other failure artifacts.
+func appendCaibCommandLog(args []string, output []byte, err error) {
+	logDir := strings.TrimSpace(os.Getenv("E2E_LOG_DIR"))
+	if logDir == "" || testNamespace == "" {
+		return
+	}
+
+	dir := filepath.Join(logDir, testNamespace)
+	if mkErr := os.MkdirAll(dir, 0o755); mkErr != nil {
+		return
+	}
+
+	caibLogMu.Lock()
+	defer caibLogMu.Unlock()
+
+	f, openErr := os.OpenFile(filepath.Join(dir, caibLogFileName), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if openErr != nil {
+		return
+	}
+	defer func() { _ = f.Close() }()
+
+	_, _ = fmt.Fprintf(f, "=== caib %s ===\n", strings.Join(args, " "))
+	if err != nil {
+		_, _ = fmt.Fprintf(f, "error: %v\n", err)
+	}
+	if len(output) > 0 {
+		_, _ = f.Write(output)
+		if output[len(output)-1] != '\n' {
+			_, _ = f.WriteString("\n")
+		}
+	}
+	_, _ = f.WriteString("\n")
 }
 
 // createBuildViaCaib creates a build via `caib image build-dev` and returns the server-assigned build name.

--- a/test/e2e/imagebuild_lifecycle_test.go
+++ b/test/e2e/imagebuild_lifecycle_test.go
@@ -38,6 +38,7 @@ var _ = Describe("ImageBuild Lifecycle", Label("operator"), Ordered, func() {
 			ensureOperatorDeployed()
 			ensureBuildAPIAccess()
 			ensureCaibCredentials()
+			ensureRegistryConfigured()
 		})
 
 		It("should cancel a running build and transition to Cancelled", func() {

--- a/test/e2e/operatorconfig_e2e_test.go
+++ b/test/e2e/operatorconfig_e2e_test.go
@@ -60,6 +60,8 @@ var _ = Describe("OperatorConfig E2E", Label("operator"), Ordered, func() {
 				}
 				return nil
 			}, 3*time.Minute, 5*time.Second).Should(Succeed())
+
+			repatchTasks()
 		})
 
 		By("disabling osBuilds")
@@ -126,6 +128,8 @@ var _ = Describe("OperatorConfig E2E", Label("operator"), Ordered, func() {
 
 		By("verifying Tekton resources are recreated")
 		verifyTektonResourcesExist()
+
+		repatchTasks()
 	})
 })
 

--- a/test/e2e/package_build_test.go
+++ b/test/e2e/package_build_test.go
@@ -66,6 +66,7 @@ var _ = Describe("Package Mode Build", Label("package-mode"), Ordered, func() {
 		if openShiftCluster {
 			pushNamespace = testNamespace
 		}
+		pushURL := fmt.Sprintf("%s:5000/%s/%s", registryHost, pushNamespace, artifactImageName)
 
 		By("launching package mode build via caib build-dev")
 		go func() {
@@ -76,7 +77,8 @@ var _ = Describe("Package Mode Build", Label("package-mode"), Ordered, func() {
 				"--arch", arch,
 				"--mode", "package",
 				"--format", "qcow2",
-				"--push", fmt.Sprintf("%s:5000/%s/%s", registryHost, pushNamespace, artifactImageName),
+				"--push", pushURL,
+				"--follow",
 			)
 			ch <- buildResult{output: out, err: err}
 		}()

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -120,9 +120,9 @@ var _ = Describe("Smoke: Build API Endpoints", Label("smoke"), Ordered, func() {
 	})
 
 	// #5
-	It("/v1/healthz should return 200", func() {
+	It(healthzPath+" should return 200", func() {
 		client := newInsecureHTTPClient()
-		resp, err := client.Get(caibServer + "/v1/healthz")
+		resp, err := client.Get(caibServer + healthzPath)
 		Expect(err).NotTo(HaveOccurred())
 		defer func() { _ = resp.Body.Close() }()
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -37,6 +37,7 @@ const (
 	openshiftInternalRegistryDefault = "image-registry.openshift-image-registry.svc:5000"
 	buildToolPodman                  = "podman"
 	buildToolDocker                  = "docker"
+	caibBin                          = "bin/caib"
 )
 
 func getOpenshiftInternalRegistry() string {
@@ -210,9 +211,9 @@ func getTektonTaskStep(obj map[string]any, taskName string, stepIndex int) (map[
 func NewCaibCommand(ctx context.Context, env []string, args ...string) *exec.Cmd {
 	var cmd *exec.Cmd
 	if ctx != nil {
-		cmd = exec.CommandContext(ctx, "bin/caib", args...)
+		cmd = exec.CommandContext(ctx, caibBin, args...)
 	} else {
-		cmd = exec.Command("bin/caib", args...)
+		cmd = exec.Command(caibBin, args...)
 	}
 	cmd.Env = append([]string{}, env...)
 	return cmd


### PR DESCRIPTION
## Summary
improves E2E test log collection into downloadable artifact, and centralizing timeout configuration, automating log collect
The changes make debugging CI failures substantially easier by capturing detailed cluster state as downloadable artifacts.

Example: https://github.com/maboras-rh/automotive-dev-operator/actions/runs/28318889917

## Related Issues
https://github.com/centos-automotive-suite/automotive-dev-operator/issues/321

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] CI/CD improvement
- [ ] Refactoring

## Testing
- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * E2E log collection now writes richer cluster and (optionally) per-namespace details to a dedicated directory and uploads it as an artifact; namespaces can be provided or left empty to skip per-namespace collection.
  * Kind E2E setup now installs Helm automatically; cleanup can optionally delete specified E2E namespaces before teardown.
* **Bug Fixes**
  * Improved E2E lane/comment parsing, Build API port-forward self-healing, and more resilient OpenShift “no match” behavior.
* **Chores**
  * Centralized lane-based E2E timeouts across workflows and Make targets, with clearer timeout selection and updated log-directory support for local runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->