### PR TITLE
use containers_image_openpgp tag to avoid gpgme requirement

### DIFF
--- a/.github/actions/setup-kind-e2e/action.yml
+++ b/.github/actions/setup-kind-e2e/action.yml
@@ -42,7 +42,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install -y libgpgme-dev jq
+        sudo apt-get install -y jq
 
     - name: Install Helm
       shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,11 +35,6 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgpgme-dev
-
       - name: Install golangci-lint
         run: make golangci-lint
 
@@ -71,11 +66,6 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgpgme-dev
 
       - name: Run unit tests
         run: make test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,8 @@ version: 2
 run:
   timeout: 5m
   allow-parallel-runners: true
+  build-tags:
+    - containers_image_openpgp
 
 issues:
   # don't skip warning about doc comments

--- a/Makefile
+++ b/Makefile
@@ -110,11 +110,11 @@ fmt: ## Run go fmt against code.
 
 .PHONY: vet
 vet: ## Run go vet against code.
-	go vet ./...
+	go vet -tags containers_image_openpgp ./...
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -tags containers_image_openpgp $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
 include Makefile.e2e
 


### PR DESCRIPTION
make build-caib already had the tag, add this to other targets so it isn't required

fixes #445 

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)
