### PR TITLE
fix: build images on tag push before retagging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,6 @@ env:
 jobs:
     build-operator-arm64:
         runs-on: ubuntu-24.04-arm
-        if: startsWith(github.ref, 'refs/heads/main') || startsWith(github.ref, 'refs/heads/release-')
         steps:
             - uses: actions/checkout@v7
 
@@ -65,7 +64,6 @@ jobs:
 
     build-operator-amd64:
         runs-on: ubuntu-latest
-        if: startsWith(github.ref, 'refs/heads/main') || startsWith(github.ref, 'refs/heads/release-')
         steps:
             - uses: actions/checkout@v7
 
@@ -108,7 +106,6 @@ jobs:
     create-multiarch-manifest:
         needs: [build-operator-arm64, build-operator-amd64]
         runs-on: ubuntu-latest
-        if: startsWith(github.ref, 'refs/heads/main') || startsWith(github.ref, 'refs/heads/release-')
         steps:
             - uses: actions/checkout@v7
 
@@ -140,7 +137,6 @@ jobs:
 
     build-tekton-bundle:
         runs-on: ubuntu-latest
-        if: startsWith(github.ref, 'refs/heads/main') || startsWith(github.ref, 'refs/heads/release-')
         steps:
             - uses: actions/checkout@v7
 
@@ -176,6 +172,7 @@ jobs:
                   tkn bundle push "${{ env.TEKTON_BUNDLE_IMAGE }}:latest" "${bundle_args[@]}"
 
     retag-on-release:
+        needs: [create-multiarch-manifest, build-tekton-bundle]
         runs-on: ubuntu-latest
         if: startsWith(github.ref, 'refs/tags/')
         outputs:
@@ -208,7 +205,6 @@ jobs:
               env:
                   TAG_NAME: ${{ github.ref_name }}
               run: |
-                  # Alias the existing multi-arch manifests built on main (by sha) to the git tag
                   docker buildx imagetools create -t "${{ env.OPERATOR_IMAGE }}:${TAG_NAME}" "${{ env.OPERATOR_IMAGE }}:${{ env.VERSION }}"
 
             - name: Create tag alias for toolchain

--- a/Makefile
+++ b/Makefile
@@ -361,7 +361,13 @@ catalog-update: opm ## Generate catalog configuration for current version
 		echo "entries:"; \
 		echo "  - name: automotive-dev-operator.v$(VERSION)"; \
 		echo "---"; \
-		$(OPM) render $(BUNDLE_IMG); \
+		rendered=$$( \
+			if $(OPM) render $(BUNDLE_IMG) -o yaml 2>/dev/null; then true; \
+			else \
+				echo "Note: Bundle image not available remotely, rendering from local bundle/ directory" >&2; \
+				$(OPM) render bundle/ -o yaml | sed 's|^image: ""|image: $(BUNDLE_IMG)|'; \
+			fi \
+		) && echo "$$rendered" | tail -n +2; \
 	} > catalog/automotive-dev-operator.yaml
 	@# Add openshift-pipelines dependency (opm render doesn't include it)
 	@awk '\


### PR DESCRIPTION
## Summary
- Build jobs (operator, toolchain, tekton bundle) now run on all pushes (branches + tags), not just branches
- `retag-on-release` uses `needs` to wait for builds to complete, eliminating the race condition where retag ran before images existed
- `catalog-update` Makefile target falls back to local `bundle/` directory when the remote bundle image isn't pushed yet

## Context
The v0.2.0 tag push triggered `retag-on-release` before the branch-triggered build had pushed the SHA-tagged images, causing the release CI to fail.
