### PR TITLE
fix(caib): respect --output-format flag in image token command

### DIFF
--- a/cmd/caib/runtime_wiring.go
+++ b/cmd/caib/runtime_wiring.go
@@ -266,6 +266,7 @@ func (s runtimeState) newHandlers() handlerSet {
 			ServerURL:       s.ServerURL,
 			AuthToken:       s.AuthToken,
 			InsecureSkipTLS: s.InsecureSkipTLS,
+			OutputFormat:    s.OutputFormat,
 			HandleError:     handleError,
 		}),
 		inspect: inspectcmd.NewHandler(inspectcmd.Options{

--- a/cmd/caib/tokencmd/token.go
+++ b/cmd/caib/tokencmd/token.go
@@ -57,6 +57,12 @@ func (h *Handler) RunToken(_ *cobra.Command, args []string) {
 	serverURL := strings.TrimSpace(*h.opts.ServerURL)
 	insecureSkipTLS := *h.opts.InsecureSkipTLS
 
+	format, fmtErr := common.ResolveOutputFormat(h.opts.OutputFormat)
+	if fmtErr != nil {
+		h.handleError(fmtErr)
+		return
+	}
+
 	var tok *buildapitypes.TokenResponse
 	err := common.ExecuteWithReauth(serverURL, h.opts.AuthToken, insecureSkipTLS, func(api *buildapiclient.Client) error {
 		var tokenErr error
@@ -65,12 +71,6 @@ func (h *Handler) RunToken(_ *cobra.Command, args []string) {
 	})
 	if err != nil {
 		h.handleError(fmt.Errorf("error requesting token for build %s: %w", buildName, err))
-		return
-	}
-
-	format, fmtErr := common.ResolveOutputFormat(h.opts.OutputFormat)
-	if fmtErr != nil {
-		h.handleError(fmtErr)
 		return
 	}
 

--- a/cmd/caib/tokencmd/token.go
+++ b/cmd/caib/tokencmd/token.go
@@ -17,6 +17,7 @@ type Options struct {
 	ServerURL       *string
 	AuthToken       *string
 	InsecureSkipTLS *bool
+	OutputFormat    *string
 
 	HandleError func(error)
 }
@@ -67,12 +68,21 @@ func (h *Handler) RunToken(_ *cobra.Command, args []string) {
 		return
 	}
 
-	fmt.Printf("Registry:  %s\n", tok.Registry)
-	fmt.Printf("Image:     %s\n", tok.Image)
-	fmt.Printf("Username:  %s\n", tok.Username)
-	fmt.Printf("Token:     %s\n", tok.Token)
-	fmt.Printf("Expires:   %s\n", tok.ExpiresAt)
-	fmt.Println()
-	fmt.Println("To authenticate:")
-	fmt.Printf("  echo '%s' | podman login %s --username %s --password-stdin\n", tok.Token, tok.Registry, tok.Username)
+	format, fmtErr := common.ResolveOutputFormat(h.opts.OutputFormat)
+	if fmtErr != nil {
+		h.handleError(fmtErr)
+		return
+	}
+
+	common.RenderFormatted(format, tok, func() error {
+		fmt.Printf("Registry:  %s\n", tok.Registry)
+		fmt.Printf("Image:     %s\n", tok.Image)
+		fmt.Printf("Username:  %s\n", tok.Username)
+		fmt.Printf("Token:     %s\n", tok.Token)
+		fmt.Printf("Expires:   %s\n", tok.ExpiresAt)
+		fmt.Println()
+		fmt.Println("To authenticate:")
+		fmt.Printf("  echo '%s' | podman login %s --username %s --password-stdin\n", tok.Token, tok.Registry, tok.Username)
+		return nil
+	}, h.handleError)
 }


### PR DESCRIPTION
## Summary

- Wire `OutputFormat` through to the token handler so `--output-format json` and `--output-format yaml` produce structured output instead of being silently ignored
- Use the existing `common.ResolveOutputFormat` / `common.RenderFormatted` helpers, consistent with `list`, `show`, `build`, and `inspect` commands

Fixes #477

## Test plan

- [ ] `caib image token <build> --output-format json` emits JSON
- [ ] `caib image token <build> --output-format yaml` emits YAML
- [ ] `caib image token <build>` (no flag) still prints the human-readable table with the `podman login` hint
- [ ] `go test ./cmd/caib/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added output format selection to the token command.
  * Token instructions can now be rendered in the requested format.

* **Bug Fixes**
  * Improved handling and reporting of invalid output format selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->