### PR TITLE
fix(imagebuild): route all completion paths through updateStatus

### DIFF
--- a/internal/controller/imagebuild/controller.go
+++ b/internal/controller/imagebuild/controller.go
@@ -758,22 +758,17 @@ func (r *ImageBuildReconciler) checkBuildProgress(
 			return ctrl.Result{}, err
 		}
 
-		// Re-read for metrics and post-completion work
-		fresh := &automotivev1alpha1.ImageBuild{}
-		if err := r.Get(ctx, types.NamespacedName{Name: imageBuild.Name, Namespace: imageBuild.Namespace}, fresh); err != nil {
-			return ctrl.Result{}, err
-		}
-		recordBuildMetrics(fresh, pipelineRun, buildStatusSuccess)
-		if fresh.Spec.IsFlashEnabled() {
-			r.recordPipelineFlashMetrics(ctx, fresh, pipelineRun, buildStatusSuccess)
+		recordBuildMetrics(imageBuild, pipelineRun, buildStatusSuccess)
+		if imageBuild.Spec.IsFlashEnabled() {
+			r.recordPipelineFlashMetrics(ctx, imageBuild, pipelineRun, buildStatusSuccess)
 		}
 
 		// Cleanup transient secrets
 		cleanupErr := r.cleanupTransientSecrets(ctx, imageBuild, r.Log)
 
 		// Write lease back to workspace for reuse by subsequent builds
-		if fresh.Spec.Workspace != "" && fresh.Status.LeaseID != "" {
-			r.updateWorkspaceLease(ctx, fresh, log)
+		if imageBuild.Spec.Workspace != "" && imageBuild.Status.LeaseID != "" {
+			r.updateWorkspaceLease(ctx, imageBuild, log)
 		}
 
 		if cleanupErr != nil {
@@ -2671,6 +2666,7 @@ func (r *ImageBuildReconciler) updateStatus(
 	if err := r.Status().Patch(ctx, fresh, patch); err != nil {
 		return err
 	}
+	fresh.DeepCopyInto(imageBuild)
 	adjustActiveBuildsGauge(oldPhase, phase)
 	if oldPhase != phase || oldMessage != message {
 		r.emitEventf(

--- a/internal/controller/imagebuild/controller.go
+++ b/internal/controller/imagebuild/controller.go
@@ -737,58 +737,36 @@ func (r *ImageBuildReconciler) checkBuildProgress(
 	}
 
 	if isPipelineRunSuccessful(pipelineRun) {
+		aibImageUsed, builderImageUsed := extractProvenance(pipelineRun, imageBuild.Spec.GetAIBImage())
+		leaseID := ""
+		if imageBuild.Spec.IsFlashEnabled() {
+			leaseID = extractLeaseID(pipelineRun)
+		}
+
+		msg := "Build completed successfully"
+		if imageBuild.Spec.IsFlashEnabled() {
+			msg = "Build and flash completed successfully"
+		}
+
+		if err := r.updateStatus(ctx, imageBuild, phaseCompleted, msg, func(ib *automotivev1alpha1.ImageBuild) {
+			ib.Status.AIBImageUsed = aibImageUsed
+			ib.Status.BuilderImageUsed = builderImageUsed
+			if leaseID != "" {
+				ib.Status.LeaseID = leaseID
+			}
+		}); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		// Re-read for metrics and post-completion work
 		fresh := &automotivev1alpha1.ImageBuild{}
-		nsName := types.NamespacedName{Name: imageBuild.Name, Namespace: imageBuild.Namespace}
-		if err := r.Get(ctx, nsName, fresh); err != nil {
+		if err := r.Get(ctx, types.NamespacedName{Name: imageBuild.Name, Namespace: imageBuild.Namespace}, fresh); err != nil {
 			return ctrl.Result{}, err
 		}
-
-		patch := client.MergeFrom(fresh.DeepCopy())
-
-		// Extract and populate build provenance
-		aibImageUsed, builderImageUsed := extractProvenance(pipelineRun, fresh.Spec.GetAIBImage())
-		fresh.Status.AIBImageUsed = aibImageUsed
-		fresh.Status.BuilderImageUsed = builderImageUsed
-
-		// Extract lease ID if flash was enabled
-		if fresh.Spec.IsFlashEnabled() {
-			fresh.Status.LeaseID = extractLeaseID(pipelineRun)
-		}
-
-		// Pipeline includes push-disk-artifact and flash-image tasks (when enabled)
-		// Pipeline completion means everything succeeded
-		fresh.Status.Phase = phaseCompleted
-		if fresh.Spec.IsFlashEnabled() {
-			fresh.Status.Message = "Build and flash completed successfully"
-		} else {
-			fresh.Status.Message = "Build completed successfully"
-		}
-		if fresh.Status.CompletionTime == nil {
-			now := metav1.Now()
-			fresh.Status.CompletionTime = &now
-		}
-
-		if err := r.Status().Patch(ctx, fresh, patch); err != nil {
-			log.Error(err, "Failed to patch status to Completed")
-			return ctrl.Result{}, err
-		}
-		adjustActiveBuildsGauge(phaseBuilding, phaseCompleted)
 		recordBuildMetrics(fresh, pipelineRun, buildStatusSuccess)
 		if fresh.Spec.IsFlashEnabled() {
 			r.recordPipelineFlashMetrics(ctx, fresh, pipelineRun, buildStatusSuccess)
 		}
-
-		r.emitEventf(
-			fresh,
-			corev1.EventTypeNormal,
-			eventReasonBuildCompleted,
-			"Build completed successfully: mode=%s target=%s arch=%s toDisk=%t pipelineRun=%s",
-			fresh.Spec.GetMode(),
-			fresh.Spec.GetTarget(),
-			fresh.Spec.Architecture,
-			fresh.Spec.GetBuildDiskImage(),
-			pipelineRun.Name,
-		)
 
 		// Cleanup transient secrets
 		cleanupErr := r.cleanupTransientSecrets(ctx, imageBuild, r.Log)
@@ -1857,40 +1835,21 @@ func (r *ImageBuildReconciler) handlePushingState(
 	// Push completed - cleanup transient secrets and update status
 	cleanupErr := r.cleanupTransientSecrets(ctx, imageBuild, log)
 
-	fresh := &automotivev1alpha1.ImageBuild{}
-	if err := r.Get(ctx, types.NamespacedName{Name: imageBuild.Name, Namespace: imageBuild.Namespace}, fresh); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	patch := client.MergeFrom(fresh.DeepCopy())
-
 	if isTaskRunSuccessful(taskRun) {
-		// Check if flash is enabled
-		if fresh.Spec.IsFlashEnabled() {
-			fresh.Status.Phase = "Flashing"
-			fresh.Status.Message = "Flashing image to device"
-			if err := r.Status().Patch(ctx, fresh, patch); err != nil {
-				log.Error(err, "Failed to patch status to Flashing")
+		if imageBuild.Spec.IsFlashEnabled() {
+			if err := r.updateStatus(ctx, imageBuild, "Flashing", "Flashing image to device"); err != nil {
 				return ctrl.Result{}, err
 			}
 			return ctrl.Result{Requeue: true}, nil
 		}
 
-		fresh.Status.Phase = phaseCompleted
-		fresh.Status.Message = "Build and push completed successfully"
+		if err := r.updateStatus(ctx, imageBuild, phaseCompleted, "Build and push completed successfully"); err != nil {
+			return ctrl.Result{}, err
+		}
 	} else {
-		fresh.Status.Phase = phaseFailed
-		fresh.Status.Message = "Push to registry failed"
-	}
-
-	if fresh.Status.CompletionTime == nil {
-		now := metav1.Now()
-		fresh.Status.CompletionTime = &now
-	}
-
-	if err := r.Status().Patch(ctx, fresh, patch); err != nil {
-		log.Error(err, "Failed to patch status after push completion")
-		return ctrl.Result{}, err
+		if err := r.updateStatus(ctx, imageBuild, phaseFailed, "Push to registry failed"); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	if cleanupErr != nil {
@@ -1948,35 +1907,16 @@ func (r *ImageBuildReconciler) handleFlashingState(
 	// Flash completed - cleanup and update status
 	cleanupErr := r.cleanupTransientSecrets(ctx, imageBuild, log)
 
-	fresh := &automotivev1alpha1.ImageBuild{}
-	if err := r.Get(ctx, types.NamespacedName{Name: imageBuild.Name, Namespace: imageBuild.Namespace}, fresh); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	patch := client.MergeFrom(fresh.DeepCopy())
-
 	flashSucceeded := isTaskRunSuccessful(taskRun)
 	if flashSucceeded {
-		fresh.Status.Phase = phaseCompleted
-		fresh.Status.Message = "Build, push, and flash completed successfully"
-	} else {
-		fresh.Status.Phase = phaseFailed
-		fresh.Status.Message = taskRunFailureMessage(taskRun, "Flash to device failed")
-	}
-
-	if fresh.Status.CompletionTime == nil {
-		now := metav1.Now()
-		fresh.Status.CompletionTime = &now
-	}
-
-	if err := r.Status().Patch(ctx, fresh, patch); err != nil {
-		log.Error(err, "Failed to patch status after flash completion")
-		return ctrl.Result{}, err
-	}
-
-	if flashSucceeded {
+		if err := r.updateStatus(ctx, imageBuild, phaseCompleted, "Build, push, and flash completed successfully"); err != nil {
+			return ctrl.Result{}, err
+		}
 		recordFlashMetrics(imageBuild, taskRun, buildStatusSuccess)
 	} else {
+		if err := r.updateStatus(ctx, imageBuild, phaseFailed, taskRunFailureMessage(taskRun, "Flash to device failed")); err != nil {
+			return ctrl.Result{}, err
+		}
 		recordFlashMetrics(imageBuild, taskRun, buildStatusFailure)
 	}
 
@@ -2686,6 +2626,7 @@ func (r *ImageBuildReconciler) updateStatus(
 	ctx context.Context,
 	imageBuild *automotivev1alpha1.ImageBuild,
 	phase, message string,
+	mutations ...func(*automotivev1alpha1.ImageBuild),
 ) error {
 	fresh := &automotivev1alpha1.ImageBuild{}
 	if err := r.Get(ctx, types.NamespacedName{
@@ -2705,6 +2646,10 @@ func (r *ImageBuildReconciler) updateStatus(
 	patch := client.MergeFrom(fresh.DeepCopy())
 	oldPhase := fresh.Status.Phase
 	oldMessage := fresh.Status.Message
+
+	for _, fn := range mutations {
+		fn(fresh)
+	}
 
 	if phase == automotivev1alpha1.ImageBuildPhaseExpired {
 		fresh.Status.PreviousPhase = fresh.Status.Phase

--- a/internal/controller/imagebuild/controller_test.go
+++ b/internal/controller/imagebuild/controller_test.go
@@ -14,8 +14,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	knativev1 "knative.dev/pkg/apis/duck/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -1006,5 +1008,136 @@ func TestGetOCIRepoImages(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func newTestReconciler(objs ...client.Object) *ImageBuildReconciler {
+	scheme := newTestSchemeWithTekton()
+	builder := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		WithStatusSubresource(objs...)
+	return &ImageBuildReconciler{
+		Client:   builder.Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(100),
+	}
+}
+
+func TestUpdateStatusSetsConditionsOnCompleted(t *testing.T) {
+	ib := &automotivev1alpha1.ImageBuild{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-build", Namespace: "test-ns"},
+		Status:     automotivev1alpha1.ImageBuildStatus{Phase: phaseBuilding},
+	}
+	r := newTestReconciler(ib)
+
+	if err := r.updateStatus(context.Background(), ib, phaseCompleted, "Build done"); err != nil {
+		t.Fatalf("updateStatus() error: %v", err)
+	}
+
+	fresh := &automotivev1alpha1.ImageBuild{}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "test-build", Namespace: "test-ns"}, fresh); err != nil {
+		t.Fatalf("Get() error: %v", err)
+	}
+
+	ready := meta.FindStatusCondition(fresh.Status.Conditions, automotivev1alpha1.ImageBuildConditionReady)
+	if ready == nil {
+		t.Fatal("Ready condition not set")
+	}
+	if ready.Status != metav1.ConditionTrue {
+		t.Errorf("Ready = %v, want True", ready.Status)
+	}
+
+	progressing := meta.FindStatusCondition(fresh.Status.Conditions, automotivev1alpha1.ImageBuildConditionProgressing)
+	if progressing == nil {
+		t.Fatal("Progressing condition not set")
+	}
+	if progressing.Status != metav1.ConditionFalse {
+		t.Errorf("Progressing = %v, want False", progressing.Status)
+	}
+}
+
+func TestUpdateStatusGuardsCancelledPhase(t *testing.T) {
+	ib := &automotivev1alpha1.ImageBuild{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-build", Namespace: "test-ns"},
+		Status:     automotivev1alpha1.ImageBuildStatus{Phase: phaseCancelled, Message: "Cancelled by user"},
+	}
+	r := newTestReconciler(ib)
+
+	if err := r.updateStatus(context.Background(), ib, phaseCompleted, "Build done"); err != nil {
+		t.Fatalf("updateStatus() error: %v", err)
+	}
+
+	fresh := &automotivev1alpha1.ImageBuild{}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "test-build", Namespace: "test-ns"}, fresh); err != nil {
+		t.Fatalf("Get() error: %v", err)
+	}
+
+	if fresh.Status.Phase != phaseCancelled {
+		t.Errorf("Phase = %q, want %q (guard should prevent overwrite)", fresh.Status.Phase, phaseCancelled)
+	}
+	if fresh.Status.Message != "Cancelled by user" {
+		t.Errorf("Message = %q, want %q", fresh.Status.Message, "Cancelled by user")
+	}
+}
+
+func TestUpdateStatusAppliesMutations(t *testing.T) {
+	ib := &automotivev1alpha1.ImageBuild{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-build", Namespace: "test-ns"},
+		Status:     automotivev1alpha1.ImageBuildStatus{Phase: phaseBuilding},
+	}
+	r := newTestReconciler(ib)
+
+	err := r.updateStatus(context.Background(), ib, phaseCompleted, "Build done", func(ib *automotivev1alpha1.ImageBuild) {
+		ib.Status.AIBImageUsed = "quay.io/aib:v1"
+		ib.Status.BuilderImageUsed = "quay.io/builder:v2"
+		ib.Status.LeaseID = "lease-123"
+	})
+	if err != nil {
+		t.Fatalf("updateStatus() error: %v", err)
+	}
+
+	fresh := &automotivev1alpha1.ImageBuild{}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "test-build", Namespace: "test-ns"}, fresh); err != nil {
+		t.Fatalf("Get() error: %v", err)
+	}
+
+	if fresh.Status.AIBImageUsed != "quay.io/aib:v1" {
+		t.Errorf("AIBImageUsed = %q, want %q", fresh.Status.AIBImageUsed, "quay.io/aib:v1")
+	}
+	if fresh.Status.BuilderImageUsed != "quay.io/builder:v2" {
+		t.Errorf("BuilderImageUsed = %q, want %q", fresh.Status.BuilderImageUsed, "quay.io/builder:v2")
+	}
+	if fresh.Status.LeaseID != "lease-123" {
+		t.Errorf("LeaseID = %q, want %q", fresh.Status.LeaseID, "lease-123")
+	}
+	if fresh.Status.Phase != phaseCompleted {
+		t.Errorf("Phase = %q, want %q", fresh.Status.Phase, phaseCompleted)
+	}
+
+	ready := meta.FindStatusCondition(fresh.Status.Conditions, automotivev1alpha1.ImageBuildConditionReady)
+	if ready == nil || ready.Status != metav1.ConditionTrue {
+		t.Error("Ready condition should be True after Completed with mutations")
+	}
+}
+
+func TestUpdateStatusSetsCompletionTime(t *testing.T) {
+	ib := &automotivev1alpha1.ImageBuild{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-build", Namespace: "test-ns"},
+		Status:     automotivev1alpha1.ImageBuildStatus{Phase: phaseBuilding},
+	}
+	r := newTestReconciler(ib)
+
+	if err := r.updateStatus(context.Background(), ib, phaseCompleted, "Build done"); err != nil {
+		t.Fatalf("updateStatus() error: %v", err)
+	}
+
+	fresh := &automotivev1alpha1.ImageBuild{}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "test-build", Namespace: "test-ns"}, fresh); err != nil {
+		t.Fatalf("Get() error: %v", err)
+	}
+
+	if fresh.Status.CompletionTime == nil {
+		t.Error("CompletionTime should be set on terminal phase")
 	}
 }


### PR DESCRIPTION
checkBuildProgress, handlePushingState, and handleFlashingState bypassed updateStatus and patched status directly. This caused completed builds to keep stale Progressing=True/Ready=False conditions, allowed cancelled builds to be overwritten by late pipeline completions, and skipped PhaseChanged/BuildCompleted events and gauge adjustments on push/flash paths.

Add variadic mutation callbacks to updateStatus so callers can inject provenance fields (AIBImageUsed, BuilderImageUsed, LeaseID) while still getting the cancelled/expired guard, condition-setting, gauge adjustment, and event emission uniformly.

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [X] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ImageBuild state transitions for pushing and flashing, with correct success/failure handling and user-facing messages.
  - Refreshed terminal completion logic to consistently set phase/conditions and completion timestamps.
  - Preserved and recorded provenance details (image usage) and lease information when flash is enabled.
  - Ensured build/flash metrics reflect the latest updated status.

- **Tests**
  - Added unit test coverage for terminal condition updates, cancellation protection, mutation-based status enrichment, and completion timestamp behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->