### PR TITLE
feat: add --output-format json for caib build

### DIFF
--- a/cmd/caib/buildcmd/build.go
+++ b/cmd/caib/buildcmd/build.go
@@ -87,13 +87,15 @@ type Options struct {
 	TTL               *string
 
 	InsecureSkipTLS *bool
+	OutputFormat    *string
 
 	HandleError func(error)
 }
 
 // Handler implements image build command run functions.
 type Handler struct {
-	opts Options
+	opts        Options
+	lastLeaseID string
 }
 
 // NewHandler creates a build workflow handler.
@@ -114,15 +116,35 @@ func (h *Handler) supportsColorOutput() bool {
 	return common.SupportsColorOutput()
 }
 
-func (h *Handler) applyWaitFollowDefaults(cmd *cobra.Command, defaultWait, defaultFollow bool) {
+func (h *Handler) isStructuredOutput() bool {
+	return common.IsStructuredFormat(h.opts.OutputFormat)
+}
+
+// BuildResult is the machine-readable output emitted when --output-format is json or yaml.
+type BuildResult struct {
+	Name                    string `json:"name" yaml:"name"`
+	Phase                   string `json:"phase" yaml:"phase"`
+	Message                 string `json:"message,omitempty" yaml:"message,omitempty"`
+	ContainerImage          string `json:"containerImage,omitempty" yaml:"containerImage,omitempty"`
+	DiskImage               string `json:"diskImage,omitempty" yaml:"diskImage,omitempty"`
+	LeaseID                 string `json:"leaseId,omitempty" yaml:"leaseId,omitempty"`
+	RegistryCredentialsFile string `json:"registryCredentialsFile,omitempty" yaml:"registryCredentialsFile,omitempty"`
+	RegistryUsername        string `json:"registryUsername,omitempty" yaml:"registryUsername,omitempty"`
+	RegistryToken           string `json:"registryToken,omitempty" yaml:"registryToken,omitempty"`
+}
+
+func (h *Handler) applyWaitFollowDefaults(cmd *cobra.Command, defaultWait bool) {
 	if cmd == nil {
 		return
+	}
+	if h.isStructuredOutput() {
+		clilog.SetQuiet(true)
 	}
 	if !cmd.Flags().Changed("wait") {
 		*h.opts.WaitForBuild = defaultWait
 	}
 	if !cmd.Flags().Changed("follow") {
-		*h.opts.FollowLogs = defaultFollow
+		*h.opts.FollowLogs = false
 	}
 }
 
@@ -347,26 +369,39 @@ func warnIfNotInList(accepted []string, field, value string) {
 // It queries the server for actual build status so that messages are only
 // shown for steps that actually succeeded.
 func (h *Handler) displayBuildResults(ctx context.Context, api *buildapiclient.Client, buildName string) {
-	labelColor := func(a ...any) string { return fmt.Sprint(a...) }
-	valueColor := func(a ...any) string { return fmt.Sprint(a...) }
-	if h.supportsColorOutput() {
-		labelColor = color.New(color.FgHiWhite, color.Bold).SprintFunc()
-		valueColor = color.New(color.FgHiGreen).SprintFunc()
-	}
-
 	st, err := api.GetBuild(ctx, buildName)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to get build results for %s: %v\n", buildName, err)
 		return
 	}
 
+	credsFile := h.handleBuildArtifacts(st)
+
+	if h.isStructuredOutput() {
+		format, _ := common.ResolveOutputFormat(h.opts.OutputFormat)
+		result := BuildResult{
+			Name:                    st.Name,
+			Phase:                   st.Phase,
+			Message:                 st.Message,
+			ContainerImage:          st.ContainerImage,
+			DiskImage:               st.DiskImage,
+			LeaseID:                 h.lastLeaseID,
+			RegistryCredentialsFile: credsFile,
+		}
+		if credsFile == "" && st.RegistryToken != "" && *h.opts.UseInternalRegistry {
+			result.RegistryUsername = "serviceaccount"
+			result.RegistryToken = st.RegistryToken
+		}
+		common.RenderFormatted(format, result, nil, h.handleError)
+		return
+	}
+
+	h.displayBuildResultsText(st, credsFile)
+}
+
+// handleBuildArtifacts performs side effects (download, creds file) and returns the creds file path.
+func (h *Handler) handleBuildArtifacts(st *buildapitypes.BuildResponse) string {
 	if *h.opts.UseInternalRegistry {
-		if st.ContainerImage != "" {
-			fmt.Printf("%s %s\n", labelColor("Container image:"), valueColor(st.ContainerImage))
-		}
-		if st.DiskImage != "" {
-			fmt.Printf("%s %s\n", labelColor("Disk image:"), valueColor(st.DiskImage))
-		}
 		if st.RegistryToken != "" {
 			if *h.opts.OutputDir != "" && st.DiskImage != "" {
 				if err := common.PullOCIArtifact(
@@ -377,32 +412,20 @@ func (h *Handler) displayBuildResults(ctx context.Context, api *buildapiclient.C
 					*h.opts.InsecureSkipTLS,
 				); err != nil {
 					h.handleError(fmt.Errorf("failed to download OCI artifact: %w", err))
-					return
+					return ""
 				}
 			} else {
 				credsFile, credsErr := common.WriteRegistryCredentialsFile(st.RegistryToken)
 				if credsErr != nil {
 					fmt.Fprintf(os.Stderr, "Warning: failed to write registry credentials file: %v\n", credsErr)
-					clilog.Infof("\n%s\n", labelColor("Registry credentials (valid ~4 hours):"))
-					clilog.Infof("  %s %s\n", labelColor("Username:"), valueColor("serviceaccount"))
-					clilog.Infof("  %s %s\n", labelColor("Token:"), valueColor(st.RegistryToken))
-				} else {
-					clilog.Infof("\n%s %s (valid ~4 hours)\n",
-						labelColor("Registry credentials written to:"),
-						valueColor(credsFile),
-					)
+					return ""
 				}
+				return credsFile
 			}
 		}
-		return
+		return ""
 	}
 
-	if st.ContainerImage != "" && *h.opts.ContainerPush != "" {
-		fmt.Printf("%s %s\n", labelColor("Container image pushed to:"), valueColor(*h.opts.ContainerPush))
-	}
-	if st.DiskImage != "" && *h.opts.ExportOCI != "" {
-		fmt.Printf("%s %s\n", labelColor("Disk image pushed to:"), valueColor(*h.opts.ExportOCI))
-	}
 	if *h.opts.OutputDir != "" && st.DiskImage != "" {
 		_, registryUsername, registryPassword := registryauth.ExtractRegistryCredentials(*h.opts.ContainerPush, *h.opts.ExportOCI)
 		if err := common.PullOCIArtifact(
@@ -413,8 +436,45 @@ func (h *Handler) displayBuildResults(ctx context.Context, api *buildapiclient.C
 			*h.opts.InsecureSkipTLS,
 		); err != nil {
 			h.handleError(fmt.Errorf("failed to download OCI artifact: %w", err))
-			return
 		}
+	}
+	return ""
+}
+
+// displayBuildResultsText prints the human-readable (table) build results.
+func (h *Handler) displayBuildResultsText(st *buildapitypes.BuildResponse, credsFile string) {
+	labelColor := func(a ...any) string { return fmt.Sprint(a...) }
+	valueColor := func(a ...any) string { return fmt.Sprint(a...) }
+	if h.supportsColorOutput() {
+		labelColor = color.New(color.FgHiWhite, color.Bold).SprintFunc()
+		valueColor = color.New(color.FgHiGreen).SprintFunc()
+	}
+
+	if *h.opts.UseInternalRegistry {
+		if st.ContainerImage != "" {
+			fmt.Printf("%s %s\n", labelColor("Container image:"), valueColor(st.ContainerImage))
+		}
+		if st.DiskImage != "" {
+			fmt.Printf("%s %s\n", labelColor("Disk image:"), valueColor(st.DiskImage))
+		}
+		if credsFile != "" {
+			clilog.Infof("\n%s %s (valid ~4 hours)\n",
+				labelColor("Registry credentials written to:"),
+				valueColor(credsFile),
+			)
+		} else if st.RegistryToken != "" && *h.opts.OutputDir == "" {
+			clilog.Infof("\n%s\n", labelColor("Registry credentials (valid ~4 hours):"))
+			clilog.Infof("  %s %s\n", labelColor("Username:"), valueColor("serviceaccount"))
+			clilog.Infof("  %s %s\n", labelColor("Token:"), valueColor(st.RegistryToken))
+		}
+		return
+	}
+
+	if st.ContainerImage != "" && *h.opts.ContainerPush != "" {
+		fmt.Printf("%s %s\n", labelColor("Container image pushed to:"), valueColor(*h.opts.ContainerPush))
+	}
+	if st.DiskImage != "" && *h.opts.ExportOCI != "" {
+		fmt.Printf("%s %s\n", labelColor("Disk image pushed to:"), valueColor(*h.opts.ExportOCI))
 	}
 }
 
@@ -458,7 +518,7 @@ func (h *Handler) applyFlashOptions(req *buildapitypes.BuildRequest, pushRequire
 }
 
 func (h *Handler) displayBuildLogsCommand(buildName string) {
-	if clilog.IsQuiet() {
+	if clilog.IsQuiet() || h.isStructuredOutput() {
 		return
 	}
 	labelColor := func(a ...any) string { return fmt.Sprint(a...) }
@@ -488,7 +548,7 @@ func (h *Handler) resolveCustomDefs() ([]string, error) {
 
 // RunBuild handles the main `caib image build` command.
 func (h *Handler) RunBuild(cmd *cobra.Command, args []string) {
-	h.applyWaitFollowDefaults(cmd, true, false)
+	h.applyWaitFollowDefaults(cmd, true)
 
 	ctx := context.Background()
 	manifestPath := args[0]
@@ -623,7 +683,7 @@ func (h *Handler) RunBuild(cmd *cobra.Command, args []string) {
 
 // RunDisk handles `caib image disk`.
 func (h *Handler) RunDisk(cmd *cobra.Command, args []string) {
-	h.applyWaitFollowDefaults(cmd, false, false)
+	h.applyWaitFollowDefaults(cmd, false)
 
 	ctx := context.Background()
 	containerRef := args[0]
@@ -727,7 +787,7 @@ func (h *Handler) RunDisk(cmd *cobra.Command, args []string) {
 
 // RunBuildDev handles `caib image build-dev` (traditional ostree/package builds).
 func (h *Handler) RunBuildDev(cmd *cobra.Command, args []string) {
-	h.applyWaitFollowDefaults(cmd, true, false)
+	h.applyWaitFollowDefaults(cmd, true)
 
 	ctx := context.Background()
 	manifestPath := args[0]

--- a/cmd/caib/buildcmd/build_result_test.go
+++ b/cmd/caib/buildcmd/build_result_test.go
@@ -1,0 +1,303 @@
+package buildcmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
+	caibcommon "github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/common"
+	buildapi "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+func strPtr(s string) *string { return &s }
+
+func TestBuildResultJSONMarshal(t *testing.T) {
+	result := BuildResult{
+		Name:                    "my-build-abc12",
+		Phase:                   "Completed",
+		Message:                 "Build completed",
+		ContainerImage:          "registry.example.com/img:v1",
+		DiskImage:               "registry.example.com/disk:v1",
+		LeaseID:                 "lease-123",
+		RegistryCredentialsFile: "/tmp/creds.json",
+	}
+
+	out, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var roundtrip map[string]any
+	if err := json.Unmarshal(out, &roundtrip); err != nil {
+		t.Fatalf("invalid JSON output: %v", err)
+	}
+
+	checks := map[string]string{
+		"name":                    "my-build-abc12",
+		"phase":                   "Completed",
+		"message":                 "Build completed",
+		"containerImage":          "registry.example.com/img:v1",
+		"diskImage":               "registry.example.com/disk:v1",
+		"leaseId":                 "lease-123",
+		"registryCredentialsFile": "/tmp/creds.json",
+	}
+	for key, want := range checks {
+		got, ok := roundtrip[key]
+		if !ok {
+			t.Errorf("missing key %q in JSON output", key)
+			continue
+		}
+		if got != want {
+			t.Errorf("key %q = %v, want %v", key, got, want)
+		}
+	}
+}
+
+func TestBuildResultOmitEmpty(t *testing.T) {
+	result := BuildResult{
+		Name:  "my-build",
+		Phase: "Pending",
+	}
+
+	out, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var roundtrip map[string]any
+	if err := json.Unmarshal(out, &roundtrip); err != nil {
+		t.Fatal(err)
+	}
+
+	omitKeys := []string{"message", "containerImage", "diskImage", "leaseId", "registryCredentialsFile", "registryUsername", "registryToken"}
+	for _, key := range omitKeys {
+		if _, ok := roundtrip[key]; ok {
+			t.Errorf("expected omitempty to exclude empty field %q", key)
+		}
+	}
+
+	if roundtrip["name"] != "my-build" {
+		t.Errorf("name = %v, want my-build", roundtrip["name"])
+	}
+	if roundtrip["phase"] != "Pending" {
+		t.Errorf("phase = %v, want Pending", roundtrip["phase"])
+	}
+}
+
+func TestIsStructuredOutput(t *testing.T) {
+	tests := []struct {
+		name   string
+		format *string
+		want   bool
+	}{
+		{"nil", nil, false},
+		{"table", strPtr("table"), false},
+		{"json", strPtr("json"), true},
+		{"yaml", strPtr("yaml"), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &Handler{opts: Options{OutputFormat: tt.format}}
+			if got := h.isStructuredOutput(); got != tt.want {
+				t.Errorf("isStructuredOutput() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyWaitFollowDefaultsStructuredOutput(t *testing.T) {
+	format := "json"
+	wait := false
+	follow := true
+
+	h := &Handler{opts: Options{
+		OutputFormat: &format,
+		WaitForBuild: &wait,
+		FollowLogs:   &follow,
+	}}
+
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("wait", false, "")
+	cmd.Flags().Bool("follow", false, "")
+
+	clilog.SetQuiet(false)
+	h.applyWaitFollowDefaults(cmd, true)
+
+	if !clilog.IsQuiet() {
+		t.Error("structured output should enable quiet mode")
+	}
+	if *h.opts.WaitForBuild != true {
+		t.Error("wait should default to true when flag not changed")
+	}
+	if *h.opts.FollowLogs != false {
+		t.Error("follow should default to false")
+	}
+
+	clilog.SetQuiet(false)
+}
+
+func TestBuildResultTokenFallback(t *testing.T) {
+	result := BuildResult{
+		Name:             "my-build",
+		Phase:            "Completed",
+		RegistryToken:    "tok-abc123",
+		RegistryUsername: "serviceaccount",
+	}
+
+	out, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var roundtrip map[string]any
+	if err := json.Unmarshal(out, &roundtrip); err != nil {
+		t.Fatal(err)
+	}
+
+	if roundtrip["registryToken"] != "tok-abc123" {
+		t.Errorf("registryToken = %v, want tok-abc123", roundtrip["registryToken"])
+	}
+	if roundtrip["registryUsername"] != "serviceaccount" {
+		t.Errorf("registryUsername = %v, want serviceaccount", roundtrip["registryUsername"])
+	}
+	if _, ok := roundtrip["registryCredentialsFile"]; ok {
+		t.Error("expected registryCredentialsFile to be omitted when empty")
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	fn()
+	_ = w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	return buf.String()
+}
+
+func TestDisplayBuildResultsTextTokenFallback(t *testing.T) {
+	useInternal := true
+	outputDir := ""
+	h := &Handler{opts: Options{
+		UseInternalRegistry: &useInternal,
+		OutputDir:           &outputDir,
+	}}
+
+	st := &buildapi.BuildResponse{
+		Name:          "test-build",
+		Phase:         "Completed",
+		RegistryToken: "secret-token-xyz",
+	}
+
+	out := captureStdout(t, func() {
+		h.displayBuildResultsText(st, "")
+	})
+
+	if !strings.Contains(out, "secret-token-xyz") {
+		t.Errorf("text fallback should print token when credsFile empty, got:\n%s", out)
+	}
+	if !strings.Contains(out, "serviceaccount") {
+		t.Errorf("text fallback should print username, got:\n%s", out)
+	}
+}
+
+func TestDisplayBuildResultsTextCredsFileSuccess(t *testing.T) {
+	useInternal := true
+	outputDir := ""
+	h := &Handler{opts: Options{
+		UseInternalRegistry: &useInternal,
+		OutputDir:           &outputDir,
+	}}
+
+	st := &buildapi.BuildResponse{
+		Name:          "test-build",
+		Phase:         "Completed",
+		RegistryToken: "secret-token-xyz",
+	}
+
+	out := captureStdout(t, func() {
+		h.displayBuildResultsText(st, "/tmp/creds.json")
+	})
+
+	if !strings.Contains(out, "/tmp/creds.json") {
+		t.Errorf("should show creds file path, got:\n%s", out)
+	}
+	if strings.Contains(out, "secret-token-xyz") {
+		t.Errorf("should NOT print raw token when creds file succeeded, got:\n%s", out)
+	}
+}
+
+func TestBuildResultYAMLKeysMatchJSON(t *testing.T) {
+	result := BuildResult{
+		Name:                    "b",
+		Phase:                   "Completed",
+		Message:                 "done",
+		ContainerImage:          "img",
+		DiskImage:               "disk",
+		LeaseID:                 "lease",
+		RegistryCredentialsFile: "/tmp/c",
+		RegistryUsername:        "user",
+		RegistryToken:           "tok",
+	}
+
+	jsonOut, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var jsonMap map[string]any
+	if err := json.Unmarshal(jsonOut, &jsonMap); err != nil {
+		t.Fatal(err)
+	}
+
+	yamlOut, err := yaml.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var yamlMap map[string]any
+	if err := yaml.Unmarshal(yamlOut, &yamlMap); err != nil {
+		t.Fatal(err)
+	}
+
+	for key := range jsonMap {
+		if _, ok := yamlMap[key]; !ok {
+			t.Errorf("JSON key %q missing from YAML output (got YAML keys: %v)", key, yamlMap)
+		}
+	}
+	for key := range yamlMap {
+		if _, ok := jsonMap[key]; !ok {
+			t.Errorf("YAML key %q missing from JSON output", key)
+		}
+	}
+}
+
+func TestBuildResultRenderFormatted(t *testing.T) {
+	result := BuildResult{
+		Name:  "test-build",
+		Phase: "Completed",
+	}
+
+	var gotErr error
+	handleErr := func(err error) { gotErr = err }
+
+	caibcommon.RenderFormatted("json", result, nil, handleErr)
+	if gotErr != nil {
+		t.Fatalf("RenderFormatted(json) error: %v", gotErr)
+	}
+
+	caibcommon.RenderFormatted("yaml", result, nil, handleErr)
+	if gotErr != nil {
+		t.Fatalf("RenderFormatted(yaml) error: %v", gotErr)
+	}
+}

--- a/cmd/caib/buildcmd/logs.go
+++ b/cmd/caib/buildcmd/logs.go
@@ -104,6 +104,7 @@ func (h *Handler) waitForBuildCompletion(ctx context.Context, api *buildapiclien
 				} else if streamState.LeaseID != "" {
 					leaseID = streamState.LeaseID
 				}
+				h.lastLeaseID = leaseID
 				if leaseID != "" && h.opts.Workspace != nil && *h.opts.Workspace != "" {
 					leaseCtx, cancelLease := context.WithTimeout(ctx, 10*time.Second)
 					leaseErr := api.SetWorkspaceLease(leaseCtx, *h.opts.Workspace, leaseID)
@@ -113,7 +114,7 @@ func (h *Handler) waitForBuildCompletion(ctx context.Context, api *buildapiclien
 					}
 				}
 
-				if !clilog.IsQuiet() {
+				if !clilog.IsQuiet() && !h.isStructuredOutput() {
 					if flashWasExecuted {
 						h.displayFlashCompletionBanner(leaseID)
 					} else {

--- a/cmd/caib/common/output.go
+++ b/cmd/caib/common/output.go
@@ -1,0 +1,66 @@
+package caibcommon
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// OutputFormatTable is the default table-formatted output mode.
+	OutputFormatTable = "table"
+	outputFormatJSON  = "json"
+	outputFormatYAML  = "yaml"
+	outputFormatYML   = "yml"
+)
+
+// ResolveOutputFormat normalises and validates a format flag value.
+func ResolveOutputFormat(format *string) (string, error) {
+	f := OutputFormatTable
+	if format != nil && strings.TrimSpace(*format) != "" {
+		f = strings.ToLower(strings.TrimSpace(*format))
+	}
+	switch f {
+	case OutputFormatTable, outputFormatJSON, outputFormatYAML, outputFormatYML:
+		return f, nil
+	default:
+		return "", fmt.Errorf("invalid output format %q (supported: table, json, yaml)", f)
+	}
+}
+
+// IsStructuredFormat returns true for json/yaml output formats.
+func IsStructuredFormat(format *string) bool {
+	f, err := ResolveOutputFormat(format)
+	if err != nil {
+		return false
+	}
+	return f != OutputFormatTable
+}
+
+// RenderFormatted outputs data as JSON, YAML, or via the tablePrinter callback.
+func RenderFormatted(format string, data any, tablePrinter func() error, handleError func(error)) {
+	switch format {
+	case outputFormatJSON:
+		out, marshalErr := json.MarshalIndent(data, "", "  ")
+		if marshalErr != nil {
+			handleError(fmt.Errorf("error rendering JSON output: %w", marshalErr))
+			return
+		}
+		fmt.Println(string(out))
+	case outputFormatYAML, outputFormatYML:
+		out, marshalErr := yaml.Marshal(data)
+		if marshalErr != nil {
+			handleError(fmt.Errorf("error rendering YAML output: %w", marshalErr))
+			return
+		}
+		fmt.Print(string(out))
+	case OutputFormatTable:
+		if err := tablePrinter(); err != nil {
+			handleError(fmt.Errorf("error writing table output: %w", err))
+		}
+	default:
+		handleError(fmt.Errorf("invalid output format %q (supported: table, json, yaml)", format))
+	}
+}

--- a/cmd/caib/common/output_test.go
+++ b/cmd/caib/common/output_test.go
@@ -1,0 +1,104 @@
+package caibcommon
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func ptr(s string) *string { return &s }
+
+func TestResolveOutputFormat(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   *string
+		want    string
+		wantErr bool
+	}{
+		{"nil defaults to table", nil, OutputFormatTable, false},
+		{"empty defaults to table", ptr(""), OutputFormatTable, false},
+		{"table", ptr("table"), OutputFormatTable, false},
+		{"json", ptr("json"), "json", false},
+		{"JSON uppercase", ptr("JSON"), "json", false},
+		{"yaml", ptr("yaml"), "yaml", false},
+		{"yml", ptr("yml"), "yml", false},
+		{"invalid format", ptr("csv"), "", true},
+		{"whitespace trimmed", ptr("  json  "), "json", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveOutputFormat(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ResolveOutputFormat() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("ResolveOutputFormat() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsStructuredFormat(t *testing.T) {
+	tests := []struct {
+		name  string
+		input *string
+		want  bool
+	}{
+		{"nil is not structured", nil, false},
+		{"table is not structured", ptr("table"), false},
+		{"json is structured", ptr("json"), true},
+		{"yaml is structured", ptr("yaml"), true},
+		{"yml is structured", ptr("yml"), true},
+		{"invalid falls back to false", ptr("csv"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsStructuredFormat(tt.input); got != tt.want {
+				t.Errorf("IsStructuredFormat() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderFormattedJSON(t *testing.T) {
+	type testData struct {
+		Name  string `json:"name"`
+		Value string `json:"value,omitempty"`
+	}
+
+	var gotErr error
+	handleErr := func(err error) { gotErr = err }
+
+	t.Run("json renders valid JSON", func(t *testing.T) {
+		gotErr = nil
+		data := testData{Name: "test", Value: "val"}
+
+		// RenderFormatted writes to stdout; just verify no error
+		RenderFormatted("json", data, nil, handleErr)
+		if gotErr != nil {
+			t.Fatalf("unexpected error: %v", gotErr)
+		}
+	})
+
+	t.Run("json omitempty works", func(t *testing.T) {
+		data := testData{Name: "test"}
+		out, err := json.MarshalIndent(data, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		var roundtrip map[string]any
+		if err := json.Unmarshal(out, &roundtrip); err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := roundtrip["value"]; ok {
+			t.Error("expected omitempty to exclude empty value field")
+		}
+	})
+
+	t.Run("invalid format calls handleError", func(t *testing.T) {
+		gotErr = nil
+		RenderFormatted("csv", nil, nil, handleErr)
+		if gotErr == nil {
+			t.Error("expected error for invalid format")
+		}
+	})
+}

--- a/cmd/caib/querycmd/query.go
+++ b/cmd/caib/querycmd/query.go
@@ -3,7 +3,6 @@ package querycmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -14,10 +13,7 @@ import (
 	buildapitypes "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi"
 	buildapiclient "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi/client"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
-
-const outputFormatTable = "table"
 
 // Options wires query handlers to caller-owned state and helper callbacks.
 type Options struct {
@@ -47,20 +43,8 @@ func (h *Handler) handleError(err error) {
 	panic(err)
 }
 
-// resolveOutputFormat normalises and validates the configured output format.
-// It returns the canonical lowercase format string or an error for unsupported values.
 func (h *Handler) resolveOutputFormat() (string, error) {
-	format := outputFormatTable
-	if h.opts.OutputFormat != nil && strings.TrimSpace(*h.opts.OutputFormat) != "" {
-		format = strings.ToLower(strings.TrimSpace(*h.opts.OutputFormat))
-	}
-
-	switch format {
-	case outputFormatTable, "json", "yaml", "yml":
-		return format, nil
-	default:
-		return "", fmt.Errorf("invalid output format %q (supported: table, json, yaml)", format)
-	}
+	return common.ResolveOutputFormat(h.opts.OutputFormat)
 }
 
 // RunList handles `caib image list`.
@@ -174,30 +158,8 @@ func (h *Handler) renderShow(format string, st *buildapitypes.BuildResponse) {
 	h.renderFormatted(format, st, func() error { return printBuildDetails(st) })
 }
 
-// renderFormatted outputs data in the given format, using tablePrinter for table output.
 func (h *Handler) renderFormatted(format string, data any, tablePrinter func() error) {
-	switch format {
-	case "json":
-		out, marshalErr := json.MarshalIndent(data, "", "  ")
-		if marshalErr != nil {
-			h.handleError(fmt.Errorf("error rendering JSON output: %w", marshalErr))
-			return
-		}
-		fmt.Println(string(out))
-	case "yaml", "yml":
-		out, marshalErr := yaml.Marshal(data)
-		if marshalErr != nil {
-			h.handleError(fmt.Errorf("error rendering YAML output: %w", marshalErr))
-			return
-		}
-		fmt.Print(string(out))
-	case outputFormatTable:
-		if err := tablePrinter(); err != nil {
-			h.handleError(fmt.Errorf("error writing table output: %w", err))
-		}
-	default:
-		h.handleError(fmt.Errorf("invalid output format %q (supported: table, json, yaml)", format))
-	}
+	common.RenderFormatted(format, data, tablePrinter, h.handleError)
 }
 
 func buildParametersFromTemplate(tpl *buildapitypes.BuildTemplateResponse) *buildapitypes.BuildParameters {

--- a/cmd/caib/runtime_wiring.go
+++ b/cmd/caib/runtime_wiring.go
@@ -198,6 +198,7 @@ func (s runtimeState) newHandlers() handlerSet {
 			RestoreSourcesRef:         s.RestoreSourcesRef,
 			TTL:                       s.TTL,
 			InsecureSkipTLS:           s.InsecureSkipTLS,
+			OutputFormat:              s.OutputFormat,
 			HandleError:               handleError,
 		}),
 		query: querycmd.NewHandler(querycmd.Options{


### PR DESCRIPTION
```
$ bin/caib image build-dev simple.aib.yml \
        --format simg \
        --internal-registry \
        --target ebbr \
         -n benny-rcar --output-format json --wait=false
{
  "name": "benny-rcar-b4110",
  "phase": "Building",
  "message": "Build started"
}
```
## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [X] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured build results output in **JSON/YAML** alongside existing table/text output.
  * Introduced a shared renderer for formatted output across supported commands.
* **Bug Fixes**
  * Fixed the output-format flag so it now correctly affects **build commands**.
  * Structured output now suppresses certain “completion” messages for cleaner machine-readable output.
* **Refactor**
  * Centralized output-format normalization/validation and rendering logic.
  * Streamlined build result rendering and internal-registry artifact/credential handling for consistent output.
* **Tests**
  * Added unit tests for structured formatting, serialization, and shared renderer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->