### PR TITLE
fix: update ci e2e smoke timeout

### DIFF
--- a/.github/workflows/e2e-lanes.yml
+++ b/.github/workflows/e2e-lanes.yml
@@ -145,7 +145,7 @@ jobs:
           E2E_NAMESPACE: ${{ needs.parse-comment.outputs.lane_name == 'all' && 'e2e-test-all' || format('e2e-{0}', needs.parse-comment.outputs.lane_name) }}
         run: |
           case "${{ needs.parse-comment.outputs.lane_name }}" in
-            smoke|operator|auth|features) test_timeout=5m ;;
+            smoke|operator|auth|features) test_timeout=10m ;;
             bootc|package-mode) test_timeout=15m ;;
             container-build|all) test_timeout=45m ;;
             *)                   echo "Unknown lane: ${{ needs.parse-comment.outputs.lane_name }}" >&2; exit 1 ;;

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -71,7 +71,7 @@ jobs:
             test_timeout=45m
           else
             case "$E2E_LABEL_FILTER" in
-              smoke|operator|auth|features) test_timeout=5m ;;
+              smoke|operator|auth|features) test_timeout=10m ;;
               bootc|package-mode) test_timeout=15m ;;
               container-build)     test_timeout=45m ;;
               *)                   test_timeout=45m ;;

--- a/Makefile.e2e
+++ b/Makefile.e2e
@@ -15,7 +15,7 @@
 ################################################################################
 
 # Ginkgo timeouts — keep in sync with .github/workflows/e2e.yml and e2e-lanes.yml
-E2E_TIMEOUT_FAST  ?= 5m   # smoke, operator, auth, features
+E2E_TIMEOUT_FAST  ?= 10m   # smoke, operator, auth, features
 E2E_TIMEOUT_SHORT ?= 15m  # bootc, package-mode
 E2E_TIMEOUT_LONG  ?= 45m  # full suite
 


### PR DESCRIPTION
## Summary

Fix CI smoke test timeout due to failure on `AfterSuite`
```
[AfterSuite] 
/home/runner/work/automotive-dev-operator/automotive-dev-operator/test/e2e/e2e_suite_test.go:47
  STEP: removing test namespace @ 06/23/26 13:06:51.979
  running: kubectl delete ns e2e-smoke --ignore-not-found=true --timeout=60s
panic: test timed out after 5m0s
	running tests:
		TestE2E (5m0s)
```


https://github.com/centos-automotive-suite/automotive-dev-operator/pull/324/checks

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)
