### PR TITLE
feat: add OCIVolumes feature gate with ORAS OCI volume support

### DIFF
--- a/api/v1alpha1/operatorconfig_types.go
+++ b/api/v1alpha1/operatorconfig_types.go
@@ -54,6 +54,9 @@ const (
 	// DefaultFlashLeaseTags is the fallback lease tags when none configured in OperatorConfig
 	DefaultFlashLeaseTags = "platform=caib"
 
+	// DefaultOrasImage is the default ORAS CLI image mounted as an OCI volume
+	DefaultOrasImage = "ghcr.io/oras-project/oras:v1.2.0"
+
 	// DefaultToolchainImage is the default container image for workspace toolchains
 	DefaultToolchainImage = "quay.io/rh-sdv-cloud/autosd-toolchain:latest"
 
@@ -97,6 +100,11 @@ type ImagesConfig struct {
 	// Operator is the operator container image (overridden by OPERATOR_IMAGE env var when set)
 	// +optional
 	Operator string `json:"operator,omitempty"`
+
+	// Oras is the ORAS CLI image mounted as an OCI volume in build pods.
+	// Only used when the OCIVolumes feature gate is enabled.
+	// +optional
+	Oras string `json:"oras,omitempty"`
 }
 
 // GetAutomotiveImageBuilderImage returns the AIB image, falling back to the default
@@ -129,6 +137,14 @@ func (c *ImagesConfig) GetOperatorImage() string {
 		return c.Operator
 	}
 	return DefaultOperatorImage
+}
+
+// GetOrasImage returns the ORAS CLI image, falling back to the default
+func (c *ImagesConfig) GetOrasImage() string {
+	if c != nil && c.Oras != "" {
+		return c.Oras
+	}
+	return DefaultOrasImage
 }
 
 // BuildAPIResourcesConfig defines resource requirements for Build API components

--- a/config/crd/bases/automotive.sdv.cloud.redhat.com_operatorconfigs.yaml
+++ b/config/crd/bases/automotive.sdv.cloud.redhat.com_operatorconfigs.yaml
@@ -661,6 +661,11 @@ spec:
                     description: Operator is the operator container image (overridden
                       by OPERATOR_IMAGE env var when set)
                     type: string
+                  oras:
+                    description: |-
+                      Oras is the ORAS CLI image mounted as an OCI volume in build pods.
+                      Only used when the OCIVolumes feature gate is enabled.
+                    type: string
                   yqHelper:
                     description: YQHelper is the yq helper image used in Tekton task
                       steps

--- a/internal/common/tasks/oci_volumes_test.go
+++ b/internal/common/tasks/oci_volumes_test.go
@@ -1,0 +1,169 @@
+package tasks
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const testOrasImage = "ghcr.io/oras-project/oras:v1.2.0"
+
+func TestOCIVolumes_MountsOnBuildTask(t *testing.T) {
+	cfg := &BuildConfig{
+		UseOCIVolumes: true,
+		OrasImage:     testOrasImage,
+	}
+	task := GenerateBuildAutomotiveImageTask("test-ns", cfg, "")
+
+	assertTaskHasNoVolume(t, task.Spec.Volumes)
+	for _, step := range task.Spec.Steps {
+		assertHasVolumeMount(t, step.VolumeMounts, ociVolumeNameOras, ociMountPathOras)
+	}
+}
+
+func TestOCIVolumes_ReturnedByOCIVolumes(t *testing.T) {
+	cfg := &BuildConfig{
+		UseOCIVolumes: true,
+		OrasImage:     testOrasImage,
+	}
+
+	vols := OCIVolumes(cfg)
+	assertHasImageVolume(t, vols, ociVolumeNameOras, testOrasImage)
+}
+
+func TestOCIVolumes_AbsentWhenDisabled(t *testing.T) {
+	cfg := &BuildConfig{
+		UseOCIVolumes: false,
+	}
+	task := GenerateBuildAutomotiveImageTask("test-ns", cfg, "")
+
+	assertTaskHasNoVolume(t, task.Spec.Volumes)
+	if vols := OCIVolumes(cfg); len(vols) != 0 {
+		t.Fatal("OCIVolumes should return nil when disabled")
+	}
+}
+
+func TestOCIVolumes_AbsentWhenNilConfig(t *testing.T) {
+	task := GenerateBuildAutomotiveImageTask("test-ns", nil, "")
+
+	assertTaskHasNoVolume(t, task.Spec.Volumes)
+	if vols := OCIVolumes(nil); len(vols) != 0 {
+		t.Fatal("OCIVolumes should return nil with nil config")
+	}
+}
+
+func TestOCIVolumes_AbsentWhenEmptyImage(t *testing.T) {
+	cfg := &BuildConfig{
+		UseOCIVolumes: true,
+		OrasImage:     "",
+	}
+	task := GenerateBuildAutomotiveImageTask("test-ns", cfg, "")
+
+	assertTaskHasNoVolume(t, task.Spec.Volumes)
+	if vols := OCIVolumes(cfg); len(vols) != 0 {
+		t.Fatal("OCIVolumes should return nil when OrasImage is empty")
+	}
+}
+
+func TestOCIVolumes_MountsOnPushTask(t *testing.T) {
+	cfg := &BuildConfig{
+		UseOCIVolumes: true,
+		OrasImage:     testOrasImage,
+	}
+	task := GeneratePushArtifactRegistryTask("test-ns", cfg)
+
+	assertTaskHasNoVolume(t, task.Spec.Volumes)
+	for _, step := range task.Spec.Steps {
+		assertHasVolumeMount(t, step.VolumeMounts, ociVolumeNameOras, ociMountPathOras)
+	}
+}
+
+func TestOCIVolumes_AbsentOnSealedTask(t *testing.T) {
+	cfg := &BuildConfig{
+		UseOCIVolumes: true,
+		OrasImage:     testOrasImage,
+	}
+	task := GenerateSealedTaskForOperation("test-ns", "prepare", cfg)
+
+	assertTaskHasNoVolume(t, task.Spec.Volumes)
+	for _, step := range task.Spec.Steps {
+		for _, vm := range step.VolumeMounts {
+			if vm.Name == ociVolumeNameOras {
+				t.Fatalf("sealed task step %q should not have OCI volume mount", step.Name)
+			}
+		}
+	}
+}
+
+func TestOCIVolumes_ReadOnly(t *testing.T) {
+	cfg := &BuildConfig{
+		UseOCIVolumes: true,
+		OrasImage:     testOrasImage,
+	}
+	task := GenerateBuildAutomotiveImageTask("test-ns", cfg, "")
+
+	for _, step := range task.Spec.Steps {
+		for _, vm := range step.VolumeMounts {
+			if vm.Name == ociVolumeNameOras && !vm.ReadOnly {
+				t.Fatalf("ORAS volume mount on step %q should be read-only", step.Name)
+			}
+		}
+	}
+}
+
+func TestOCIVolumes_PullPolicy(t *testing.T) {
+	cfg := &BuildConfig{
+		UseOCIVolumes: true,
+		OrasImage:     testOrasImage,
+	}
+
+	vols := OCIVolumes(cfg)
+	for _, vol := range vols {
+		if vol.Name == ociVolumeNameOras {
+			if vol.Image == nil {
+				t.Fatal("ORAS volume should use Image volume source")
+			}
+			if vol.Image.PullPolicy != corev1.PullIfNotPresent {
+				t.Fatalf("ORAS volume pull policy = %v, want IfNotPresent", vol.Image.PullPolicy)
+			}
+		}
+	}
+}
+
+func assertHasImageVolume(t *testing.T, volumes []corev1.Volume, name, reference string) {
+	t.Helper()
+	for _, vol := range volumes {
+		if vol.Name == name {
+			if vol.Image == nil {
+				t.Fatalf("volume %q exists but is not an Image volume", name)
+			}
+			if vol.Image.Reference != reference {
+				t.Fatalf("volume %q reference = %q, want %q", name, vol.Image.Reference, reference)
+			}
+			return
+		}
+	}
+	t.Fatalf("image volume %q not found", name)
+}
+
+func assertTaskHasNoVolume(t *testing.T, volumes []corev1.Volume) {
+	t.Helper()
+	for _, vol := range volumes {
+		if vol.Name == ociVolumeNameOras {
+			t.Fatalf("volume %q should not be on Task spec (belongs in podTemplate)", vol.Name)
+		}
+	}
+}
+
+func assertHasVolumeMount(t *testing.T, mounts []corev1.VolumeMount, name, path string) {
+	t.Helper()
+	for _, vm := range mounts {
+		if vm.Name == name {
+			if vm.MountPath != path {
+				t.Fatalf("volume mount %q path = %q, want %q", name, vm.MountPath, path)
+			}
+			return
+		}
+	}
+	t.Fatalf("volume mount %q not found", name)
+}

--- a/internal/common/tasks/scripts/build_image.sh
+++ b/internal/common/tasks/scripts/build_image.sh
@@ -92,31 +92,7 @@ RESTORE_SOURCES_REF="$(params.restore-sources-ref)"
 if [ -n "$RESTORE_SOURCES_REF" ]; then
   echo "=== Restoring sources from $RESTORE_SOURCES_REF ==="
 
-  ORAS_VERSION="1.2.0"
-  case "$(uname -m)" in
-    x86_64) ORAS_ARCH="amd64" ;;
-    aarch64|arm64) ORAS_ARCH="arm64" ;;
-    *) echo "ERROR: Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
-  esac
-  ORAS_TARBALL="oras_${ORAS_VERSION}_linux_${ORAS_ARCH}.tar.gz"
-  ORAS_BASE_URL="https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}"
-  ORAS_CHECKSUMS="oras_${ORAS_VERSION}_checksums.txt"
-  curl -sLO "${ORAS_BASE_URL}/${ORAS_TARBALL}"
-  curl -sLO "${ORAS_BASE_URL}/${ORAS_CHECKSUMS}"
-  expected_checksum=$(grep "${ORAS_TARBALL}" "${ORAS_CHECKSUMS}" | cut -d' ' -f1)
-  if command -v sha256sum >/dev/null; then
-    actual_checksum=$(sha256sum "${ORAS_TARBALL}" | cut -d' ' -f1)
-  else
-    actual_checksum=$(shasum -a 256 "${ORAS_TARBALL}" | cut -d' ' -f1)
-  fi
-  if [ "$expected_checksum" != "$actual_checksum" ]; then
-    echo "ERROR: ORAS checksum verification failed" >&2; exit 1
-  fi
-  tar -zxf "$ORAS_TARBALL" oras
-  mkdir -p "$HOME/bin"
-  mv oras "$HOME/bin/"
-  rm -f "$ORAS_TARBALL" "$ORAS_CHECKSUMS"
-  export PATH="$HOME/bin:$PATH"
+  install_oras || exit 1
 
   ORAS_AUTH_FLAGS=()
   if [ -n "$REGISTRY_AUTH_FILE" ] && [ -f "$REGISTRY_AUTH_FILE" ]; then

--- a/internal/common/tasks/scripts/common.sh
+++ b/internal/common/tasks/scripts/common.sh
@@ -26,6 +26,109 @@ if [[ -n "${ADO_TRACE_ID:-}" ]]; then
   echo "{\"traceID\":\"${ADO_TRACE_ID}\",\"msg\":\"task started\",\"hostname\":\"${HOSTNAME:-unknown}\"}"
 fi
 
+# Add OCI volume tool paths when mounted (OCIVolumes feature gate)
+OCI_TOOLS_BASE="/oci-tools"
+if [ -d "$OCI_TOOLS_BASE/oras/bin" ]; then
+  export PATH="$OCI_TOOLS_BASE/oras/bin:$PATH"
+fi
+
+# --- ORAS install ---
+
+# install_oras downloads and checksum-verifies the ORAS CLI binary.
+# Sets ORAS_BIN to the installed path and adds it to PATH.
+# Skips if oras is already available (e.g. via OCI volume mount).
+install_oras() {
+  if command -v oras >/dev/null 2>&1; then
+    ORAS_BIN="$(command -v oras)"
+    echo "ORAS already available at $ORAS_BIN"
+    return 0
+  fi
+
+  if [ -d "$OCI_TOOLS_BASE/oras" ]; then
+    echo "WARN: OCI volume mounted at $OCI_TOOLS_BASE/oras but oras binary not found on PATH, falling back to download" >&2
+  fi
+
+  ORAS_VERSION="1.2.0"
+  case "$(uname -m)" in
+    x86_64) ORAS_ARCH="amd64" ;;
+    aarch64|arm64) ORAS_ARCH="arm64" ;;
+    *)
+      echo "ERROR: Unsupported architecture: $(uname -m)" >&2
+      return 1
+      ;;
+  esac
+  ORAS_TARBALL="oras_${ORAS_VERSION}_linux_${ORAS_ARCH}.tar.gz"
+  ORAS_BASE_URL="https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}"
+  ORAS_CHECKSUMS="oras_${ORAS_VERSION}_checksums.txt"
+
+  _cleanup_oras_files() {
+    rm -f "$ORAS_TARBALL" "$ORAS_CHECKSUMS" oras
+  }
+
+  trap _cleanup_oras_files EXIT
+
+  echo "Downloading ORAS ${ORAS_VERSION} with integrity verification..."
+
+  curl -LO "${ORAS_BASE_URL}/${ORAS_TARBALL}" || {
+    echo "ERROR: Failed to download ORAS tarball" >&2
+    return 1
+  }
+
+  curl -LO "${ORAS_BASE_URL}/${ORAS_CHECKSUMS}" || {
+    echo "ERROR: Failed to download ORAS checksums" >&2
+    return 1
+  }
+
+  expected_checksum=$(grep "${ORAS_TARBALL}" "${ORAS_CHECKSUMS}" | cut -d' ' -f1)
+  if [ -z "$expected_checksum" ]; then
+    echo "ERROR: Could not find checksum for ${ORAS_TARBALL} in checksums file" >&2
+    return 1
+  fi
+
+  if command -v sha256sum >/dev/null; then
+    actual_checksum=$(sha256sum "${ORAS_TARBALL}" | cut -d' ' -f1)
+  elif command -v shasum >/dev/null; then
+    actual_checksum=$(shasum -a 256 "${ORAS_TARBALL}" | cut -d' ' -f1)
+  else
+    echo "ERROR: Neither sha256sum nor shasum available for checksum verification" >&2
+    return 1
+  fi
+
+  if [ "$expected_checksum" != "$actual_checksum" ]; then
+    echo "ERROR: Checksum verification failed for ${ORAS_TARBALL}" >&2
+    echo "  Expected: $expected_checksum" >&2
+    echo "  Actual:   $actual_checksum" >&2
+    return 1
+  fi
+
+  echo "Checksum verification passed: $expected_checksum"
+
+  tar -zxf "$ORAS_TARBALL" oras || {
+    echo "ERROR: Failed to extract ORAS from tarball" >&2
+    return 1
+  }
+
+  ORAS_INSTALL_DIR="${HOME:-/tmp}/bin"
+  if [ "$ORAS_INSTALL_DIR" = "//bin" ] || [ "$ORAS_INSTALL_DIR" = "/bin" ]; then
+    ORAS_INSTALL_DIR="/tmp/bin"
+  fi
+  mkdir -p "$ORAS_INSTALL_DIR"
+  mv oras "$ORAS_INSTALL_DIR/" || {
+    echo "ERROR: Failed to install ORAS binary" >&2
+    return 1
+  }
+
+  if ! echo "$PATH" | grep -q "$ORAS_INSTALL_DIR"; then
+    export PATH="$ORAS_INSTALL_DIR:$PATH"
+  fi
+
+  _cleanup_oras_files
+  trap - EXIT
+
+  ORAS_BIN="$ORAS_INSTALL_DIR/oras"
+  echo "ORAS ${ORAS_VERSION} installed successfully"
+}
+
 # --- Validation ---
 
 validate_container_ref() {

--- a/internal/common/tasks/scripts/push_artifact.sh
+++ b/internal/common/tasks/scripts/push_artifact.sh
@@ -1,81 +1,7 @@
 # shellcheck shell=bash
 # NOTE: common.sh is prepended to this script at embed time.
 
-ORAS_VERSION="1.2.0"
-# Detect container architecture
-case "$(uname -m)" in
-  x86_64) ORAS_ARCH="amd64" ;;
-  aarch64|arm64) ORAS_ARCH="arm64" ;;
-  *)
-    echo "ERROR: Unsupported architecture: $(uname -m)" >&2
-    exit 1
-    ;;
-esac
-ORAS_TARBALL="oras_${ORAS_VERSION}_linux_${ORAS_ARCH}.tar.gz"
-ORAS_BASE_URL="https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}"
-ORAS_CHECKSUMS="oras_${ORAS_VERSION}_checksums.txt"
-
-cleanup_oras_files() {
-  rm -f "$ORAS_TARBALL" "$ORAS_CHECKSUMS" oras
-}
-
-trap cleanup_oras_files EXIT
-
-echo "Downloading ORAS ${ORAS_VERSION} with integrity verification..."
-
-curl -LO "${ORAS_BASE_URL}/${ORAS_TARBALL}" || {
-  echo "ERROR: Failed to download ORAS tarball" >&2
-  exit 1
-}
-
-curl -LO "${ORAS_BASE_URL}/${ORAS_CHECKSUMS}" || {
-  echo "ERROR: Failed to download ORAS checksums" >&2
-  exit 1
-}
-
-expected_checksum=$(grep "${ORAS_TARBALL}" "${ORAS_CHECKSUMS}" | cut -d' ' -f1)
-if [ -z "$expected_checksum" ]; then
-  echo "ERROR: Could not find checksum for ${ORAS_TARBALL} in checksums file" >&2
-  exit 1
-fi
-
-if command -v sha256sum >/dev/null; then
-  actual_checksum=$(sha256sum "${ORAS_TARBALL}" | cut -d' ' -f1)
-elif command -v shasum >/dev/null; then
-  actual_checksum=$(shasum -a 256 "${ORAS_TARBALL}" | cut -d' ' -f1)
-else
-  echo "ERROR: Neither sha256sum nor shasum available for checksum verification" >&2
-  exit 1
-fi
-
-if [ "$expected_checksum" != "$actual_checksum" ]; then
-  echo "ERROR: Checksum verification failed for ${ORAS_TARBALL}" >&2
-  echo "  Expected: $expected_checksum" >&2
-  echo "  Actual:   $actual_checksum" >&2
-  exit 1
-fi
-
-echo "Checksum verification passed: $expected_checksum"
-
-tar -zxf "$ORAS_TARBALL" oras || {
-  echo "ERROR: Failed to extract ORAS from tarball" >&2
-  exit 1
-}
-
-mkdir -p "$HOME/bin"
-mv oras "$HOME/bin/" || {
-  echo "ERROR: Failed to install ORAS binary" >&2
-  exit 1
-}
-
-if ! echo "$PATH" | grep -q "$HOME/bin"; then
-  export PATH="$HOME/bin:$PATH"
-fi
-
-cleanup_oras_files
-trap - EXIT
-
-echo "ORAS ${ORAS_VERSION} installed successfully"
+install_oras || exit 1
 
 # Get media type based on file format and compression
 get_media_type() {
@@ -369,7 +295,7 @@ EOF
   # Push with multi-layer manifest using annotation file
   # Files are pushed from current directory (parts_dir) so they extract flat
   set -o pipefail
-  "$HOME/bin/oras" push "${ORAS_EXTRA_ARGS[@]}" --disable-path-validation \
+  "$ORAS_BIN" push "${ORAS_EXTRA_ARGS[@]}" --disable-path-validation \
     --image-spec v1.1 \
     --artifact-type "${artifact_type}" \
     --annotation-file "$annotations_file" \
@@ -438,7 +364,7 @@ PYEOF
   echo "  Annotations: distro=${distro}, target=${target}, arch=${arch}"
 
   set -o pipefail
-  "$HOME/bin/oras" push "${ORAS_EXTRA_ARGS[@]}" --disable-path-validation \
+  "$ORAS_BIN" push "${ORAS_EXTRA_ARGS[@]}" --disable-path-validation \
     --image-spec v1.1 \
     --artifact-type "${media_type}" \
     --annotation-file "$single_annotations_file" \
@@ -474,7 +400,7 @@ echo -n "${DISK_DIGEST}" > /workspace/shared/.chains/disk/digest
 OSBUILD_MANIFEST="/workspace/shared/image.json"
 if [ -f "$OSBUILD_MANIFEST" ] && [ -n "$DISK_DIGEST" ]; then
   echo "Attaching osbuild manifest to ${repo_url}@${DISK_DIGEST}"
-  if ! "$HOME/bin/oras" attach --disable-path-validation "${ORAS_EXTRA_ARGS[@]}" \
+  if ! "$ORAS_BIN" attach --disable-path-validation "${ORAS_EXTRA_ARGS[@]}" \
     --artifact-type "$OCI_REFERRER_TYPE_OSBUILD_MANIFEST" \
     "${repo_url}@${DISK_DIGEST}" \
     "${OSBUILD_MANIFEST}:${OCI_REFERRER_TYPE_OSBUILD_MANIFEST}" 2>&1; then
@@ -497,7 +423,7 @@ attach_referrer() {
     exit 1
   fi
   echo "Attaching $label ($(du -sh "$file" | cut -f1)) to ${repo_url}@${DISK_DIGEST}"
-  if ! "$HOME/bin/oras" attach "${ORAS_EXTRA_ARGS[@]}" \
+  if ! "$ORAS_BIN" attach "${ORAS_EXTRA_ARGS[@]}" \
     --artifact-type "$artifact_type" \
     "${repo_url}@${DISK_DIGEST}" \
     "${file}:${artifact_type}"; then

--- a/internal/common/tasks/scripts/sealed_operation.sh
+++ b/internal/common/tasks/scripts/sealed_operation.sh
@@ -256,60 +256,6 @@ validate_arg "${INPUT_REF}" "input-ref"
 validate_arg "${OUTPUT_REF:-}" "output-ref"
 validate_arg "${SIGNED_REF:-}" "signed-ref"
 
-# ── Install oras (for extract-for-signing / inject-signed) ──
-install_oras() {
-  if command -v oras >/dev/null 2>&1; then return; fi
-  ORAS_VERSION="1.2.0"
-  case "$(uname -m)" in
-    x86_64) ORAS_ARCH="amd64" ;;
-    aarch64|arm64) ORAS_ARCH="arm64" ;;
-    *) echo "ERROR: Unsupported architecture $(uname -m)" >&2; exit 1 ;;
-  esac
-  local ORAS_TARBALL="oras_${ORAS_VERSION}_linux_${ORAS_ARCH}.tar.gz"
-  local ORAS_BASE_URL="https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}"
-  local ORAS_CHECKSUMS="oras_${ORAS_VERSION}_checksums.txt"
-
-  echo "Installing oras ${ORAS_VERSION} with integrity verification..."
-
-  curl -sSLf -o "/tmp/${ORAS_TARBALL}" "${ORAS_BASE_URL}/${ORAS_TARBALL}" || {
-    echo "ERROR: Failed to download ORAS tarball" >&2; exit 1
-  }
-  curl -sSLf -o "/tmp/${ORAS_CHECKSUMS}" "${ORAS_BASE_URL}/${ORAS_CHECKSUMS}" || {
-    echo "ERROR: Failed to download ORAS checksums" >&2; exit 1
-  }
-
-  local expected_checksum
-  expected_checksum=$(grep "${ORAS_TARBALL}" "/tmp/${ORAS_CHECKSUMS}" | cut -d' ' -f1)
-  if [ -z "$expected_checksum" ]; then
-    echo "ERROR: Could not find checksum for ${ORAS_TARBALL} in checksums file" >&2
-    exit 1
-  fi
-
-  local actual_checksum
-  if command -v sha256sum >/dev/null; then
-    actual_checksum=$(sha256sum "/tmp/${ORAS_TARBALL}" | cut -d' ' -f1)
-  elif command -v shasum >/dev/null; then
-    actual_checksum=$(shasum -a 256 "/tmp/${ORAS_TARBALL}" | cut -d' ' -f1)
-  else
-    echo "ERROR: Neither sha256sum nor shasum available for checksum verification" >&2
-    exit 1
-  fi
-
-  if [ "$expected_checksum" != "$actual_checksum" ]; then
-    echo "ERROR: Checksum verification failed for ${ORAS_TARBALL}" >&2
-    echo "  Expected: $expected_checksum" >&2
-    echo "  Actual:   $actual_checksum" >&2
-    exit 1
-  fi
-  echo "Checksum verification passed: $expected_checksum"
-
-  tar -xzf "/tmp/${ORAS_TARBALL}" -C /tmp oras || {
-    echo "ERROR: Failed to extract ORAS from tarball" >&2; exit 1
-  }
-  mv /tmp/oras /usr/local/bin/oras
-  chmod +x /usr/local/bin/oras
-  rm -f "/tmp/${ORAS_TARBALL}" "/tmp/${ORAS_CHECKSUMS}"
-}
 insecure_oras_flags=()
 if [ "${INSECURE_REGISTRY:-}" = "true" ]; then
   # shellcheck disable=SC2207

--- a/internal/common/tasks/tasks.go
+++ b/internal/common/tasks/tasks.go
@@ -31,6 +31,8 @@ type BuildConfig struct {
 	UsePVCScratchVolumes        bool
 	TaskResolver                string // TaskResolverCluster (default) or TaskResolverBundle
 	TaskBundleRef               string // OCI bundle ref when TaskResolver is TaskResolverBundle
+	UseOCIVolumes               bool
+	OrasImage                   string
 }
 
 const (
@@ -183,6 +185,13 @@ const workspaceNameShared = "shared-workspace"
 // Tekton resolves this at runtime to the actual volume name in the pod spec.
 const workspaceVolumeRef = "$(workspaces." + workspaceNameShared + ".volume)"
 
+const (
+	ociVolumeNameOras = "oras-tools"
+	// OCIToolsMountBase is the root mount path for OCI tool volumes in task containers.
+	OCIToolsMountBase = "/oci-tools"
+	ociMountPathOras  = OCIToolsMountBase + "/oras"
+)
+
 // DefaultTrustedCABundleConfigMap is the default ConfigMap name for trusted CA bundles.
 // Exported so the controller can detect divergence when using bundle-resolved tasks.
 const DefaultTrustedCABundleConfigMap = "rhivos-ca-bundle"
@@ -225,7 +234,7 @@ func trustedCABundleVolumeSource(buildConfig *BuildConfig) corev1.VolumeSource {
 
 // GeneratePushArtifactRegistryTask creates a Tekton Task for pushing artifacts to a registry
 func GeneratePushArtifactRegistryTask(namespace string, buildConfig *BuildConfig) *tektonv1.Task {
-	return &tektonv1.Task{
+	task := &tektonv1.Task{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "tekton.dev/v1",
 			Kind:       "Task",
@@ -461,6 +470,10 @@ func GeneratePushArtifactRegistryTask(namespace string, buildConfig *BuildConfig
 			},
 		},
 	}
+
+	applyOCIVolumeMounts(task, buildConfig)
+
+	return task
 }
 
 // GenerateBuildAutomotiveImageTask creates a Tekton Task for building automotive images
@@ -885,7 +898,52 @@ func GenerateBuildAutomotiveImageTask(namespace string, buildConfig *BuildConfig
 		task.Spec.Volumes = filtered
 	}
 
+	applyOCIVolumeMounts(task, buildConfig)
+
 	return task
+}
+
+// applyOCIVolumeMounts conditionally adds OCI volume mounts to task steps when
+// the OCIVolumes feature gate is enabled. The actual volume definition must be
+// placed in the PipelineRun/TaskRun podTemplate (not the Task spec) because
+// Tekton's Task CRD schema prunes the corev1.ImageVolumeSource field, while
+// podTemplate has PreserveUnknownFields and passes it through to the pod.
+func applyOCIVolumeMounts(task *tektonv1.Task, buildConfig *BuildConfig) {
+	if buildConfig == nil || !buildConfig.UseOCIVolumes || buildConfig.OrasImage == "" {
+		return
+	}
+
+	for i := range task.Spec.Steps {
+		step := &task.Spec.Steps[i]
+		step.VolumeMounts = append(step.VolumeMounts, corev1.VolumeMount{
+			Name:      ociVolumeNameOras,
+			MountPath: ociMountPathOras,
+			ReadOnly:  true,
+		})
+	}
+}
+
+// OCIVolumes returns the OCI image volumes to inject via podTemplate. Returns
+// nil when OCI volumes are disabled. The caller must add these to the
+// PipelineRun or TaskRun podTemplate.Volumes.
+// Requires the Kubernetes ImageVolume feature gate on the cluster (beta in 1.33+,
+// GA in OpenShift 4.20) and a compatible container runtime (CRI-O >= 1.31).
+func OCIVolumes(buildConfig *BuildConfig) []corev1.Volume {
+	if buildConfig == nil || !buildConfig.UseOCIVolumes || buildConfig.OrasImage == "" {
+		return nil
+	}
+
+	return []corev1.Volume{
+		{
+			Name: ociVolumeNameOras,
+			VolumeSource: corev1.VolumeSource{
+				Image: &corev1.ImageVolumeSource{
+					Reference:  buildConfig.OrasImage,
+					PullPolicy: corev1.PullIfNotPresent,
+				},
+			},
+		},
+	}
 }
 
 // GenerateTektonPipeline creates a Tekton Pipeline for automotive building process
@@ -2103,7 +2161,7 @@ func GenerateSealedTaskForOperation(namespace, operation string, buildConfig ...
 	if len(buildConfig) > 0 {
 		cfg = buildConfig[0]
 	}
-	return &tektonv1.Task{
+	task := &tektonv1.Task{
 		TypeMeta: metav1.TypeMeta{APIVersion: "tekton.dev/v1", Kind: "Task"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      SealedTaskName(operation),
@@ -2115,6 +2173,8 @@ func GenerateSealedTaskForOperation(namespace, operation string, buildConfig ...
 		},
 		Spec: sealedTaskSpec(operation, cfg),
 	}
+
+	return task
 }
 
 // GenerateSealedTasks returns all four sealed-operation Tasks for the given namespace (for OperatorConfig).

--- a/internal/controller/controllerutils/oci_volumes.go
+++ b/internal/controller/controllerutils/oci_volumes.go
@@ -1,0 +1,19 @@
+package controllerutils
+
+import (
+	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/tasks"
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/featuregates"
+)
+
+// ApplyOCIVolumesConfig enables OCI volume mounts on the build config when the OCIVolumes feature gate is active.
+func ApplyOCIVolumesConfig(buildConfig *tasks.BuildConfig, spec *automotivev1alpha1.OperatorConfigSpec) {
+	if buildConfig == nil || spec == nil {
+		return
+	}
+	gates := featuregates.NewFromConfig(spec)
+	if gates.Enabled(featuregates.OCIVolumes) {
+		buildConfig.UseOCIVolumes = true
+		buildConfig.OrasImage = spec.GetImages().GetOrasImage()
+	}
+}

--- a/internal/controller/controllerutils/oci_volumes_test.go
+++ b/internal/controller/controllerutils/oci_volumes_test.go
@@ -1,0 +1,68 @@
+package controllerutils
+
+import (
+	"testing"
+
+	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/tasks"
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/featuregates"
+)
+
+func TestApplyOCIVolumesConfig_NilBuildConfig(_ *testing.T) {
+	spec := &automotivev1alpha1.OperatorConfigSpec{
+		FeatureGates: map[string]bool{string(featuregates.OCIVolumes): true},
+	}
+	ApplyOCIVolumesConfig(nil, spec)
+}
+
+func TestApplyOCIVolumesConfig_NilSpec(t *testing.T) {
+	cfg := &tasks.BuildConfig{}
+	ApplyOCIVolumesConfig(cfg, nil)
+	if cfg.UseOCIVolumes {
+		t.Fatal("UseOCIVolumes should remain false with nil spec")
+	}
+}
+
+func TestApplyOCIVolumesConfig_GateDisabled(t *testing.T) {
+	cfg := &tasks.BuildConfig{}
+	spec := &automotivev1alpha1.OperatorConfigSpec{}
+	ApplyOCIVolumesConfig(cfg, spec)
+	if cfg.UseOCIVolumes {
+		t.Fatal("UseOCIVolumes should be false when gate is not enabled")
+	}
+	if cfg.OrasImage != "" {
+		t.Fatalf("OrasImage = %q, want empty", cfg.OrasImage)
+	}
+}
+
+func TestApplyOCIVolumesConfig_GateEnabled_DefaultImage(t *testing.T) {
+	cfg := &tasks.BuildConfig{}
+	spec := &automotivev1alpha1.OperatorConfigSpec{
+		FeatureGates: map[string]bool{string(featuregates.OCIVolumes): true},
+	}
+	ApplyOCIVolumesConfig(cfg, spec)
+	if !cfg.UseOCIVolumes {
+		t.Fatal("UseOCIVolumes should be true when gate is enabled")
+	}
+	if cfg.OrasImage != automotivev1alpha1.DefaultOrasImage {
+		t.Fatalf("OrasImage = %q, want default %q", cfg.OrasImage, automotivev1alpha1.DefaultOrasImage)
+	}
+}
+
+func TestApplyOCIVolumesConfig_GateEnabled_CustomImage(t *testing.T) {
+	custom := "registry.example.com/oras:custom"
+	cfg := &tasks.BuildConfig{}
+	spec := &automotivev1alpha1.OperatorConfigSpec{
+		FeatureGates: map[string]bool{string(featuregates.OCIVolumes): true},
+		Images: &automotivev1alpha1.ImagesConfig{
+			Oras: custom,
+		},
+	}
+	ApplyOCIVolumesConfig(cfg, spec)
+	if !cfg.UseOCIVolumes {
+		t.Fatal("UseOCIVolumes should be true")
+	}
+	if cfg.OrasImage != custom {
+		t.Fatalf("OrasImage = %q, want %q", cfg.OrasImage, custom)
+	}
+}

--- a/internal/controller/imagebuild/controller.go
+++ b/internal/controller/imagebuild/controller.go
@@ -901,6 +901,9 @@ func (r *ImageBuildReconciler) createBuildTaskRun(
 			UsePVCScratchVolumes:        operatorConfig.Spec.OSBuilds.GetUsePVCScratchVolumes(),
 		}
 		controllerutils.ApplyTrustedCABundleFromOSBuilds(buildConfig, operatorConfig.Spec.OSBuilds)
+
+		controllerutils.ApplyOCIVolumesConfig(buildConfig, &operatorConfig.Spec)
+
 		if imageBuild.Spec.SecureBuild {
 			// Use the digest-pinned ref snapshotted on the CR by the Build API,
 			// not the current OperatorConfig value (which may have changed).
@@ -942,6 +945,10 @@ func (r *ImageBuildReconciler) createBuildTaskRun(
 			if buildConfig.UsePVCScratchVolumes {
 				r.emitEventf(imageBuild, corev1.EventTypeWarning, "SecureBuildConfigDrift",
 					"OperatorConfig.usePVCScratchVolumes is enabled but bundle tasks use emptyDir; PVC scratch will not apply to this build")
+			}
+			if buildConfig.UseOCIVolumes {
+				r.emitEventf(imageBuild, corev1.EventTypeWarning, "SecureBuildConfigDrift",
+					"OperatorConfig has OCIVolumes enabled but bundle tasks do not include OCI volume mounts; ORAS will be downloaded at runtime")
 			}
 		}
 	}
@@ -1455,6 +1462,7 @@ func (r *ImageBuildReconciler) createBuildTaskRun(
 		log.Info("Setting RuntimeClassName from ImageBuild spec", "runtimeClassName", imageBuild.Spec.RuntimeClassName)
 		podTemplate.RuntimeClassName = &imageBuild.Spec.RuntimeClassName
 	}
+	podTemplate.Volumes = append(podTemplate.Volumes, tasks.OCIVolumes(buildConfig)...)
 	pipelineRunSpec := tektonv1.PipelineRunSpec{
 		Params:     params,
 		Workspaces: pipelineWorkspaces,
@@ -1740,6 +1748,10 @@ func (r *ImageBuildReconciler) createPushTaskRun(ctx context.Context, imageBuild
 		},
 	}
 
+	var pushPodTemplate *pod.PodTemplate
+	if ociVols := tasks.OCIVolumes(pushBuildConfig); len(ociVols) > 0 {
+		pushPodTemplate = &pod.PodTemplate{Volumes: ociVols}
+	}
 	taskRun := &tektonv1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: safeDerivedName(imageBuild.Name, "-push-"),
@@ -1756,9 +1768,10 @@ func (r *ImageBuildReconciler) createPushTaskRun(ctx context.Context, imageBuild
 			},
 		},
 		Spec: tektonv1.TaskRunSpec{
-			TaskSpec:   &pushTask.Spec,
-			Params:     params,
-			Workspaces: workspaces,
+			TaskSpec:    &pushTask.Spec,
+			Params:      params,
+			Workspaces:  workspaces,
+			PodTemplate: pushPodTemplate,
 		},
 	}
 
@@ -2583,6 +2596,9 @@ func (r *ImageBuildReconciler) resolveBuildConfig(ctx context.Context) *tasks.Bu
 		bc.FlashTimeoutMinutes = operatorConfig.Spec.OSBuilds.GetFlashTimeoutMinutes()
 		controllerutils.ApplyTrustedCABundleFromOSBuilds(bc, operatorConfig.Spec.OSBuilds)
 	}
+
+	controllerutils.ApplyOCIVolumesConfig(bc, &operatorConfig.Spec)
+
 	return bc
 }
 

--- a/internal/controller/operatorconfig/controller.go
+++ b/internal/controller/operatorconfig/controller.go
@@ -34,6 +34,7 @@ import (
 
 	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
 	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/tasks"
+	controllerutils "github.com/centos-automotive-suite/automotive-dev-operator/internal/controller/controllerutils"
 )
 
 const (
@@ -704,6 +705,8 @@ func (r *OperatorConfigReconciler) deployOSBuilds(
 		if config.Spec.OSBuilds.TaskBundleRef != "" {
 			buildConfig.TaskBundleRef = config.Spec.OSBuilds.TaskBundleRef
 		}
+
+		controllerutils.ApplyOCIVolumesConfig(buildConfig, &config.Spec)
 	}
 
 	// Create target defaults ConfigMap (architecture, partition rules, etc.)

--- a/internal/featuregates/features.go
+++ b/internal/featuregates/features.go
@@ -21,9 +21,20 @@ type FeatureSpec struct {
 	Stage Stage
 }
 
+// Feature gate constants.
+const (
+	// OCIVolumes enables mounting OCI images as read-only volumes in build
+	// pods, eliminating runtime tool downloads (e.g. ORAS).
+	// Requires the ImageVolume feature gate on the cluster (k8s 1.31+ alpha,
+	// 1.33+ beta, OpenShift 4.20 GA).
+	OCIVolumes FeatureName = "OCIVolumes"
+)
+
 // defaultFeatures is the compile-time registry of known features and their
 // default stages. Each feature PR adds its own entry here.
-var defaultFeatures = map[FeatureName]FeatureSpec{}
+var defaultFeatures = map[FeatureName]FeatureSpec{
+	OCIVolumes: {Stage: Alpha},
+}
 
 // Register adds a feature to the default registry. Intended for use in init()
 // functions within the package that implements the feature, or directly in this

--- a/internal/featuregates/gates_test.go
+++ b/internal/featuregates/gates_test.go
@@ -158,6 +158,29 @@ func TestKnown(t *testing.T) {
 	}
 }
 
+func TestOCIVolumesRegistered(t *testing.T) {
+	if !Known(OCIVolumes) {
+		t.Fatal("OCIVolumes feature should be registered")
+	}
+	if DefaultStage(OCIVolumes) != Alpha {
+		t.Fatalf("OCIVolumes should be Alpha, got %s", DefaultStage(OCIVolumes))
+	}
+	g := New(nil)
+	if g.Enabled(OCIVolumes) {
+		t.Fatal("OCIVolumes (Alpha) should be disabled by default")
+	}
+}
+
+func TestOCIVolumesEnabledViaOverride(t *testing.T) {
+	spec := &automotivev1alpha1.OperatorConfigSpec{
+		FeatureGates: map[string]bool{string(OCIVolumes): true},
+	}
+	g := NewFromConfig(spec)
+	if !g.Enabled(OCIVolumes) {
+		t.Fatal("OCIVolumes should be enabled when overridden to true")
+	}
+}
+
 func TestRegisterPanicsOnDuplicate(t *testing.T) {
 	setupTestFeatures(t)
 


### PR DESCRIPTION
Gate OCI image volumes behind a new Alpha feature gate (OCIVolumes). When enabled, mount the ORAS CLI container image as a read-only volume in build pods, eliminating the runtime download+verify of the ORAS binary.

Enable via OperatorConfig:
  spec.featureGates.OCIVolumes: true


## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [X] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional OCI volume support for build and push workflows behind the **OCIVolumes** feature gate.
  * Added configurable ORAS CLI image selection with a default fallback.
* **Bug Fixes**
  * Improved ORAS CLI installation flow by sharing the install logic and using the resolved ORAS executable consistently.
  * When enabled, OCI volume mounts are applied to generated pod templates; added a Secure Build drift warning noting bundle task behavior.
* **Tests**
  * Expanded coverage for OCI volume creation, mount behavior (read-only, pull policy), and feature-gate/config handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->