### PR TITLE
multi arch catalog build

### DIFF
--- a/.tekton/catalog-pull-request.yaml
+++ b/.tekton/catalog-pull-request.yaml
@@ -9,7 +9,6 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: "false"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: automotive-dev-operator
     appstudio.openshift.io/component: catalog
@@ -25,29 +24,19 @@ spec:
     value: quay.io/rh-sdv-cloud/automotive-dev-operator-catalog:on-pr-{{revision}}
   - name: dockerfile
     value: catalog.Dockerfile
+  - name: path-context
+    value: .
   - name: bundle-image
     value: quay.io/rh-sdv-cloud/automotive-dev-operator-bundle:on-pr-{{revision}}
   - name: image-expires-after
     value: 3d
-  - name: skip-checks
-    value: "false"
-  taskRunSpecs:
-  - pipelineTaskName: build-multiarch
-    computeResources:
-      requests:
-        memory: 6Gi
-        cpu: "4"
-      limits:
-        memory: 12Gi
-        cpu: "8"
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
+  - name: build-image-index
+    value: "true"
   pipelineSpec:
-    description: |
-      This pipeline is ideal for building demo container images from a Containerfile while maintaining trust after pipeline customization.
-
-      This version of pipeline has minimal resource requests set, it's good for demonstrating and testing.
-
-      _Uses `buildah` to create a container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://conforma.dev/docs/policy/packages/release_trusted_task.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
-      This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta?tab=tags)_
     params:
     - description: Source Repository URL
       name: git-url
@@ -69,7 +58,7 @@ spec:
         path-context
       name: dockerfile
       type: string
-    - description: Upstream image required before building this component
+    - description: Bundle image the catalog is generated from
       name: bundle-image
       type: string
     - default: "false"
@@ -85,17 +74,15 @@ spec:
       name: prefetch-input
       type: string
     - default: ""
-      description: Image tag expiration time, time values could be something like
-        1h, 2d, 3w for hours, days, and weeks, respectively.
+      description: Image tag expiration time
       name: image-expires-after
       type: string
-    - default: "false"
+    - default: "true"
       description: Add built image into an OCI image index
       name: build-image-index
       type: string
     - default: docker
-      description: The format for the resulting image's mediaType. Valid values are
-        oci or docker.
+      description: The format for the resulting image's mediaType
       name: buildah-format
       type: string
     - default: "false"
@@ -105,30 +92,33 @@ spec:
       description: Use the package registry proxy when prefetching dependencies
       name: enable-package-registry-proxy
     - default: .
-      description: Target directories in component's source code to scan with SAST
-        tools. Multiple values should be separated with commas.
+      description: Target directories to scan with SAST tools
       name: sast-target-dirs
       type: string
     - default: []
-      description: Array of --build-arg values ("arg=value" strings) for buildah
+      description: Array of --build-arg values for buildah
       name: build-args
       type: array
     - default: ""
-      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      description: Path to a file with build arguments for buildah
       name: build-args-file
       type: string
     - default: "false"
-      description: Whether to enable privileged mode, should be used only with remote
-        VMs
+      description: Whether to enable privileged mode
       name: privileged-nested
       type: string
+    - default:
+      - linux/x86_64
+      description: Platforms to build (multi-platform-controller)
+      name: build-platforms
+      type: array
     results:
     - description: ""
       name: IMAGE_URL
-      value: $(tasks.build-multiarch.results.IMAGE_URL)
+      value: $(tasks.build-image-index.results.IMAGE_URL)
     - description: ""
       name: IMAGE_DIGEST
-      value: $(tasks.build-multiarch.results.IMAGE_DIGEST)
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     - description: ""
       name: CHAINS-GIT_URL
       value: $(tasks.clone-repository.results.url)
@@ -201,61 +191,49 @@ spec:
         workspace: git-auth
       - name: netrc
         workspace: netrc
-    - name: build-multiarch
+    - name: prepare-catalog
       params:
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-      - name: IMAGE
-        value: $(params.output-image)
-      - name: DOCKERFILE
-        value: $(params.dockerfile)
       - name: BUNDLE_IMAGE
         value: $(params.bundle-image)
-      - name: PUSH_LATEST
-        value: "false"
+      - name: ociStorage
+        value: $(params.output-image).catalog-src
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
       runAfter:
       - prefetch-dependencies
       taskSpec:
         params:
         - name: SOURCE_ARTIFACT
-        - name: IMAGE
-        - name: DOCKERFILE
-          default: Dockerfile
         - name: BUNDLE_IMAGE
-        - name: PUSH_LATEST
-          default: "false"
+        - name: ociStorage
+        - name: ociArtifactExpiresAfter
+          default: ""
         results:
-        - name: IMAGE_URL
-        - name: IMAGE_DIGEST
+        - name: SOURCE_ARTIFACT
+          description: Trusted Artifact URI with generated catalog content
         stepTemplate:
-          env:
-          - name: HOME
-            value: /tekton/home
           volumeMounts:
           - name: workdir
             mountPath: /var/workdir
         steps:
-        - name: fetch-source
-          image: ghcr.io/oras-project/oras:v1.2.0
-          script: |
-            #!/usr/bin/env sh
-            set -e
-            mkdir -p /var/workdir/source
-            ARTIFACT="$(params.SOURCE_ARTIFACT)"
-            ARTIFACT="${ARTIFACT#oci:}"
-            oras blob fetch \
-              --registry-config "${HOME}/.docker/config.json" \
-              "${ARTIFACT}" \
-              --output - | tar xz -C /var/workdir/source
-        - name: prepare-catalog
+        - name: use-trusted-artifact
+          image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:adf22f3ec90bfa3f7e2c832a7d52febd1ea31aa9fff6db21324c965d7d622327
+          args:
+          - use
+          - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+        - name: generate-catalog
           image: registry.access.redhat.com/ubi9/go-toolset:1.25.9
+          env:
+          - name: HOME
+            value: /tekton/home
           securityContext:
             runAsUser: 0
           script: |
             #!/usr/bin/env bash
             set -euo pipefail
             dnf install -y -q make git skopeo
-            export HOME="${HOME:-/tekton/home}"
             mkdir -p "${HOME}/.config/containers"
             cat > "${HOME}/.config/containers/policy.json" <<'POLICY'
             {
@@ -279,65 +257,102 @@ spec:
             export VERSION="$(tr -d '[:space:]' < VERSION)"
             echo "Generating catalog from ${BUNDLE_IMG} (OLM version ${VERSION})..."
             make catalog-update
-        - name: build-and-push
-          image: quay.io/buildah/stable:latest
-          securityContext:
-            capabilities:
-              add:
-              - SETFCAP
-          script: |
-            #!/usr/bin/env bash
-            set -euo pipefail
-
-            export STORAGE_DRIVER=vfs
-            IMAGE_FULL="$(params.IMAGE)"
-            IMAGE_BASE=$(echo "${IMAGE_FULL}" | sed 's/:[^/:]*$//')
-            IMAGE_TAG="${IMAGE_FULL##*:}"
-            DOCKERFILE="$(params.DOCKERFILE)"
-            AUTHFILE="${HOME}/.docker/config.json"
-            PUSH_LATEST="$(params.PUSH_LATEST)"
-
-            cd /var/workdir/source
-
-            echo "=== Building single-arch linux/amd64 (FBC catalog must not be a manifest list) ==="
-            buildah build \
-              --storage-driver vfs \
-              --platform linux/amd64 \
-              --authfile "${AUTHFILE}" \
-              -t "${IMAGE_FULL}" \
-              -f "${DOCKERFILE}" .
-
-            buildah push \
-              --storage-driver vfs \
-              --authfile "${AUTHFILE}" \
-              --digestfile /tmp/image-digest.txt \
-              "${IMAGE_FULL}"
-            DIGEST=$(cat /tmp/image-digest.txt)
-            if [ -z "${DIGEST}" ]; then
-              echo "ERROR: Failed to extract image digest" >&2
-              exit 1
-            fi
-
-            if [ "${PUSH_LATEST}" = "true" ]; then
-              echo "=== Tagging as :latest ==="
-              buildah push --authfile "${AUTHFILE}" \
-                "${IMAGE_FULL}" \
-                "docker://${IMAGE_BASE}:latest"
-            fi
-
-            echo -n "${IMAGE_BASE}:${IMAGE_TAG}" > $(results.IMAGE_URL.path)
-            echo -n "${DIGEST}" > $(results.IMAGE_DIGEST.path)
+        - name: create-trusted-artifact
+          image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:adf22f3ec90bfa3f7e2c832a7d52febd1ea31aa9fff6db21324c965d7d622327
+          env:
+          - name: IMAGE_EXPIRES_AFTER
+            value: $(params.ociArtifactExpiresAfter)
+          args:
+          - create
+          - --store
+          - $(params.ociStorage)
+          - $(results.SOURCE_ARTIFACT.path)=/var/workdir/source
         volumes:
         - name: workdir
           emptyDir: {}
+    - matrix:
+        params:
+        - name: PLATFORM
+          value:
+          - $(params.build-platforms[*])
+      name: build-images
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: PRIVILEGED_NESTED
+        value: $(params.privileged-nested)
+      - name: SOURCE_URL
+        value: $(tasks.clone-repository.results.url)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prepare-catalog.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: IMAGE_APPEND_PLATFORM
+        value: "true"
+      runAfter:
+      - prepare-catalog
+      taskRef:
+        params:
+        - name: name
+          value: buildah-remote-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.10@sha256:c77892be9e7217b9baa9abdbaf432c16ee49c30601b6b25cfbc9d704295c58ef
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: build-image-index
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: ALWAYS_BUILD_INDEX
+        value: $(params.build-image-index)
+      - name: IMAGES
+        value:
+        - $(tasks.build-images.results.IMAGE_REF[*])
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      runAfter:
+      - build-images
+      taskRef:
+        params:
+        - name: name
+          value: build-image-index
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:70c52e88e737340e7b58418fda38c13273aa7cdf587b825778e3560aca1d1133
+        - name: kind
+          value: task
+        resolver: bundles
     - name: deprecated-base-image-check
       params:
       - name: IMAGE_URL
-        value: $(tasks.build-multiarch.results.IMAGE_URL)
+        value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
-        value: $(tasks.build-multiarch.results.IMAGE_DIGEST)
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
-      - build-multiarch
+      - build-image-index
       taskRef:
         params:
         - name: name
@@ -355,11 +370,11 @@ spec:
     - name: clamav-scan
       params:
       - name: image-digest
-        value: $(tasks.build-multiarch.results.IMAGE_DIGEST)
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
-        value: $(tasks.build-multiarch.results.IMAGE_URL)
+        value: $(tasks.build-image-index.results.IMAGE_URL)
       runAfter:
-      - build-multiarch
+      - build-image-index
       taskRef:
         params:
         - name: name
@@ -377,17 +392,17 @@ spec:
     - name: sast-shell-check
       params:
       - name: image-digest
-        value: $(tasks.build-multiarch.results.IMAGE_DIGEST)
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
-        value: $(tasks.build-multiarch.results.IMAGE_URL)
+        value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: TARGET_DIRS
         value: $(params.sast-target-dirs)
       - name: SOURCE_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        value: $(tasks.prepare-catalog.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       runAfter:
-      - build-multiarch
+      - build-image-index
       taskRef:
         params:
         - name: name
@@ -405,17 +420,17 @@ spec:
     - name: sast-unicode-check
       params:
       - name: image-digest
-        value: $(tasks.build-multiarch.results.IMAGE_DIGEST)
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
-        value: $(tasks.build-multiarch.results.IMAGE_URL)
+        value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: TARGET_DIRS
         value: $(params.sast-target-dirs)
       - name: SOURCE_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        value: $(tasks.prepare-catalog.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       runAfter:
-      - build-multiarch
+      - build-image-index
       taskRef:
         params:
         - name: name
@@ -433,11 +448,11 @@ spec:
     - name: rpms-signature-scan
       params:
       - name: image-url
-        value: $(tasks.build-multiarch.results.IMAGE_URL)
+        value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: image-digest
-        value: $(tasks.build-multiarch.results.IMAGE_DIGEST)
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
-      - build-multiarch
+      - build-image-index
       taskRef:
         params:
         - name: name
@@ -455,11 +470,11 @@ spec:
     - name: tpa-scan
       params:
       - name: image-digest
-        value: $(tasks.build-multiarch.results.IMAGE_DIGEST)
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
-        value: $(tasks.build-multiarch.results.IMAGE_URL)
+        value: $(tasks.build-image-index.results.IMAGE_URL)
       runAfter:
-      - build-multiarch
+      - build-image-index
       taskRef:
         params:
         - name: name
@@ -485,4 +500,3 @@ spec:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}

--- a/.tekton/catalog-push.yaml
+++ b/.tekton/catalog-push.yaml
@@ -7,8 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
-  creationTimestamp: null
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main"
   labels:
     appstudio.openshift.io/application: automotive-dev-operator
     appstudio.openshift.io/component: catalog
@@ -25,27 +25,20 @@ spec:
     value: quay.io/rh-sdv-cloud/automotive-dev-operator-catalog:{{revision}}
   - name: dockerfile
     value: catalog.Dockerfile
+  - name: path-context
+    value: .
   - name: bundle-image
     value: quay.io/rh-sdv-cloud/automotive-dev-operator-bundle:{{revision}}
-  - name: skip-checks
-    value: "false"
-  taskRunSpecs:
-  - pipelineTaskName: build-multiarch
-    computeResources:
-      requests:
-        memory: 6Gi
-        cpu: "4"
-      limits:
-        memory: 12Gi
-        cpu: "8"
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
+  - name: build-image-index
+    value: "true"
+  - name: additional-tags
+    value:
+    - latest
   pipelineSpec:
-    description: |
-      This pipeline is ideal for building demo container images from a Containerfile while maintaining trust after pipeline customization.
-
-      This version of pipeline has minimal resource requests set, it's good for demonstrating and testing.
-
-      _Uses `buildah` to create a container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://conforma.dev/docs/policy/packages/release_trusted_task.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
-      This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta?tab=tags)_
     params:
     - description: Source Repository URL
       name: git-url
@@ -67,7 +60,7 @@ spec:
         path-context
       name: dockerfile
       type: string
-    - description: Upstream image required before building this component
+    - description: Bundle image the catalog is generated from
       name: bundle-image
       type: string
     - default: "false"
@@ -83,17 +76,15 @@ spec:
       name: prefetch-input
       type: string
     - default: ""
-      description: Image tag expiration time, time values could be something like
-        1h, 2d, 3w for hours, days, and weeks, respectively.
+      description: Image tag expiration time
       name: image-expires-after
       type: string
-    - default: "false"
+    - default: "true"
       description: Add built image into an OCI image index
       name: build-image-index
       type: string
     - default: docker
-      description: The format for the resulting image's mediaType. Valid values are
-        oci or docker.
+      description: The format for the resulting image's mediaType
       name: buildah-format
       type: string
     - default: "false"
@@ -103,30 +94,37 @@ spec:
       description: Use the package registry proxy when prefetching dependencies
       name: enable-package-registry-proxy
     - default: .
-      description: Target directories in component's source code to scan with SAST
-        tools. Multiple values should be separated with commas.
+      description: Target directories to scan with SAST tools
       name: sast-target-dirs
       type: string
     - default: []
-      description: Array of --build-arg values ("arg=value" strings) for buildah
+      description: Array of --build-arg values for buildah
       name: build-args
       type: array
     - default: ""
-      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      description: Path to a file with build arguments for buildah
       name: build-args-file
       type: string
     - default: "false"
-      description: Whether to enable privileged mode, should be used only with remote
-        VMs
+      description: Whether to enable privileged mode
       name: privileged-nested
       type: string
+    - default:
+      - linux/x86_64
+      description: Platforms to build (multi-platform-controller)
+      name: build-platforms
+      type: array
+    - default: []
+      description: Additional tags to apply to the built image index
+      name: additional-tags
+      type: array
     results:
     - description: ""
       name: IMAGE_URL
-      value: $(tasks.build-multiarch.results.IMAGE_URL)
+      value: $(tasks.build-image-index.results.IMAGE_URL)
     - description: ""
       name: IMAGE_DIGEST
-      value: $(tasks.build-multiarch.results.IMAGE_DIGEST)
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     - description: ""
       name: CHAINS-GIT_URL
       value: $(tasks.clone-repository.results.url)
@@ -199,61 +197,49 @@ spec:
         workspace: git-auth
       - name: netrc
         workspace: netrc
-    - name: build-multiarch
+    - name: prepare-catalog
       params:
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-      - name: IMAGE
-        value: $(params.output-image)
-      - name: DOCKERFILE
-        value: $(params.dockerfile)
       - name: BUNDLE_IMAGE
         value: $(params.bundle-image)
-      - name: PUSH_LATEST
-        value: "true"
+      - name: ociStorage
+        value: $(params.output-image).catalog-src
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
       runAfter:
       - prefetch-dependencies
       taskSpec:
         params:
         - name: SOURCE_ARTIFACT
-        - name: IMAGE
-        - name: DOCKERFILE
-          default: Dockerfile
         - name: BUNDLE_IMAGE
-        - name: PUSH_LATEST
-          default: "false"
+        - name: ociStorage
+        - name: ociArtifactExpiresAfter
+          default: ""
         results:
-        - name: IMAGE_URL
-        - name: IMAGE_DIGEST
+        - name: SOURCE_ARTIFACT
+          description: Trusted Artifact URI with generated catalog content
         stepTemplate:
-          env:
-          - name: HOME
-            value: /tekton/home
           volumeMounts:
           - name: workdir
             mountPath: /var/workdir
         steps:
-        - name: fetch-source
-          image: ghcr.io/oras-project/oras:v1.2.0
-          script: |
-            #!/usr/bin/env sh
-            set -e
-            mkdir -p /var/workdir/source
-            ARTIFACT="$(params.SOURCE_ARTIFACT)"
-            ARTIFACT="${ARTIFACT#oci:}"
-            oras blob fetch \
-              --registry-config "${HOME}/.docker/config.json" \
-              "${ARTIFACT}" \
-              --output - | tar xz -C /var/workdir/source
-        - name: prepare-catalog
+        - name: use-trusted-artifact
+          image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:adf22f3ec90bfa3f7e2c832a7d52febd1ea31aa9fff6db21324c965d7d622327
+          args:
+          - use
+          - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+        - name: generate-catalog
           image: registry.access.redhat.com/ubi9/go-toolset:1.25.9
+          env:
+          - name: HOME
+            value: /tekton/home
           securityContext:
             runAsUser: 0
           script: |
             #!/usr/bin/env bash
             set -euo pipefail
             dnf install -y -q make git skopeo
-            export HOME="${HOME:-/tekton/home}"
             mkdir -p "${HOME}/.config/containers"
             cat > "${HOME}/.config/containers/policy.json" <<'POLICY'
             {
@@ -277,113 +263,102 @@ spec:
             export VERSION="$(tr -d '[:space:]' < VERSION)"
             echo "Generating catalog from ${BUNDLE_IMG} (OLM version ${VERSION})..."
             make catalog-update
-        - name: build-and-push
-          image: quay.io/buildah/stable:latest
-          securityContext:
-            capabilities:
-              add:
-              - SETFCAP
-          script: |
-            #!/usr/bin/env bash
-            set -euo pipefail
-
-            export STORAGE_DRIVER=vfs
-            IMAGE_FULL="$(params.IMAGE)"
-            IMAGE_BASE=$(echo "${IMAGE_FULL}" | sed 's/:[^/:]*$//')
-            IMAGE_TAG="${IMAGE_FULL##*:}"
-            DOCKERFILE="$(params.DOCKERFILE)"
-            AUTHFILE="${HOME}/.docker/config.json"
-            PUSH_LATEST="$(params.PUSH_LATEST)"
-
-            cd /var/workdir/source
-
-            echo "=== Building single-arch linux/amd64 (FBC base images may lack other arches; IIB generates multi-arch index at release time) ==="
-            buildah build \
-              --storage-driver vfs \
-              --platform linux/amd64 \
-              --authfile "${AUTHFILE}" \
-              -t "${IMAGE_FULL}" \
-              -f "${DOCKERFILE}" .
-
-            buildah push \
-              --storage-driver vfs \
-              --authfile "${AUTHFILE}" \
-              --digestfile /tmp/image-digest.txt \
-              "${IMAGE_FULL}"
-            DIGEST=$(cat /tmp/image-digest.txt)
-            if [ -z "${DIGEST}" ]; then
-              echo "ERROR: Failed to extract image digest" >&2
-              exit 1
-            fi
-
-            if [ "${PUSH_LATEST}" = "true" ]; then
-              echo "=== Tagging as :latest ==="
-              buildah push --authfile "${AUTHFILE}" \
-                "${IMAGE_FULL}" \
-                "docker://${IMAGE_BASE}:latest"
-            fi
-
-            echo -n "${IMAGE_BASE}:${IMAGE_TAG}" > $(results.IMAGE_URL.path)
-            echo -n "${DIGEST}" > $(results.IMAGE_DIGEST.path)
+        - name: create-trusted-artifact
+          image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:adf22f3ec90bfa3f7e2c832a7d52febd1ea31aa9fff6db21324c965d7d622327
+          env:
+          - name: IMAGE_EXPIRES_AFTER
+            value: $(params.ociArtifactExpiresAfter)
+          args:
+          - create
+          - --store
+          - $(params.ociStorage)
+          - $(results.SOURCE_ARTIFACT.path)=/var/workdir/source
         volumes:
         - name: workdir
           emptyDir: {}
-    - name: clair-scan
-      params:
-      - name: image-digest
-        value: $(tasks.build-multiarch.results.IMAGE_DIGEST)
-      - name: image-url
-        value: $(tasks.build-multiarch.results.IMAGE_URL)
-      runAfter:
-      - build-multiarch
-      taskRef:
+    - matrix:
         params:
-        - name: name
-          value: clair-scan
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:312fb4d135e351bde38bcb14a7897b238d0aac19703b4e507c105f12b57836f1
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
-    - name: push-dockerfile
+        - name: PLATFORM
+          value:
+          - $(params.build-platforms[*])
+      name: build-images
       params:
       - name: IMAGE
-        value: $(tasks.build-multiarch.results.IMAGE_URL)
-      - name: IMAGE_DIGEST
-        value: $(tasks.build-multiarch.results.IMAGE_DIGEST)
+        value: $(params.output-image)
       - name: DOCKERFILE
         value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: PRIVILEGED_NESTED
+        value: $(params.privileged-nested)
+      - name: SOURCE_URL
+        value: $(tasks.clone-repository.results.url)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
       - name: SOURCE_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        value: $(tasks.prepare-catalog.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: IMAGE_APPEND_PLATFORM
+        value: "true"
       runAfter:
-      - build-multiarch
+      - prepare-catalog
       taskRef:
         params:
         - name: name
-          value: push-dockerfile-oci-ta
+          value: buildah-remote-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:e56a9b6a707f1d5465750db7ee194fdec619f57f6ad874a615d89f77288aea41
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.10@sha256:c77892be9e7217b9baa9abdbaf432c16ee49c30601b6b25cfbc9d704295c58ef
         - name: kind
           value: task
         resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
+    - name: build-image-index
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: ALWAYS_BUILD_INDEX
+        value: $(params.build-image-index)
+      - name: IMAGES
+        value:
+        - $(tasks.build-images.results.IMAGE_REF[*])
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      runAfter:
+      - build-images
+      taskRef:
+        params:
+        - name: name
+          value: build-image-index
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:70c52e88e737340e7b58418fda38c13273aa7cdf587b825778e3560aca1d1133
+        - name: kind
+          value: task
+        resolver: bundles
     - name: deprecated-base-image-check
       params:
       - name: IMAGE_URL
-        value: $(tasks.build-multiarch.results.IMAGE_URL)
+        value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
-        value: $(tasks.build-multiarch.results.IMAGE_DIGEST)
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
-      - build-multiarch
+      - build-image-index
       taskRef:
         params:
         - name: name
@@ -398,14 +373,36 @@ spec:
         operator: in
         values:
         - "false"
+    - name: clair-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clair-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:312fb4d135e351bde38bcb14a7897b238d0aac19703b4e507c105f12b57836f1
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
     - name: clamav-scan
       params:
       - name: image-digest
-        value: $(tasks.build-multiarch.results.IMAGE_DIGEST)
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
-        value: $(tasks.build-multiarch.results.IMAGE_URL)
+        value: $(tasks.build-image-index.results.IMAGE_URL)
       runAfter:
-      - build-multiarch
+      - build-image-index
       taskRef:
         params:
         - name: name
@@ -423,17 +420,17 @@ spec:
     - name: sast-shell-check
       params:
       - name: image-digest
-        value: $(tasks.build-multiarch.results.IMAGE_DIGEST)
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
-        value: $(tasks.build-multiarch.results.IMAGE_URL)
+        value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: TARGET_DIRS
         value: $(params.sast-target-dirs)
       - name: SOURCE_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        value: $(tasks.prepare-catalog.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       runAfter:
-      - build-multiarch
+      - build-image-index
       taskRef:
         params:
         - name: name
@@ -451,17 +448,17 @@ spec:
     - name: sast-unicode-check
       params:
       - name: image-digest
-        value: $(tasks.build-multiarch.results.IMAGE_DIGEST)
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
-        value: $(tasks.build-multiarch.results.IMAGE_URL)
+        value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: TARGET_DIRS
         value: $(params.sast-target-dirs)
       - name: SOURCE_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        value: $(tasks.prepare-catalog.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       runAfter:
-      - build-multiarch
+      - build-image-index
       taskRef:
         params:
         - name: name
@@ -476,14 +473,62 @@ spec:
         operator: in
         values:
         - "false"
+    - name: apply-tags
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+        - $(params.additional-tags[*])
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: apply-tags
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:3ab844157eccd68e95e4852adc06c3c4ea674edb7865a474b0a898227f2893d6
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: push-dockerfile
+      params:
+      - name: IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prepare-catalog.results.SOURCE_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: push-dockerfile-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:e56a9b6a707f1d5465750db7ee194fdec619f57f6ad874a615d89f77288aea41
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
     - name: rpms-signature-scan
       params:
       - name: image-url
-        value: $(tasks.build-multiarch.results.IMAGE_URL)
+        value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: image-digest
-        value: $(tasks.build-multiarch.results.IMAGE_DIGEST)
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
-      - build-multiarch
+      - build-image-index
       taskRef:
         params:
         - name: name
@@ -501,11 +546,11 @@ spec:
     - name: tpa-scan
       params:
       - name: image-digest
-        value: $(tasks.build-multiarch.results.IMAGE_DIGEST)
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
-        value: $(tasks.build-multiarch.results.IMAGE_URL)
+        value: $(tasks.build-image-index.results.IMAGE_URL)
       runAfter:
-      - build-multiarch
+      - build-image-index
       taskRef:
         params:
         - name: name
@@ -531,4 +576,3 @@ spec:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}


### PR DESCRIPTION
## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-platform catalog image builds with configurable target platforms.
  * Added image-index creation and support for publishing additional image tags.
  * Added trusted catalog preparation and artifact handoff between build stages.
  * Updated pipeline configuration for build arguments, image expiration, and related options.

* **Bug Fixes**
  * Improved image scanning and validation by using the finalized image index and prepared catalog artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->