### PR TITLE
feat: add support for abl partitions

### DIFF
--- a/internal/common/tasks/scripts/build_image.sh
+++ b/internal/common/tasks/scripts/build_image.sh
@@ -862,14 +862,17 @@ if [ -n "$final_name" ] && [ "$final_name" != "container:$CONTAINER_PUSH" ]; the
   # For ride4/ridesx4 targets, duplicate boot_a as boot_b BEFORE computing the
   # integrity digest so the digest covers the complete artifact that will be pushed.
   if [ -d "$parts_dir" ]; then
+    # ride4/ridesx4 use A/B partition slots. AIB only populates the _a slot;
+    # duplicate as _b so the full partition set is present in the artifact.
+    # abl_a is only produced on SIG distros (qcom-abl package); glob skips when absent.
     case "$(params.target)" in
       ride4*|ridesx4*)
-        for boot_a_file in "${parts_dir}"/boot_a.*; do
-          [ -f "$boot_a_file" ] || continue
-          boot_b_file=$(echo "$boot_a_file" | sed 's/boot_a/boot_b/')
-          if [ ! -f "$boot_b_file" ]; then
-            echo "Duplicating $(basename "$boot_a_file") as $(basename "$boot_b_file") for target $(params.target)"
-            cp "$boot_a_file" "$boot_b_file"
+        for a_file in "${parts_dir}"/boot_a.* "${parts_dir}"/abl_a.*; do
+          [ -f "$a_file" ] || continue
+          b_file=$(echo "$a_file" | sed 's/_a\./_b./')
+          if [ ! -f "$b_file" ]; then
+            echo "Duplicating $(basename "$a_file") as $(basename "$b_file") for target $(params.target)"
+            cp "$a_file" "$b_file"
           fi
         done
         ;;

--- a/internal/common/tasks/scripts/push_artifact.sh
+++ b/internal/common/tasks/scripts/push_artifact.sh
@@ -167,16 +167,17 @@ if [ -d "${parts_dir}" ] && [ -n "$(ls -A "${parts_dir}" 2>/dev/null)" ]; then
   echo "Found parts directory: ${parts_dir}"
   echo "Using multi-layer push for individual partition files"
 
-  # For ride4/ridesx4 targets, ensure boot_b exists (normally created by build task;
-  # kept here as idempotent fallback for backwards compatibility with older bundles)
+  # For ride4/ridesx4 targets, ensure _b slots exist (normally created by build task;
+  # kept here as idempotent fallback for backwards compatibility with older bundles).
+  # abl_a is only produced on SIG distros (qcom-abl package); glob skips when absent.
   case "$target" in
     ride4*|ridesx4*)
-      for boot_a_file in "${parts_dir}"/boot_a.*; do
-        [ -f "$boot_a_file" ] || continue
-        boot_b_file=$(echo "$boot_a_file" | sed 's/boot_a/boot_b/')
-        if [ ! -f "$boot_b_file" ]; then
-          echo "Duplicating $(basename "$boot_a_file") as $(basename "$boot_b_file") for target $target"
-          cp "$boot_a_file" "$boot_b_file"
+      for a_file in "${parts_dir}"/boot_a.* "${parts_dir}"/abl_a.*; do
+        [ -f "$a_file" ] || continue
+        b_file=$(echo "$a_file" | sed 's/_a\./_b./')
+        if [ ! -f "$b_file" ]; then
+          echo "Duplicating $(basename "$a_file") as $(basename "$b_file") for target $target"
+          cp "$a_file" "$b_file"
         fi
       done
       ;;

--- a/internal/controller/operatorconfig/controller.go
+++ b/internal/controller/operatorconfig/controller.go
@@ -52,56 +52,56 @@ var targetDefaultsYAML = `targets:
   ridesx4:
     architecture: arm64
     extraArgs: ["--separate-partitions"]
-    include: ["system_a", "system_b", "boot_a", "boot_b"]
+    include: ["system_a", "system_b", "boot_a", "boot_b", "abl_a", "abl_b"]
     defaultFormat: "simg"
     acceptedFormats: ["simg"]
     acceptedArchitectures: ["arm64"]
   ridesx4_r3:
     architecture: arm64
     extraArgs: ["--separate-partitions"]
-    include: ["system_a", "system_b", "boot_a", "boot_b"]
+    include: ["system_a", "system_b", "boot_a", "boot_b", "abl_a", "abl_b"]
     defaultFormat: "simg"
     acceptedFormats: ["simg"]
     acceptedArchitectures: ["arm64"]
   ridesx4_scmi:
     architecture: arm64
     extraArgs: ["--separate-partitions"]
-    include: ["system_a", "system_b", "boot_a", "boot_b"]
+    include: ["system_a", "system_b", "boot_a", "boot_b", "abl_a", "abl_b"]
     defaultFormat: "simg"
     acceptedFormats: ["simg"]
     acceptedArchitectures: ["arm64"]
   ride4_sa8775p_sx_r3:
     architecture: arm64
     extraArgs: ["--separate-partitions"]
-    include: ["system_a", "system_b", "boot_a", "boot_b"]
+    include: ["system_a", "system_b", "boot_a", "boot_b", "abl_a", "abl_b"]
     defaultFormat: "simg"
     acceptedFormats: ["simg"]
     acceptedArchitectures: ["arm64"]
   ride4_sa8775p_sx:
     architecture: arm64
     extraArgs: ["--separate-partitions"]
-    include: ["system_a", "system_b", "boot_a", "boot_b"]
+    include: ["system_a", "system_b", "boot_a", "boot_b", "abl_a", "abl_b"]
     defaultFormat: "simg"
     acceptedFormats: ["simg"]
     acceptedArchitectures: ["arm64"]
   ride4_sa8775p_sx_legacy:
     architecture: arm64
     extraArgs: ["--separate-partitions"]
-    include: ["system_a", "system_b", "boot_a", "boot_b"]
+    include: ["system_a", "system_b", "boot_a", "boot_b", "abl_a", "abl_b"]
     defaultFormat: "simg"
     acceptedFormats: ["simg"]
     acceptedArchitectures: ["arm64"]
   ride4_sa8775p_sx_legacy_r3:
     architecture: arm64
     extraArgs: ["--separate-partitions"]
-    include: ["system_a", "system_b", "boot_a", "boot_b"]
+    include: ["system_a", "system_b", "boot_a", "boot_b", "abl_a", "abl_b"]
     defaultFormat: "simg"
     acceptedFormats: ["simg"]
     acceptedArchitectures: ["arm64"]
   ride4_sa8650p_sx_r3:
     architecture: arm64
     extraArgs: ["--separate-partitions"]
-    include: ["system_a", "system_b", "boot_a", "boot_b"]
+    include: ["system_a", "system_b", "boot_a", "boot_b", "abl_a", "abl_b"]
     defaultFormat: "simg"
     acceptedFormats: ["simg"]
     acceptedArchitectures: ["arm64"]

--- a/internal/controller/operatorconfig/controller.go
+++ b/internal/controller/operatorconfig/controller.go
@@ -49,27 +49,6 @@ const (
 // targetDefaultsYAML is the default content for the aib-target-defaults ConfigMap.
 // It defines per-target build defaults (architecture, extra args, partition rules).
 var targetDefaultsYAML = `targets:
-  ridesx4:
-    architecture: arm64
-    extraArgs: ["--separate-partitions"]
-    include: ["system_a", "system_b", "boot_a", "boot_b", "abl_a", "abl_b"]
-    defaultFormat: "simg"
-    acceptedFormats: ["simg"]
-    acceptedArchitectures: ["arm64"]
-  ridesx4_r3:
-    architecture: arm64
-    extraArgs: ["--separate-partitions"]
-    include: ["system_a", "system_b", "boot_a", "boot_b", "abl_a", "abl_b"]
-    defaultFormat: "simg"
-    acceptedFormats: ["simg"]
-    acceptedArchitectures: ["arm64"]
-  ridesx4_scmi:
-    architecture: arm64
-    extraArgs: ["--separate-partitions"]
-    include: ["system_a", "system_b", "boot_a", "boot_b", "abl_a", "abl_b"]
-    defaultFormat: "simg"
-    acceptedFormats: ["simg"]
-    acceptedArchitectures: ["arm64"]
   ride4_sa8775p_sx_r3:
     architecture: arm64
     extraArgs: ["--separate-partitions"]
@@ -78,20 +57,6 @@ var targetDefaultsYAML = `targets:
     acceptedFormats: ["simg"]
     acceptedArchitectures: ["arm64"]
   ride4_sa8775p_sx:
-    architecture: arm64
-    extraArgs: ["--separate-partitions"]
-    include: ["system_a", "system_b", "boot_a", "boot_b", "abl_a", "abl_b"]
-    defaultFormat: "simg"
-    acceptedFormats: ["simg"]
-    acceptedArchitectures: ["arm64"]
-  ride4_sa8775p_sx_legacy:
-    architecture: arm64
-    extraArgs: ["--separate-partitions"]
-    include: ["system_a", "system_b", "boot_a", "boot_b", "abl_a", "abl_b"]
-    defaultFormat: "simg"
-    acceptedFormats: ["simg"]
-    acceptedArchitectures: ["arm64"]
-  ride4_sa8775p_sx_legacy_r3:
     architecture: arm64
     extraArgs: ["--separate-partitions"]
     include: ["system_a", "system_b", "boot_a", "boot_b", "abl_a", "abl_b"]
@@ -110,17 +75,7 @@ var targetDefaultsYAML = `targets:
     defaultFormat: "simg"
     acceptedFormats: ["simg", "raw"]
     acceptedArchitectures: ["arm64"]
-  rcar_s4:
-    architecture: arm64
-    defaultFormat: "simg"
-    acceptedFormats: ["simg", "raw"]
-    acceptedArchitectures: ["arm64"]
   j784s4evm:
-    architecture: arm64
-    defaultFormat: "simg"
-    acceptedFormats: ["simg", "raw"]
-    acceptedArchitectures: ["arm64"]
-  s32g_vnp_rdb3:
     architecture: arm64
     defaultFormat: "simg"
     acceptedFormats: ["simg", "raw"]


### PR DESCRIPTION
- AIB now produces the abl partition and we need to pack and add annotation hints for the flashing tools

- Remove old targets from defaults list
## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] Manifests are up to date (`make manifests generate`)
- [x] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image preparation and artifact publishing for supported Ride platforms by ensuring required bootloader components are available across both A/B partitions.
  * Reduced failures during multi-layer artifact uploads when secondary partition files are missing.

* **Improvements**
  * Updated supported platform target definitions and partition mappings for newer Ride platform variants.
  * Removed obsolete target configurations from the default platform options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->