### PR TITLE
fix: disable direct bundle push trigger and enforce single-arch

### DIFF
--- a/.tekton/bundle-pull-request.yaml
+++ b/.tekton/bundle-pull-request.yaml
@@ -288,57 +288,30 @@ spec:
 
             cd /var/workdir/source
 
-            echo "=== Building linux/arm64 (native) ==="
-            buildah build \
-              --platform linux/arm64 \
-              --build-arg TARGETARCH=arm64 \
-              --build-arg TARGETOS=linux \
-              --build-arg BUILDPLATFORM=linux/arm64 \
-              --authfile "${AUTHFILE}" \
-              -t "${IMAGE_BASE}:${IMAGE_TAG}-arm64" \
-              -f "${DOCKERFILE}" .
-            buildah push --authfile "${AUTHFILE}" "${IMAGE_BASE}:${IMAGE_TAG}-arm64"
-
-            echo "=== Building linux/amd64 (cross-compilation) ==="
-            NATIVE_ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+            echo "=== Building single-arch linux/amd64 (bundle must not be a manifest list) ==="
             buildah build \
               --platform linux/amd64 \
-              --build-arg TARGETARCH=amd64 \
-              --build-arg TARGETOS=linux \
-              --build-arg BUILDPLATFORM=linux/${NATIVE_ARCH} \
               --authfile "${AUTHFILE}" \
-              -t "${IMAGE_BASE}:${IMAGE_TAG}-amd64" \
+              -t "${IMAGE_FULL}" \
               -f "${DOCKERFILE}" .
-            buildah push --authfile "${AUTHFILE}" "${IMAGE_BASE}:${IMAGE_TAG}-amd64"
 
-            echo "=== Creating manifest: ${IMAGE_BASE}:${IMAGE_TAG} ==="
-            buildah manifest rm multiarch 2>/dev/null || true
-            buildah manifest create multiarch
-            buildah manifest add multiarch "${IMAGE_BASE}:${IMAGE_TAG}-arm64"
-            buildah manifest add multiarch "${IMAGE_BASE}:${IMAGE_TAG}-amd64"
-            buildah manifest push --all multiarch \
+            buildah push \
               --authfile "${AUTHFILE}" \
-              "docker://${IMAGE_BASE}:${IMAGE_TAG}"
+              --digestfile /tmp/image-digest.txt \
+              "${IMAGE_FULL}"
+            DIGEST=$(cat /tmp/image-digest.txt)
+            if [ -z "${DIGEST}" ]; then
+              echo "ERROR: Failed to extract image digest" >&2
+              exit 1
+            fi
 
             if [ "${PUSH_LATEST}" = "true" ]; then
-              echo "=== Tagging as :latest, :latest-arm64, :latest-amd64 ==="
+              echo "=== Tagging as :latest ==="
               buildah push --authfile "${AUTHFILE}" \
-                "${IMAGE_BASE}:${IMAGE_TAG}-arm64" \
-                "docker://${IMAGE_BASE}:latest-arm64"
-              buildah push --authfile "${AUTHFILE}" \
-                "${IMAGE_BASE}:${IMAGE_TAG}-amd64" \
-                "docker://${IMAGE_BASE}:latest-amd64"
-              buildah manifest rm latest-manifest 2>/dev/null || true
-              buildah manifest create latest-manifest
-              buildah manifest add latest-manifest "${IMAGE_BASE}:${IMAGE_TAG}-arm64"
-              buildah manifest add latest-manifest "${IMAGE_BASE}:${IMAGE_TAG}-amd64"
-              buildah manifest push --all latest-manifest \
-                --authfile "${AUTHFILE}" \
+                "${IMAGE_FULL}" \
                 "docker://${IMAGE_BASE}:latest"
             fi
 
-            DIGEST=$(buildah manifest inspect multiarch \
-              | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('digest',''))" 2>/dev/null || echo "")
             echo -n "${IMAGE_BASE}:${IMAGE_TAG}" > $(results.IMAGE_URL.path)
             echo -n "${DIGEST}" > $(results.IMAGE_DIGEST.path)
         volumes:

--- a/.tekton/catalog-pull-request.yaml
+++ b/.tekton/catalog-pull-request.yaml
@@ -296,57 +296,30 @@ spec:
 
             cd /var/workdir/source
 
-            echo "=== Building linux/arm64 (native) ==="
-            buildah build \
-              --platform linux/arm64 \
-              --build-arg TARGETARCH=arm64 \
-              --build-arg TARGETOS=linux \
-              --build-arg BUILDPLATFORM=linux/arm64 \
-              --authfile "${AUTHFILE}" \
-              -t "${IMAGE_BASE}:${IMAGE_TAG}-arm64" \
-              -f "${DOCKERFILE}" .
-            buildah push --authfile "${AUTHFILE}" "${IMAGE_BASE}:${IMAGE_TAG}-arm64"
-
-            echo "=== Building linux/amd64 (cross-compilation) ==="
-            NATIVE_ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+            echo "=== Building single-arch linux/amd64 (FBC catalog must not be a manifest list) ==="
             buildah build \
               --platform linux/amd64 \
-              --build-arg TARGETARCH=amd64 \
-              --build-arg TARGETOS=linux \
-              --build-arg BUILDPLATFORM=linux/${NATIVE_ARCH} \
               --authfile "${AUTHFILE}" \
-              -t "${IMAGE_BASE}:${IMAGE_TAG}-amd64" \
+              -t "${IMAGE_FULL}" \
               -f "${DOCKERFILE}" .
-            buildah push --authfile "${AUTHFILE}" "${IMAGE_BASE}:${IMAGE_TAG}-amd64"
 
-            echo "=== Creating manifest: ${IMAGE_BASE}:${IMAGE_TAG} ==="
-            buildah manifest rm multiarch 2>/dev/null || true
-            buildah manifest create multiarch
-            buildah manifest add multiarch "${IMAGE_BASE}:${IMAGE_TAG}-arm64"
-            buildah manifest add multiarch "${IMAGE_BASE}:${IMAGE_TAG}-amd64"
-            buildah manifest push --all multiarch \
+            buildah push \
               --authfile "${AUTHFILE}" \
-              "docker://${IMAGE_BASE}:${IMAGE_TAG}"
+              --digestfile /tmp/image-digest.txt \
+              "${IMAGE_FULL}"
+            DIGEST=$(cat /tmp/image-digest.txt)
+            if [ -z "${DIGEST}" ]; then
+              echo "ERROR: Failed to extract image digest" >&2
+              exit 1
+            fi
 
             if [ "${PUSH_LATEST}" = "true" ]; then
-              echo "=== Tagging as :latest, :latest-arm64, :latest-amd64 ==="
+              echo "=== Tagging as :latest ==="
               buildah push --authfile "${AUTHFILE}" \
-                "${IMAGE_BASE}:${IMAGE_TAG}-arm64" \
-                "docker://${IMAGE_BASE}:latest-arm64"
-              buildah push --authfile "${AUTHFILE}" \
-                "${IMAGE_BASE}:${IMAGE_TAG}-amd64" \
-                "docker://${IMAGE_BASE}:latest-amd64"
-              buildah manifest rm latest-manifest 2>/dev/null || true
-              buildah manifest create latest-manifest
-              buildah manifest add latest-manifest "${IMAGE_BASE}:${IMAGE_TAG}-arm64"
-              buildah manifest add latest-manifest "${IMAGE_BASE}:${IMAGE_TAG}-amd64"
-              buildah manifest push --all latest-manifest \
-                --authfile "${AUTHFILE}" \
+                "${IMAGE_FULL}" \
                 "docker://${IMAGE_BASE}:latest"
             fi
 
-            DIGEST=$(buildah manifest inspect multiarch \
-              | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('digest',''))" 2>/dev/null || echo "")
             echo -n "${IMAGE_BASE}:${IMAGE_TAG}" > $(results.IMAGE_URL.path)
             echo -n "${DIGEST}" > $(results.IMAGE_DIGEST.path)
         volumes:

--- a/.tekton/catalog-push.yaml
+++ b/.tekton/catalog-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: "false"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: automotive-dev-operator


### PR DESCRIPTION

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [X] CI/CD improvement
- [ ] Refactoring

## Testing
- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Container images are now built and published for Linux amd64 only; arm64 images and multi-architecture manifests are no longer provided.
  * Image publishing now reports the digest of the single published image.
  * Automatic publishing triggered by pushes to the main branch has been disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->