### PR TITLE
fix: build images on tag push before retagging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,6 @@ env:
 jobs:
     build-operator-arm64:
         runs-on: ubuntu-24.04-arm
-        if: startsWith(github.ref, 'refs/heads/main') || startsWith(github.ref, 'refs/heads/release-')
         steps:
             - uses: actions/checkout@v7
 
@@ -65,7 +64,6 @@ jobs:
 
     build-operator-amd64:
         runs-on: ubuntu-latest
-        if: startsWith(github.ref, 'refs/heads/main') || startsWith(github.ref, 'refs/heads/release-')
         steps:
             - uses: actions/checkout@v7
 
@@ -108,7 +106,6 @@ jobs:
     create-multiarch-manifest:
         needs: [build-operator-arm64, build-operator-amd64]
         runs-on: ubuntu-latest
-        if: startsWith(github.ref, 'refs/heads/main') || startsWith(github.ref, 'refs/heads/release-')
         steps:
             - uses: actions/checkout@v7
 
@@ -140,7 +137,6 @@ jobs:
 
     build-tekton-bundle:
         runs-on: ubuntu-latest
-        if: startsWith(github.ref, 'refs/heads/main') || startsWith(github.ref, 'refs/heads/release-')
         steps:
             - uses: actions/checkout@v7
 
@@ -176,6 +172,7 @@ jobs:
                   tkn bundle push "${{ env.TEKTON_BUNDLE_IMAGE }}:latest" "${bundle_args[@]}"
 
     retag-on-release:
+        needs: [create-multiarch-manifest, build-tekton-bundle]
         runs-on: ubuntu-latest
         if: startsWith(github.ref, 'refs/tags/')
         outputs:

--- a/Makefile
+++ b/Makefile
@@ -346,6 +346,10 @@ catalog-deploy: ## Build and deploy the catalog to OpenShift OperatorHub
 	./deploy-catalog.sh
 
 .PHONY: catalog-update
+# Fallback: when bundle image isn't pushed yet, render from local bundle/ dir.
+# opm emits image: "" for local dirs (no registry ref), so sed injects BUNDLE_IMG.
+# The leading YAML '---' separator from opm output is stripped to avoid duplicating
+# the one already emitted by the echo block.
 catalog-update: opm ## Generate catalog configuration for current version
 	@echo "Generating catalog configuration for version $(VERSION)..."
 	@mkdir -p catalog
@@ -361,7 +365,14 @@ catalog-update: opm ## Generate catalog configuration for current version
 		echo "entries:"; \
 		echo "  - name: automotive-dev-operator.v$(VERSION)"; \
 		echo "---"; \
-		$(OPM) render $(BUNDLE_IMG); \
+		rendered=$$( \
+			if $(OPM) render $(BUNDLE_IMG) -o yaml 2>/dev/null; then true; \
+			else \
+				echo "Note: Bundle image not available remotely, rendering from local bundle/ directory" >&2; \
+				$(OPM) render bundle/ -o yaml | \
+					sed 's|^image: ""|image: $(BUNDLE_IMG)|'; \
+			fi \
+		) && echo "$$rendered" | sed '1{/^---$$/d}'; \
 	} > catalog/automotive-dev-operator.yaml
 	@# Add openshift-pipelines dependency (opm render doesn't include it)
 	@awk '\


### PR DESCRIPTION
Build jobs now run on all pushes (branches + tags) instead of only branches. retag-on-release depends on create-multiarch-manifest and build-tekton-bundle via needs, eliminating the race where retag ran before images were built.

Also add local bundle directory fallback to catalog-update make target for release prep when the bundle image is not yet pushed.

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [X] CI/CD improvement
- [ ] Refactoring

## Testing
- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)
