### PR TITLE
fix: add labels to Dockerfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,13 @@ jobs:
         steps:
             - uses: actions/checkout@v7
 
+            - name: Read operator version
+              run: |
+                  set -euo pipefail
+                  v=$(cat VERSION)
+                  [ -n "$v" ] || { echo "::error::VERSION file is empty"; exit 1; }
+                  echo "OPERATOR_VERSION=$v" >> "$GITHUB_ENV"
+
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v4
 
@@ -46,6 +53,8 @@ jobs:
                   tags: |
                       ${{ env.OPERATOR_IMAGE }}:${{ env.VERSION }}-arm64
                       ${{ env.OPERATOR_IMAGE }}:latest-arm64
+                  build-args: |
+                      VERSION=${{ env.OPERATOR_VERSION }}
                   cache-from: type=gha
                   cache-to: type=gha,mode=max
 
@@ -67,6 +76,13 @@ jobs:
         steps:
             - uses: actions/checkout@v7
 
+            - name: Read operator version
+              run: |
+                  set -euo pipefail
+                  v=$(cat VERSION)
+                  [ -n "$v" ] || { echo "::error::VERSION file is empty"; exit 1; }
+                  echo "OPERATOR_VERSION=$v" >> "$GITHUB_ENV"
+
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v4
 
@@ -87,6 +103,8 @@ jobs:
                   tags: |
                       ${{ env.OPERATOR_IMAGE }}:${{ env.VERSION }}-amd64
                       ${{ env.OPERATOR_IMAGE }}:latest-amd64
+                  build-args: |
+                      VERSION=${{ env.OPERATOR_VERSION }}
                   cache-from: type=gha
                   cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ ARG TARGETARCH
 
 WORKDIR /workspace
 
-# Copy files as root first
 COPY go.mod go.mod
 COPY go.sum go.sum
 COPY vendor/ vendor/
@@ -15,7 +14,6 @@ COPY cmd/init-secrets/main.go cmd/init-secrets/main.go
 COPY api/ api/
 COPY internal/ internal/
 
-# Set ownership and switch to non-root user (go-toolset runs as 1001)
 USER root
 RUN chown -R 1001:0 /workspace && chmod -R 775 /workspace
 USER 1001
@@ -26,14 +24,26 @@ RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -mod=vendor -trimpath -ldflag
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -mod=vendor -trimpath -ldflags "-s -w" -o build-api cmd/build-api/main.go
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -mod=vendor -trimpath -ldflags "-s -w" -o init-secrets cmd/init-secrets/main.go
 
-# Runtime stage uses the target platform
-FROM --platform=$TARGETPLATFORM gcr.io/distroless/static:nonroot
+FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi10/ubi-minimal:latest
+
+ARG VERSION=0.0.0
+LABEL com.redhat.component="automotive-dev-operator-container" \
+      name="automotive-dev-operator" \
+      summary="Automotive Dev Operator" \
+      description="OpenShift operator for automotive OS development" \
+      io.k8s.display-name="Automotive Dev Operator" \
+      io.k8s.description="Kubernetes operator for automotive OS development" \
+      io.openshift.tags="automotive,operator" \
+      vendor="Red Hat" \
+      version="${VERSION}" \
+      release="1"
+
+COPY LICENSE /licenses/LICENSE
+
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/build-api .
 COPY --from=builder /workspace/init-secrets .
-COPY --from=builder /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt
-COPY --from=builder /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/tls/certs/ca-bundle.crt
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	$(CONTAINER_TOOL) buildx build -f Dockerfile --platform $(BUILD_PLATFORM) --load -t ${IMG} .
+	$(CONTAINER_TOOL) buildx build -f Dockerfile --build-arg VERSION=$(VERSION) --platform $(BUILD_PLATFORM) --load -t ${IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
@@ -165,7 +165,7 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- $(CONTAINER_TOOL) buildx create --name automotive-dev-operator-builder
 	$(CONTAINER_TOOL) buildx use automotive-dev-operator-builder
-	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
+	- $(CONTAINER_TOOL) buildx build --push --build-arg VERSION=$(VERSION) --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
 	- $(CONTAINER_TOOL) buildx rm automotive-dev-operator-builder
 	rm Dockerfile.cross
 


### PR DESCRIPTION
and switch to ubi10-minimal

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [X] CI/CD improvement
- [ ] Refactoring

## Testing
- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved container build consistency by explicitly sourcing the operator version from the repository and passing it into both ARM64 and AMD64 image builds.
  * Updated Docker build targets to forward the `VERSION` build argument to the image build process.
  * Refreshed the runtime image base and added licensing information to the container while keeping required operator binaries included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->