### PR TITLE
feat: support AIB's new --root-password

### DIFF
--- a/api/v1alpha1/imagebuild_types.go
+++ b/api/v1alpha1/imagebuild_types.go
@@ -203,6 +203,10 @@ type AIBSpec struct {
 
 	// AIBExtraArgs are extra arguments to pass to automotive-image-builder
 	AIBExtraArgs []string `json:"aibExtraArgs,omitempty"`
+
+	// RootPassword is a hashed root password passed to AIB's --root-password flag.
+	// See crypt(5) for supported hash formats.
+	RootPassword string `json:"rootPassword,omitempty"`
 }
 
 // ExportSpec defines the configuration for exporting build artifacts
@@ -417,6 +421,14 @@ func (s *ImageBuildSpec) GetAIBExtraArgs() []string {
 		return s.AIB.AIBExtraArgs
 	}
 	return nil
+}
+
+// GetRootPassword returns the root password value from AIB spec
+func (s *ImageBuildSpec) GetRootPassword() string {
+	if s.AIB != nil {
+		return s.AIB.RootPassword
+	}
+	return ""
 }
 
 // GetExportFormat returns the export format, or "qcow2" as default

--- a/api/v1alpha1/imagebuild_types_test.go
+++ b/api/v1alpha1/imagebuild_types_test.go
@@ -238,3 +238,42 @@ func TestGetAIBExtraArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestGetRootPassword(t *testing.T) {
+	tests := []struct {
+		name string
+		spec ImageBuildSpec
+		want string
+	}{
+		{
+			name: "returns root password when set",
+			spec: ImageBuildSpec{
+				AIB: &AIBSpec{
+					RootPassword: "$6$salt$hashvalue",
+				},
+			},
+			want: "$6$salt$hashvalue",
+		},
+		{
+			name: "returns empty when AIB is nil",
+			spec: ImageBuildSpec{},
+			want: "",
+		},
+		{
+			name: "returns empty when root password is empty",
+			spec: ImageBuildSpec{
+				AIB: &AIBSpec{},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.spec.GetRootPassword()
+			if got != tt.want {
+				t.Errorf("GetRootPassword() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/caib/buildcmd/build.go
+++ b/cmd/caib/buildcmd/build.go
@@ -56,6 +56,7 @@ type Options struct {
 	CustomDefs             *[]string
 	DefineFiles            *[]string
 	AIBExtraArgs           *[]string
+	RootPassword           *string
 	ExtraRepos             *[]string
 	Workspace              *string
 	FollowLogs             *bool
@@ -551,6 +552,40 @@ func (h *Handler) resolveCustomDefs() ([]string, error) {
 	return defs, nil
 }
 
+func parseRootPassword(input string) (string, error) {
+	if input == "" {
+		return "", fmt.Errorf("root password value cannot be empty, must be env:VAR or file:PATH")
+	}
+	parts := strings.SplitN(input, ":", 2)
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid root password format %q, must be env:VAR or file:PATH", input)
+	}
+	prefix, value := parts[0], parts[1]
+	switch prefix {
+	case "env":
+		v, ok := os.LookupEnv(value)
+		if !ok {
+			return "", fmt.Errorf("environment variable %q not set", value)
+		}
+		return v, nil
+	case "file":
+		data, err := os.ReadFile(value)
+		if err != nil {
+			return "", fmt.Errorf("reading root password file: %w", err)
+		}
+		return strings.TrimSpace(string(data)), nil
+	default:
+		return "", fmt.Errorf("unknown root password prefix %q, must be env or file", prefix)
+	}
+}
+
+func (h *Handler) resolveRootPassword() (string, error) {
+	if h.opts.RootPassword == nil || *h.opts.RootPassword == "" {
+		return "", nil
+	}
+	return parseRootPassword(*h.opts.RootPassword)
+}
+
 // RunBuild handles the main `caib image build` command.
 func (h *Handler) RunBuild(cmd *cobra.Command, args []string) {
 	h.applyWaitFollowDefaults(cmd, true)
@@ -615,6 +650,12 @@ func (h *Handler) RunBuild(cmd *cobra.Command, args []string) {
 		return
 	}
 
+	rootPassword, err := h.resolveRootPassword()
+	if err != nil {
+		h.handleError(err)
+		return
+	}
+
 	req := buildapitypes.BuildRequest{
 		Name:                   *h.opts.BuildName,
 		Manifest:               string(manifestBytes),
@@ -628,6 +669,7 @@ func (h *Handler) RunBuild(cmd *cobra.Command, args []string) {
 		StorageClass:           *h.opts.StorageClass,
 		CustomDefs:             customDefs,
 		AIBExtraArgs:           *h.opts.AIBExtraArgs,
+		RootPassword:           rootPassword,
 		ExtraRepos:             *h.opts.ExtraRepos,
 		Workspace:              *h.opts.Workspace,
 		Compression:            buildapitypes.Compression(*h.opts.CompressionAlgo),
@@ -873,6 +915,12 @@ func (h *Handler) RunBuildDev(cmd *cobra.Command, args []string) {
 		return
 	}
 
+	rootPassword, err := h.resolveRootPassword()
+	if err != nil {
+		h.handleError(err)
+		return
+	}
+
 	var parsedMode buildapitypes.Mode
 	switch *h.opts.Mode {
 	case "image":
@@ -902,6 +950,7 @@ func (h *Handler) RunBuildDev(cmd *cobra.Command, args []string) {
 		StorageClass:           *h.opts.StorageClass,
 		CustomDefs:             customDefs,
 		AIBExtraArgs:           *h.opts.AIBExtraArgs,
+		RootPassword:           rootPassword,
 		ExtraRepos:             *h.opts.ExtraRepos,
 		Workspace:              *h.opts.Workspace,
 		Compression:            buildapitypes.Compression(*h.opts.CompressionAlgo),

--- a/cmd/caib/buildcmd/build_disk_test.go
+++ b/cmd/caib/buildcmd/build_disk_test.go
@@ -26,6 +26,7 @@ func newTestDiskOpts() Options {
 		timeout              = 60
 		waitForBuild         bool
 		customDefs           []string
+		rootPassword         string
 		aibExtraArgs         []string
 		followLogs           bool
 		compressionAlgo      = "gzip"
@@ -70,6 +71,7 @@ func newTestDiskOpts() Options {
 		WaitForBuild:              &waitForBuild,
 		CustomDefs:                &customDefs,
 		DefineFiles:               &defineFiles,
+		RootPassword:              &rootPassword,
 		AIBExtraArgs:              &aibExtraArgs,
 		FollowLogs:                &followLogs,
 		CompressionAlgo:           &compressionAlgo,

--- a/cmd/caib/buildcmd/build_rootpw_test.go
+++ b/cmd/caib/buildcmd/build_rootpw_test.go
@@ -1,0 +1,95 @@
+package buildcmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseRootPassword(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		envVars map[string]string
+		files   map[string]string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "env prefix resolves environment variable",
+			input: "env:ROOT_PW_HASH",
+			envVars: map[string]string{
+				"ROOT_PW_HASH": "$6$salt$hashvalue",
+			},
+			want: "$6$salt$hashvalue",
+		},
+		{
+			name:    "env prefix with missing variable returns error",
+			input:   "env:NONEXISTENT_VAR",
+			wantErr: true,
+		},
+		{
+			name:  "file prefix reads from file",
+			input: "file:PLACEHOLDER",
+			files: map[string]string{
+				"root-pw.txt": "$6$rounds=5000$salt$longhashvalue\n",
+			},
+			want: "$6$rounds=5000$salt$longhashvalue",
+		},
+		{
+			name:    "file prefix with missing file returns error",
+			input:   "file:/nonexistent/path/to/file",
+			wantErr: true,
+		},
+		{
+			name:    "no prefix returns error",
+			input:   "$6$salt$hashvalue",
+			wantErr: true,
+		},
+		{
+			name:    "empty string returns error",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "unknown prefix returns error",
+			input:   "secret:my-secret",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.envVars {
+				t.Setenv(k, v)
+			}
+
+			if len(tt.files) > 0 {
+				dir := t.TempDir()
+				for name, content := range tt.files {
+					path := filepath.Join(dir, name)
+					if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+						t.Fatal(err)
+					}
+					if tt.input == "file:PLACEHOLDER" {
+						tt.input = "file:" + path
+					}
+				}
+			}
+
+			got, err := parseRootPassword(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/caib/image/image.go
+++ b/cmd/caib/image/image.go
@@ -46,6 +46,7 @@ type Options struct {
 	CustomDefs             *[]string
 	DefineFiles            *[]string
 	AIBExtraArgs           *[]string
+	RootPassword           *string
 	ExtraRepos             *[]string
 	Workspace              *string
 	FollowLogs             *bool
@@ -151,6 +152,7 @@ func NewImageCmd(opts Options) *cobra.Command {
 	buildCmd.Flags().StringArrayVarP(opts.CustomDefs, "define", "D", []string{}, "custom definition KEY=VALUE")
 	buildCmd.Flags().StringArrayVar(opts.DefineFiles, "define-file", []string{}, "load defines from YAML dictionary file (can be repeated)")
 	buildCmd.Flags().StringArrayVar(opts.AIBExtraArgs, "extra-args", []string{}, "extra arguments to pass to AIB (can be repeated)")
+	buildCmd.Flags().StringVar(opts.RootPassword, "root-password", "", "set hashed root password (env:VAR or file:PATH)")
 	buildCmd.Flags().StringArrayVar(opts.ExtraRepos, "extra-repo", []string{}, "serve RPMs from workspace as extra repo (workspace:path, can be repeated)")
 	buildCmd.Flags().StringVar(opts.Workspace, "workspace", "", "workspace name for build caching and lease forwarding")
 	buildCmd.Flags().IntVar(opts.Timeout, "timeout", 60, "timeout in minutes")
@@ -261,6 +263,7 @@ func NewImageCmd(opts Options) *cobra.Command {
 	buildDevCmd.Flags().StringArrayVarP(opts.CustomDefs, "define", "D", []string{}, "custom definition KEY=VALUE")
 	buildDevCmd.Flags().StringArrayVar(opts.DefineFiles, "define-file", []string{}, "load defines from YAML dictionary file (can be repeated)")
 	buildDevCmd.Flags().StringArrayVar(opts.AIBExtraArgs, "extra-args", []string{}, "extra arguments to pass to AIB (can be repeated)")
+	buildDevCmd.Flags().StringVar(opts.RootPassword, "root-password", "", "set hashed root password (env:VAR or file:PATH)")
 	buildDevCmd.Flags().StringArrayVar(opts.ExtraRepos, "extra-repo", []string{}, "serve RPMs from workspace as extra repo (workspace:path, can be repeated)")
 	buildDevCmd.Flags().StringVar(opts.Workspace, "workspace", "", "workspace name for build caching and lease forwarding")
 	buildDevCmd.Flags().IntVar(opts.Timeout, "timeout", 60, "timeout in minutes")

--- a/cmd/caib/main.go
+++ b/cmd/caib/main.go
@@ -31,6 +31,7 @@ var (
 	customDefs             []string
 	defineFiles            []string
 	aibExtraArgs           []string
+	rootPassword           string
 	extraRepos             []string
 	workspaceName          string
 	followLogs             bool

--- a/cmd/caib/runtime_wiring.go
+++ b/cmd/caib/runtime_wiring.go
@@ -29,6 +29,7 @@ type runtimeState struct {
 	CustomDefs             *[]string
 	DefineFiles            *[]string
 	AIBExtraArgs           *[]string
+	RootPassword           *string
 	ExtraRepos             *[]string
 	Workspace              *string
 	FollowLogs             *bool
@@ -95,6 +96,7 @@ func newRuntimeState() runtimeState {
 		CustomDefs:             &customDefs,
 		DefineFiles:            &defineFiles,
 		AIBExtraArgs:           &aibExtraArgs,
+		RootPassword:           &rootPassword,
 		ExtraRepos:             &extraRepos,
 		Workspace:              &workspaceName,
 		FollowLogs:             &followLogs,
@@ -172,6 +174,7 @@ func (s runtimeState) newHandlers() handlerSet {
 			CustomDefs:                s.CustomDefs,
 			DefineFiles:               s.DefineFiles,
 			AIBExtraArgs:              s.AIBExtraArgs,
+			RootPassword:              s.RootPassword,
 			ExtraRepos:                s.ExtraRepos,
 			Workspace:                 s.Workspace,
 			FollowLogs:                s.FollowLogs,
@@ -307,6 +310,7 @@ func (s runtimeState) imageOptions(h handlerSet) image.Options {
 		CustomDefs:             s.CustomDefs,
 		DefineFiles:            s.DefineFiles,
 		AIBExtraArgs:           s.AIBExtraArgs,
+		RootPassword:           s.RootPassword,
 		ExtraRepos:             s.ExtraRepos,
 		Workspace:              s.Workspace,
 		FollowLogs:             s.FollowLogs,

--- a/config/crd/bases/automotive.sdv.cloud.redhat.com_imagebuilds.yaml
+++ b/config/crd/bases/automotive.sdv.cloud.redhat.com_imagebuilds.yaml
@@ -98,6 +98,11 @@ spec:
                     description: RebuildBuilder forces rebuilding the bootc builder
                       image even if a cached version exists in the registry.
                     type: boolean
+                  rootPassword:
+                    description: |-
+                      RootPassword is a hashed root password passed to AIB's --root-password flag.
+                      See crypt(5) for supported hash formats.
+                    type: string
                   target:
                     description: Target specifies the build target platform (e.g.,
                       "qemu", "aws")

--- a/internal/buildapi/build_aib_spec_test.go
+++ b/internal/buildapi/build_aib_spec_test.go
@@ -22,6 +22,7 @@ func TestBuildAIBSpec(t *testing.T) {
 		wantContainerRef string
 		wantCustomDefs   []string
 		wantExtraArgs    []string
+		wantRootPassword string
 	}{
 		{
 			name: "basic build spec",
@@ -79,6 +80,23 @@ func TestBuildAIBSpec(t *testing.T) {
 			wantImage:        "quay.io/centos-sig-automotive/aib:v1",
 			wantBuilderImage: "quay.io/myorg/builder:latest",
 			wantInputFiles:   true,
+		},
+		{
+			name: "with root password",
+			req: &BuildRequest{
+				Distro:       "autosd",
+				Target:       "qemu",
+				Mode:         ModeBootc,
+				RootPassword: "$6$salt$hashvalue",
+			},
+			manifest:         "name: root-pw\n",
+			manifestFileName: "root-pw.aib.yml",
+			wantDistro:       "autosd",
+			wantTarget:       "qemu",
+			wantMode:         "bootc",
+			wantManifest:     "name: root-pw\n",
+			wantFileName:     "root-pw.aib.yml",
+			wantRootPassword: "$6$salt$hashvalue",
 		},
 		{
 			name: "empty manifest filename",
@@ -139,6 +157,10 @@ func TestBuildAIBSpec(t *testing.T) {
 						}
 					}
 				}
+			}
+
+			if got.RootPassword != tt.wantRootPassword {
+				t.Errorf("RootPassword = %q, want %q", got.RootPassword, tt.wantRootPassword)
 			}
 
 			// Check extra args

--- a/internal/buildapi/build_spec.go
+++ b/internal/buildapi/build_spec.go
@@ -18,6 +18,7 @@ func buildAIBSpec(req *BuildRequest, manifest, manifestFileName string, inputFil
 		ContainerRef:     req.ContainerRef,
 		CustomDefs:       req.CustomDefs,
 		AIBExtraArgs:     req.AIBExtraArgs,
+		RootPassword:     req.RootPassword,
 	}
 }
 

--- a/internal/buildapi/types.go
+++ b/internal/buildapi/types.go
@@ -166,6 +166,7 @@ type BuildRequest struct {
 	StorageClass           string               `json:"storageClass"`
 	CustomDefs             []string             `json:"customDefs"`
 	AIBExtraArgs           []string             `json:"aibExtraArgs"`
+	RootPassword           string               `json:"rootPassword,omitempty"`
 	ExtraRepos             []string             `json:"extraRepos,omitempty"` // workspace-name:/path pairs
 	Workspace              string               `json:"workspace,omitempty"`  // workspace name for build caching and lease forwarding
 	Compression            Compression          `json:"compression,omitempty"`

--- a/internal/common/tasks/scripts/build_image.sh
+++ b/internal/common/tasks/scripts/build_image.sh
@@ -222,6 +222,14 @@ else
   echo "No AIB extra args file found"
 fi
 
+# Load root password
+declare -a ROOT_PASSWORD_ARGS=()
+ROOT_PASSWORD_FILE="$(workspaces.manifest-config-workspace.path)/root-password.txt"
+if [ -f "$ROOT_PASSWORD_FILE" ] && [ -s "$ROOT_PASSWORD_FILE" ]; then
+  ROOT_PASSWORD_ARGS=("--root-password" "file:${ROOT_PASSWORD_FILE}")
+  echo "Root password override configured"
+fi
+
 arch="$(params.target-architecture)"
 case "$arch" in
   "arm64")
@@ -437,6 +445,7 @@ case "$BUILD_MODE" in
           "${BUILD_CONTAINER_ARGS[@]}"
           "${CUSTOM_DEFS_ARGS[@]}"
           "${AIB_EXTRA_ARGS[@]}"
+          "${ROOT_PASSWORD_ARGS[@]}"
           "$MANIFEST_FILE"
           "$BOOTC_CONTAINER_NAME"
         )
@@ -456,6 +465,7 @@ case "$BUILD_MODE" in
           "${BUILD_CONTAINER_ARGS[@]}"
           "${CUSTOM_DEFS_ARGS[@]}"
           "${AIB_EXTRA_ARGS[@]}"
+          "${ROOT_PASSWORD_ARGS[@]}"
           "$MANIFEST_FILE"
           "$BOOTC_CONTAINER_NAME"
           "${DISK_OUTPUT_ARGS[@]}"
@@ -585,6 +595,7 @@ PYEOF
         "${FORMAT_ARGS[@]}"
         "${COMMON_BUILD_ARGS[@]}"
         "${AIB_EXTRA_ARGS[@]}"
+        "${ROOT_PASSWORD_ARGS[@]}"
         "$MANIFEST_FILE"
         "/output/${exportFile}"
       )

--- a/internal/controller/imagebuild/controller.go
+++ b/internal/controller/imagebuild/controller.go
@@ -1566,6 +1566,9 @@ func (r *ImageBuildReconciler) createOrUpdateManifestConfigMap(
 		if extraArgs := imageBuild.Spec.GetAIBExtraArgs(); len(extraArgs) > 0 {
 			cm.Data["aib-extra-args.txt"] = strings.Join(extraArgs, "\n")
 		}
+		if rootPw := imageBuild.Spec.GetRootPassword(); rootPw != "" {
+			cm.Data["root-password.txt"] = rootPw
+		}
 
 		return controllerutil.SetControllerReference(imageBuild, cm, r.Scheme)
 	})


### PR DESCRIPTION

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [X] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for providing a root password during image builds.
  * You can now set the value directly in build requests or via the new CLI option, including `env:` and `file:` input forms.

* **Bug Fixes**
  * Root password values are now carried through consistently from the controller to the build process.
  * Build behavior remains unchanged when no root password is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->