### PR TITLE
fix: improve concurrency and cache digests

### DIFF
--- a/internal/controller/imagebuild/controller.go
+++ b/internal/controller/imagebuild/controller.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
@@ -41,8 +42,11 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/yaml"
 )
 
@@ -179,11 +183,12 @@ func (r *ImageBuildReconciler) buildLogger(imageBuild *automotivev1alpha1.ImageB
 //nolint:revive // Name follows Kubebuilder convention for reconcilers
 type ImageBuildReconciler struct {
 	client.Client
-	APIReader  client.Reader
-	Scheme     *runtime.Scheme
-	Log        logr.Logger
-	Recorder   record.EventRecorder
-	RestConfig *rest.Config
+	APIReader       client.Reader
+	Scheme          *runtime.Scheme
+	Log             logr.Logger
+	Recorder        record.EventRecorder
+	RestConfig      *rest.Config
+	verifiedBundles sync.Map
 }
 
 // +kubebuilder:rbac:groups=automotive.sdv.cloud.redhat.com,namespace=system,resources=workspaces,verbs=get;update
@@ -894,12 +899,17 @@ func (r *ImageBuildReconciler) createBuildTaskRun(
 			}
 
 			if operatorConfig.Spec.OSBuilds.TaskBundleVerify {
-				pubKeyPEM, err := bundleverify.FetchCosignPublicKey(ctx, r.Client, operatorConfig.Spec.OSBuilds.TaskBundleCosignKeyRef, controllerutils.OperatorNamespace())
-				if err != nil {
-					return fmt.Errorf("secureBuild: cosign key is unavailable: %w: %w", err, errTerminalConfig)
-				}
-				if err := bundleverify.VerifyBundle(ctx, ref, pubKeyPEM); err != nil {
-					return fmt.Errorf("task bundle signature verification failed: %w: %w", err, errTerminalConfig)
+				if _, ok := r.verifiedBundles.Load(ref); !ok {
+					verifyCtx, verifyCancel := context.WithTimeout(ctx, 30*time.Second)
+					defer verifyCancel()
+					pubKeyPEM, err := bundleverify.FetchCosignPublicKey(verifyCtx, r.Client, operatorConfig.Spec.OSBuilds.TaskBundleCosignKeyRef, controllerutils.OperatorNamespace())
+					if err != nil {
+						return fmt.Errorf("secureBuild: cosign key is unavailable: %w: %w", err, errTerminalConfig)
+					}
+					if err := bundleverify.VerifyBundle(verifyCtx, ref, pubKeyPEM); err != nil {
+						return fmt.Errorf("task bundle signature verification failed: %w: %w", err, errTerminalConfig)
+					}
+					r.verifiedBundles.Store(ref, struct{}{})
 				}
 			}
 
@@ -2155,17 +2165,17 @@ func (r *ImageBuildReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return fmt.Errorf("failed to register metrics seeder: %w", err)
 	}
 
-	builder := ctrl.NewControllerManagedBy(mgr).
+	b := ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 4}).
 		For(&automotivev1alpha1.ImageBuild{}).
 		Owns(&tektonv1.PipelineRun{}).
 		Owns(&tektonv1.TaskRun{}).
 		Owns(&corev1.Pod{}).
 		Owns(&corev1.PersistentVolumeClaim{}).
 		Owns(&corev1.Service{}).
-		Owns(&corev1.ConfigMap{}).
-		Owns(&corev1.Secret{})
+		Owns(&corev1.Secret{}, builder.WithPredicates(predicate.GenerationChangedPredicate{}))
 
-	return builder.Complete(r)
+	return b.Complete(r)
 }
 
 func isTaskRunCompleted(taskRun *tektonv1.TaskRun) bool {

--- a/internal/controller/imagebuild/controller_test.go
+++ b/internal/controller/imagebuild/controller_test.go
@@ -1141,3 +1141,70 @@ func TestUpdateStatusSetsCompletionTime(t *testing.T) {
 		t.Error("CompletionTime should be set on terminal phase")
 	}
 }
+
+func TestVerifiedBundlesCacheHitSkipsLookup(t *testing.T) {
+	const ref = "registry.example.com/bundle@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+
+	scheme := newTestSchemeWithTekton()
+	getCalled := false
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*corev1.ConfigMap); ok && key.Name == "cosign-pub-key" {
+					getCalled = true
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	r := &ImageBuildReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+	}
+	r.verifiedBundles.Store(ref, struct{}{})
+
+	if _, ok := r.verifiedBundles.Load(ref); !ok {
+		t.Fatal("expected cache hit for pre-stored digest ref")
+	}
+	if getCalled {
+		t.Error("cache hit should not trigger cosign key lookup")
+	}
+}
+
+func TestVerifiedBundlesCacheMissAndFailureNotCached(t *testing.T) {
+	const ref = "registry.example.com/bundle@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+
+	r := &ImageBuildReconciler{}
+
+	if _, ok := r.verifiedBundles.Load(ref); ok {
+		t.Fatal("expected cache miss for unknown digest ref")
+	}
+
+	r.verifiedBundles.Store(ref, struct{}{})
+	if _, ok := r.verifiedBundles.Load(ref); !ok {
+		t.Fatal("expected cache hit after Store")
+	}
+
+	const failedRef = "registry.example.com/bundle@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+	if _, ok := r.verifiedBundles.Load(failedRef); ok {
+		t.Fatal("never-stored ref should not be in cache (simulates failed verification not being cached)")
+	}
+}
+
+func TestVerifiedBundlesCacheKeyIsolation(t *testing.T) {
+	r := &ImageBuildReconciler{}
+
+	refA := "registry.example.com/bundle@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	refB := "registry.example.com/bundle@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	r.verifiedBundles.Store(refA, struct{}{})
+
+	if _, ok := r.verifiedBundles.Load(refA); !ok {
+		t.Error("refA should be cached")
+	}
+	if _, ok := r.verifiedBundles.Load(refB); ok {
+		t.Error("refB should not be cached — different digest means different bundle")
+	}
+}


### PR DESCRIPTION
Increase default concurrency to avoid getting blocked on i/o.

Additionally add a timeout to avoid verification blocking for too long.

Drop CM watch, as we do not need to reconcile it.

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [X] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved secure build processing by reusing successful bundle verification results.
  * Increased controller reconciliation concurrency for faster processing.

* **Reliability**
  * Refined reconciliation triggers to reduce unnecessary processing when secrets change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->