### PR TITLE
fix: invalidate cached server URL when Jumpstarter endpoint changes

### DIFF
--- a/cmd/caib/config/config.go
+++ b/cmd/caib/config/config.go
@@ -28,7 +28,8 @@ var healthHTTPClient *http.Client
 
 // CLIConfig holds saved CLI settings.
 type CLIConfig struct {
-	ServerURL string `json:"server_url"`
+	ServerURL           string `json:"server_url"`
+	DerivedFromEndpoint string `json:"derived_from_endpoint,omitempty"`
 }
 
 // DefaultServer returns the effective default server URL: CAIB_SERVER env, then saved config.
@@ -47,12 +48,34 @@ func DefaultServer() string {
 }
 
 // DefaultServerWithDerive returns the effective default server URL.
-// Resolution order: CAIB_SERVER env → saved config → Jumpstarter derivation.
+// Resolution order: CAIB_SERVER env → saved config (with staleness check) → Jumpstarter derivation.
+// When the saved URL was auto-derived from a Jumpstarter endpoint that no longer matches
+// the current Jumpstarter config, the cached value is skipped and re-derived.
 func DefaultServerWithDerive() string {
-	if s := DefaultServer(); s != "" {
+	if s := strings.TrimSpace(os.Getenv("CAIB_SERVER")); s != "" {
 		return s
 	}
+
+	cfg, err := Read()
+	if err == nil && cfg != nil {
+		if s := strings.TrimSpace(cfg.ServerURL); s != "" {
+			if !IsDerivedAndStale(cfg) {
+				return s
+			}
+		}
+	}
+
 	return DeriveServerFromJumpstarter()
+}
+
+// IsDerivedAndStale returns true when the saved config was auto-derived from a
+// Jumpstarter endpoint that no longer matches the current Jumpstarter client config.
+// Manually-set URLs (DerivedFromEndpoint == "") are never considered stale.
+func IsDerivedAndStale(cfg *CLIConfig) bool {
+	if cfg.DerivedFromEndpoint == "" {
+		return false
+	}
+	return JumpstarterEndpoint() != cfg.DerivedFromEndpoint
 }
 
 // JumpstarterEndpoint reads the default Jumpstarter client config files and returns
@@ -120,6 +143,7 @@ func DeriveServerFromJumpstarter() string {
 	if grpcEndpoint == "" {
 		return ""
 	}
+	rawEndpoint := grpcEndpoint
 
 	// Derive Build API URL from gRPC endpoint:
 	// grpc.jumpstarter-lab.apps.example.com:443 → https://ado-build-api-<ns>.apps.example.com
@@ -165,7 +189,7 @@ func DeriveServerFromJumpstarter() string {
 		}
 
 		fmt.Fprintf(os.Stderr, "Using Build API server derived from Jumpstarter config: %s\n", apiURL)
-		if err := SaveServerURL(apiURL); err != nil {
+		if err := saveDerivedServerURL(apiURL, rawEndpoint); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: could not save derived server URL to config: %v\n", err)
 		}
 		return apiURL
@@ -196,7 +220,23 @@ func Read() (*CLIConfig, error) {
 }
 
 // SaveServerURL writes the given server URL to the local config file.
+// This is the manual-set path (e.g. caib login <url>) — clears DerivedFromEndpoint
+// so the URL is never auto-invalidated.
 func SaveServerURL(serverURL string) error {
+	return saveConfig(&CLIConfig{ServerURL: strings.TrimSpace(serverURL)})
+}
+
+// saveDerivedServerURL saves a server URL that was auto-derived from a Jumpstarter endpoint.
+// The source endpoint is recorded so the cached URL can be invalidated when the
+// Jumpstarter config changes.
+func saveDerivedServerURL(serverURL, sourceEndpoint string) error {
+	return saveConfig(&CLIConfig{
+		ServerURL:           strings.TrimSpace(serverURL),
+		DerivedFromEndpoint: strings.TrimSpace(sourceEndpoint),
+	})
+}
+
+func saveConfig(cfg *CLIConfig) error {
 	path, err := configFilePath()
 	if err != nil {
 		return err
@@ -204,7 +244,6 @@ func SaveServerURL(serverURL string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 		return err
 	}
-	cfg := &CLIConfig{ServerURL: strings.TrimSpace(serverURL)}
 	data, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {
 		return err

--- a/cmd/caib/config/config_test.go
+++ b/cmd/caib/config/config_test.go
@@ -85,11 +85,12 @@ var _ = Describe("DeriveServerFromJumpstarter", func() {
 		Expect(result).To(Equal(expected))
 		Expect(requestedURL).To(Equal(expected + "/v1/healthz"))
 
-		// Verify it was persisted
+		// Verify it was persisted with source endpoint
 		cfg, err := Read()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(cfg).NotTo(BeNil())
 		Expect(cfg.ServerURL).To(Equal(expected))
+		Expect(cfg.DerivedFromEndpoint).To(Equal("grpc.lab.apps.example.com:443"))
 	})
 
 	It("uses CAIB_BUILD_API_NAMESPACE when set", func() {
@@ -257,7 +258,7 @@ var _ = Describe("DefaultServerWithDerive", func() {
 		Expect(called).To(BeFalse(), "derivation should not be attempted when CAIB_SERVER is set")
 	})
 
-	It("returns saved config when CAIB_SERVER is empty, without calling derive", func() {
+	It("returns manually-saved config when CAIB_SERVER is empty, without calling derive", func() {
 		Expect(SaveServerURL("https://from-config.example.com")).To(Succeed())
 		writeJumpstarterConfig(tempDir, "grpc.lab.apps.example.com:443")
 
@@ -274,6 +275,94 @@ var _ = Describe("DefaultServerWithDerive", func() {
 
 		Expect(DefaultServerWithDerive()).To(Equal("https://from-config.example.com"))
 		Expect(called).To(BeFalse(), "derivation should not be attempted when saved config exists")
+	})
+
+	It("returns derived config when Jumpstarter endpoint still matches (cache hit)", func() {
+		// Simulate a previously-derived config that matches current Jumpstarter endpoint
+		Expect(saveConfig(&CLIConfig{
+			ServerURL:           "https://ado-build-api-automotive-dev-operator-system.apps.example.com",
+			DerivedFromEndpoint: "grpc.lab.apps.example.com:443",
+		})).To(Succeed())
+		writeJumpstarterConfig(tempDir, "grpc.lab.apps.example.com:443")
+
+		called := false
+		healthHTTPClient = &http.Client{
+			Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+				called = true
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("")),
+				}, nil
+			}),
+		}
+
+		Expect(DefaultServerWithDerive()).To(Equal("https://ado-build-api-automotive-dev-operator-system.apps.example.com"))
+		Expect(called).To(BeFalse(), "should use cached URL when Jumpstarter endpoint matches")
+	})
+
+	It("invalidates derived config when Jumpstarter endpoint changes", func() {
+		// Simulate a derived config from old cluster
+		Expect(saveConfig(&CLIConfig{
+			ServerURL:           "https://ado-build-api-automotive-dev-operator-system.apps.old-cluster.com",
+			DerivedFromEndpoint: "grpc.lab.apps.old-cluster.com:443",
+		})).To(Succeed())
+		// Current Jumpstarter config points to new cluster
+		writeJumpstarterConfig(tempDir, "grpc.lab.apps.new-cluster.com:443")
+
+		healthHTTPClient = &http.Client{
+			Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("")),
+				}, nil
+			}),
+		}
+
+		result := DefaultServerWithDerive()
+		Expect(result).To(Equal("https://ado-build-api-automotive-dev-operator-system.apps.new-cluster.com"))
+
+		// Verify new derivation was persisted with new source
+		cfg, err := Read()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.DerivedFromEndpoint).To(Equal("grpc.lab.apps.new-cluster.com:443"))
+	})
+
+	It("does not invalidate manually-set config even when Jumpstarter endpoint changes", func() {
+		// Manually set (no DerivedFromEndpoint)
+		Expect(SaveServerURL("https://manual-server.example.com")).To(Succeed())
+		writeJumpstarterConfig(tempDir, "grpc.lab.apps.different-cluster.com:443")
+
+		called := false
+		healthHTTPClient = &http.Client{
+			Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+				called = true
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("")),
+				}, nil
+			}),
+		}
+
+		Expect(DefaultServerWithDerive()).To(Equal("https://manual-server.example.com"))
+		Expect(called).To(BeFalse(), "manually-set URL should never be invalidated")
+	})
+
+	It("invalidates derived config when Jumpstarter config is removed", func() {
+		// Derived URL from a cluster that no longer has Jumpstarter config
+		Expect(saveConfig(&CLIConfig{
+			ServerURL:           "https://ado-build-api-automotive-dev-operator-system.apps.old-cluster.com",
+			DerivedFromEndpoint: "grpc.lab.apps.old-cluster.com:443",
+		})).To(Succeed())
+		// No Jumpstarter config written - simulates deletion/corruption
+
+		healthHTTPClient = &http.Client{
+			Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+				return nil, fmt.Errorf("connection refused")
+			}),
+		}
+
+		// Should not return stale URL; derivation runs but fails → empty
+		Expect(DefaultServerWithDerive()).To(BeEmpty())
 	})
 
 	It("falls through to Jumpstarter derivation when env and config are empty", func() {

--- a/cmd/caib/status.go
+++ b/cmd/caib/status.go
@@ -101,7 +101,9 @@ func resolveServerWithSource() (string, string) {
 	cfg, err := config.Read()
 	if err == nil && cfg != nil {
 		if s := strings.TrimSpace(cfg.ServerURL); s != "" {
-			return s, "saved config (~/.config/caib/cli.json)"
+			if !config.IsDerivedAndStale(cfg) {
+				return s, "saved config (~/.config/caib/cli.json)"
+			}
 		}
 	}
 


### PR DESCRIPTION
When caib auto-derives the Build API URL from the Jumpstarter gRPC endpoint, it saves the result to ~/.config/caib/cli.json. Previously, this cached URL was never invalidated — switching Jumpstarter clients caused caib to connect to the old cluster's Build API, triggering OIDC login prompts for the wrong instance.

Add a DerivedFromEndpoint field to CLIConfig that records which Jumpstarter endpoint produced the cached URL. On resolution, DefaultServerWithDerive() compares the current Jumpstarter endpoint against the saved source a mismatch triggers re-derivation. Manually set URLs have no DerivedFromEndpoint
and are never auto-invalidated.

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [X] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically derives and caches the server URL from the current Jumpstarter endpoint.
  * Refreshes cached derived URLs when the Jumpstarter endpoint changes.
  * Preserves manually configured server URLs without replacing them automatically.

* **Bug Fixes**
  * Prevents stale automatically derived server URLs from being used.
  * Ensures server status resolution uses the current valid configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->