### PR TITLE
fix: remove privileged buildah requirement from bundle/catalog builds

### DIFF
--- a/.tekton/bundle-pull-request.yaml
+++ b/.tekton/bundle-pull-request.yaml
@@ -274,11 +274,14 @@ spec:
         - name: build-and-push
           image: quay.io/buildah/stable:latest
           securityContext:
-            privileged: true
+            capabilities:
+              add:
+              - SETFCAP
           script: |
             #!/usr/bin/env bash
             set -euo pipefail
 
+            export STORAGE_DRIVER=vfs
             IMAGE_FULL="$(params.IMAGE)"
             IMAGE_BASE=$(echo "${IMAGE_FULL}" | sed 's/:[^/:]*$//')
             IMAGE_TAG="${IMAGE_FULL##*:}"
@@ -290,12 +293,14 @@ spec:
 
             echo "=== Building single-arch linux/amd64 (bundle must not be a manifest list) ==="
             buildah build \
+              --storage-driver vfs \
               --platform linux/amd64 \
               --authfile "${AUTHFILE}" \
               -t "${IMAGE_FULL}" \
               -f "${DOCKERFILE}" .
 
             buildah push \
+              --storage-driver vfs \
               --authfile "${AUTHFILE}" \
               --digestfile /tmp/image-digest.txt \
               "${IMAGE_FULL}"

--- a/.tekton/bundle-push.yaml
+++ b/.tekton/bundle-push.yaml
@@ -272,11 +272,14 @@ spec:
         - name: build-and-push
           image: quay.io/buildah/stable:latest
           securityContext:
-            privileged: true
+            capabilities:
+              add:
+              - SETFCAP
           script: |
             #!/usr/bin/env bash
             set -euo pipefail
 
+            export STORAGE_DRIVER=vfs
             IMAGE_FULL="$(params.IMAGE)"
             IMAGE_BASE=$(echo "${IMAGE_FULL}" | sed 's/:[^/:]*$//')
             IMAGE_TAG="${IMAGE_FULL##*:}"
@@ -288,12 +291,14 @@ spec:
 
             echo "=== Building single-arch linux/amd64 (bundle must not be a manifest list) ==="
             buildah build \
+              --storage-driver vfs \
               --platform linux/amd64 \
               --authfile "${AUTHFILE}" \
               -t "${IMAGE_FULL}" \
               -f "${DOCKERFILE}" .
 
             buildah push \
+              --storage-driver vfs \
               --authfile "${AUTHFILE}" \
               --digestfile /tmp/image-digest.txt \
               "${IMAGE_FULL}"

--- a/.tekton/catalog-pull-request.yaml
+++ b/.tekton/catalog-pull-request.yaml
@@ -282,11 +282,14 @@ spec:
         - name: build-and-push
           image: quay.io/buildah/stable:latest
           securityContext:
-            privileged: true
+            capabilities:
+              add:
+              - SETFCAP
           script: |
             #!/usr/bin/env bash
             set -euo pipefail
 
+            export STORAGE_DRIVER=vfs
             IMAGE_FULL="$(params.IMAGE)"
             IMAGE_BASE=$(echo "${IMAGE_FULL}" | sed 's/:[^/:]*$//')
             IMAGE_TAG="${IMAGE_FULL##*:}"
@@ -298,12 +301,14 @@ spec:
 
             echo "=== Building single-arch linux/amd64 (FBC catalog must not be a manifest list) ==="
             buildah build \
+              --storage-driver vfs \
               --platform linux/amd64 \
               --authfile "${AUTHFILE}" \
               -t "${IMAGE_FULL}" \
               -f "${DOCKERFILE}" .
 
             buildah push \
+              --storage-driver vfs \
               --authfile "${AUTHFILE}" \
               --digestfile /tmp/image-digest.txt \
               "${IMAGE_FULL}"

--- a/.tekton/catalog-push.yaml
+++ b/.tekton/catalog-push.yaml
@@ -280,11 +280,14 @@ spec:
         - name: build-and-push
           image: quay.io/buildah/stable:latest
           securityContext:
-            privileged: true
+            capabilities:
+              add:
+              - SETFCAP
           script: |
             #!/usr/bin/env bash
             set -euo pipefail
 
+            export STORAGE_DRIVER=vfs
             IMAGE_FULL="$(params.IMAGE)"
             IMAGE_BASE=$(echo "${IMAGE_FULL}" | sed 's/:[^/:]*$//')
             IMAGE_TAG="${IMAGE_FULL##*:}"
@@ -296,12 +299,14 @@ spec:
 
             echo "=== Building single-arch linux/amd64 (FBC base images may lack other arches; IIB generates multi-arch index at release time) ==="
             buildah build \
+              --storage-driver vfs \
               --platform linux/amd64 \
               --authfile "${AUTHFILE}" \
               -t "${IMAGE_FULL}" \
               -f "${DOCKERFILE}" .
 
             buildah push \
+              --storage-driver vfs \
               --authfile "${AUTHFILE}" \
               --digestfile /tmp/image-digest.txt \
               "${IMAGE_FULL}"


### PR DESCRIPTION
## Summary
Our custom bundle/catalog pipelines build the image directly inside the Tekton pod. The pod's appstudio-pipelines-scc forbids privileged: true, which our build-and-push step was using causing pod admission to fail immediately.

What changed:
Removed privileged: true
Added capabilities: add: [SETFCAP], same capability Konflux's own buildah task uses
Switched buildah's storage driver from overlay (needs privileged mounts) to vfs (plain file copies, no special privileges needed)

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [X] CI/CD improvement
- [ ] Refactoring

## Testing
- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)
