### PR TITLE
ci: enable package-mode tests in Smoke lane

### DIFF
--- a/.claude/skills/e2e/SKILL.md
+++ b/.claude/skills/e2e/SKILL.md
@@ -254,7 +254,7 @@ Fully wired lanes (use as models):
 
 | Label | File | Make / PR lane | Timeout |
 |-------|------|----------------|---------|
-| `smoke` | `smoke_test.go` | `test-e2e-smoke` / `/e2e-smoke` | 10m |
+| `smoke` | `smoke_test.go` | `test-e2e-smoke` / `/e2e-smoke` | 15m |
 | `operator` | `operator_test.go` | `test-e2e-operator` / `/e2e-operator` | 10m |
 | `auth` | `auth_test.go` | `test-e2e-auth` / `/e2e-auth` | 10m |
 | `features` | `features_e2e_test.go` | `test-e2e-features` / `/e2e-features` | 10m |

--- a/hack/e2e/timeouts.env
+++ b/hack/e2e/timeouts.env
@@ -6,13 +6,13 @@
 # Variable names use underscores; scripts convert hyphens with: ${suite//-/_}
 
 # fast lanes (~10m)
-E2E_TIMEOUT_smoke=10m
 E2E_TIMEOUT_operator=10m
 E2E_TIMEOUT_auth=10m
 E2E_TIMEOUT_features=10m
 E2E_TIMEOUT_manifest_validation=10m
 
 # medium lanes (~15m)
+E2E_TIMEOUT_smoke=15m
 E2E_TIMEOUT_bootc=15m
 E2E_TIMEOUT_internal_registry=15m
 E2E_TIMEOUT_package_mode=15m

--- a/test/e2e/package_build_test.go
+++ b/test/e2e/package_build_test.go
@@ -30,7 +30,7 @@ import (
 
 // Test #23 from e2e-test-coverage-proposal.md.
 
-var _ = Describe("Package Mode Build", Label("package-mode"), Ordered, func() {
+var _ = Describe("Package Mode Build", Label("package-mode", "smoke"), Ordered, func() {
 
 	BeforeAll(func() {
 		if registryHost == "" {


### PR DESCRIPTION
## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Broadened test coverage by tagging the Package Mode Build suite as **smoke**.
* **Chores**
  * Increased the smoke end-to-end timeout to **15 minutes** to reduce failures from slow-running checks.
  * Reordered timeout settings for clearer organization.
* **Documentation**
  * Updated the documented smoke lane timeout to **15 minutes**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->