### PR TITLE
feat: show traceId in caib image show

### DIFF
--- a/cmd/caib/querycmd/query.go
+++ b/cmd/caib/querycmd/query.go
@@ -243,6 +243,7 @@ func printBuildDetails(st *buildapitypes.BuildResponse) error {
 		{"Container Image", valueOrDash(st.ContainerImage)},
 		{"Disk Image", valueOrDash(st.DiskImage)},
 		{"Warning", valueOrDash(st.Warning)},
+		{"Trace ID", valueOrDash(st.TraceID)},
 	}
 
 	if st.Parameters != nil {

--- a/cmd/caib/querycmd/query_test.go
+++ b/cmd/caib/querycmd/query_test.go
@@ -3,6 +3,7 @@ package querycmd
 import (
 	"encoding/json"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -263,6 +264,40 @@ func TestFormatOutputYAML_Show(t *testing.T) {
 	}
 	if parsed["name"] != "test-build" {
 		t.Errorf("expected name test-build, got %v", parsed["name"])
+	}
+}
+
+func TestPrintBuildDetails_TraceID(t *testing.T) {
+	resp := &buildapitypes.BuildResponse{
+		Name:    "test-build",
+		Phase:   "Succeeded",
+		TraceID: "a39035cd440a23aaf86986f35d468674",
+	}
+
+	out := captureStdout(t, func() {
+		_ = printBuildDetails(resp)
+	})
+
+	if !strings.Contains(out, "Trace ID") {
+		t.Errorf("expected 'Trace ID' label in output, got: %s", out)
+	}
+	if !strings.Contains(out, "a39035cd440a23aaf86986f35d468674") {
+		t.Errorf("expected trace ID value in output, got: %s", out)
+	}
+}
+
+func TestPrintBuildDetails_TraceIDEmpty(t *testing.T) {
+	resp := &buildapitypes.BuildResponse{
+		Name:  "test-build",
+		Phase: "Running",
+	}
+
+	out := captureStdout(t, func() {
+		_ = printBuildDetails(resp)
+	})
+
+	if !regexp.MustCompile(`(?m)^Trace ID\s+-$`).MatchString(out) {
+		t.Errorf("expected Trace ID row to render a dash, got: %s", out)
 	}
 }
 


### PR DESCRIPTION
This would make it easier to integrate with tools like logcli

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [X] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `caib image show` now displays a **Trace ID** in the build details table.
  * If no trace ID is available, the output shows a dash (`-`) for consistency.

* **Tests**
  * Added coverage to verify the Trace ID appears correctly when present and falls back to `-` when missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->