### PR TITLE
fix: backport action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -30,6 +30,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           token: ${{ steps.app-token.outputs.token }}
+          # Safe: workflow only runs on merged PRs (merge_commit_sha), not raw fork code
+          allow-unsafe-pr-checkout: true
 
       - name: Create backport PRs
         uses: korthout/backport-action@v4


### PR DESCRIPTION
Backport action stopped working on forks, enable allow-unsafe-pr-checkout since the code is merged anyway

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [X] CI/CD improvement
- [ ] Refactoring

## Testing
- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the backport workflow’s checkout behavior for merged pull requests to ensure it operates on the finalized merged result.
  * Added an explicit safeguard and clarification in the workflow to reduce the chance of pulling unreviewed fork code during backport processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->