### PR TITLE
change default install dir

### DIFF
--- a/hack/install-caib.sh
+++ b/hack/install-caib.sh
@@ -46,12 +46,12 @@ esac
 ARTIFACT="caib-${VERSION}-${SUFFIX}.tar.gz"
 URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARTIFACT}"
 CHECKSUMS_URL="https://github.com/${REPO}/releases/download/${VERSION}/checksums.txt"
-INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+INSTALL_DIR="${INSTALL_DIR:-${HOME}/.local/bin}"
 
 if [ ! -d "$INSTALL_DIR" ]; then
-    echo "Error: Install directory does not exist: ${INSTALL_DIR}" >&2
-    echo "Please create it first or use an existing directory." >&2
-    exit 1
+    if ! mkdir -p "$INSTALL_DIR"; then
+        sudo mkdir -p "$INSTALL_DIR"
+    fi
 fi
 
 TMPDIR=$(mktemp -d)


### PR DESCRIPTION
install in $HOME/.local/bin

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The installation script now defaults to a user-local directory, reducing the need for elevated permissions.
  * Automatically creates the installation directory when it does not already exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->