### PR TITLE
fix: add lease ID to flash API response

### DIFF
--- a/cmd/caib/flashcmd/flash.go
+++ b/cmd/caib/flashcmd/flash.go
@@ -286,7 +286,12 @@ func (h *Handler) waitForFlashCompletion(ctx context.Context, _ *buildapiclient.
 			}
 
 			if st.Phase == phaseCompleted {
-				clilog.Infoln("Flash completed successfully!")
+				if st.LeaseID != "" {
+					clilog.Infof("Flash completed successfully! Lease: %s\n", st.LeaseID)
+					clilog.Infof("Connect with: jmp shell --lease %s\n", st.LeaseID)
+				} else {
+					clilog.Infoln("Flash completed successfully!")
+				}
 				return
 			}
 			if st.Phase == phaseFailed {

--- a/internal/buildapi/flash.go
+++ b/internal/buildapi/flash.go
@@ -307,7 +307,17 @@ func (a *APIServer) getFlash(c *gin.Context, name string) {
 		StartTime:      startStr,
 		CompletionTime: compStr,
 		TaskRunName:    taskRun.Name,
+		LeaseID:        extractTaskRunResult(taskRun, "lease-id"),
 	})
+}
+
+func extractTaskRunResult(tr *tektonv1.TaskRun, name string) string {
+	for _, result := range tr.Status.Results {
+		if result.Name == name {
+			return result.Value.StringVal
+		}
+	}
+	return ""
 }
 
 func getTaskRunStatus(tr *tektonv1.TaskRun) (phase, message string) {

--- a/internal/buildapi/flash_test.go
+++ b/internal/buildapi/flash_test.go
@@ -208,6 +208,33 @@ var _ = Describe("Flash", func() {
 			Expect(resp.Phase).To(Equal(phaseRunning))
 			Expect(resp.RequestedBy).To(Equal("alice"))
 		})
+
+		It("should return lease ID for completed flash TaskRun", func() {
+			tr := newFlashTaskRun("my-flash", "alice", "completed")
+			tr.Status.Results = []tektonv1.TaskRunResult{
+				{
+					Name:  "lease-id",
+					Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "lease-abc123"},
+				},
+			}
+			fakeClient := newFakeClient(tr)
+			getClientFromRequestFn = func(_ *gin.Context) (ctrlclient.Client, error) {
+				return fakeClient, nil
+			}
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request, _ = http.NewRequest(http.MethodGet, "/v1/flashes/my-flash", nil)
+
+			server.getFlash(c, "my-flash")
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var resp FlashResponse
+			Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp.Name).To(Equal("my-flash"))
+			Expect(resp.Phase).To(Equal(phaseCompleted))
+			Expect(resp.LeaseID).To(Equal("lease-abc123"))
+		})
 	})
 
 	Context("listFlash", func() {

--- a/internal/buildapi/types.go
+++ b/internal/buildapi/types.go
@@ -269,6 +269,7 @@ type FlashResponse struct {
 	StartTime      string `json:"startTime,omitempty"`
 	CompletionTime string `json:"completionTime,omitempty"`
 	TaskRunName    string `json:"taskRunName,omitempty"`
+	LeaseID        string `json:"leaseId,omitempty"`
 }
 
 // FlashListItem represents a flash TaskRun in the list API


### PR DESCRIPTION
## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [X] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Flash completion responses now include the assigned lease ID when available.
  * The command provides a ready-to-use `jmp shell` command for accessing the leased environment.

* **Bug Fixes**
  * Flash operations without an assigned lease continue to display the standard success message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->