### PR TITLE
fix: use nointeractive when logging in

### DIFF
--- a/internal/common/tasks/scripts/flash_image.sh
+++ b/internal/common/tasks/scripts/flash_image.sh
@@ -15,10 +15,15 @@ if [[ ! -f "${JMP_CLIENT_CONFIG}" ]]; then
     exit 1
 fi
 
+# Copy config to writable path so jmp can persist refreshed tokens
+cp "${JMP_CLIENT_CONFIG}" /tmp/client.yaml
+export JMP_CLIENT_CONFIG=/tmp/client.yaml
+export JMP_CLIENT_CONFIG_HOME=/tmp
+
 echo "Using client config: ${JMP_CLIENT_CONFIG}"
 
 echo "refreshing jumpstarter token"
-if ! jmp login --client-config "${JMP_CLIENT_CONFIG}" 2>&1; then
+if ! timeout 30 jmp login --nointeractive --client-config "${JMP_CLIENT_CONFIG}" 2>&1; then
     echo "WARNING: jmp login failed, continuing with existing credentials"
 fi
 


### PR DESCRIPTION
When flashing and refreshing the token, use --nointeractive to ensure there is no OIDC callback prompt.

Also, change the location of the config so saving the refresh token doesn't fail on a permission error.

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [X] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image flashing reliability by using a writable temporary location for client configuration.
  * Added a noninteractive timeout to token refresh, while preserving existing credentials if refresh fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->