### PR TITLE
feat: imply internal-registry when using -o

### DIFF
--- a/cmd/caib/buildcmd/build.go
+++ b/cmd/caib/buildcmd/build.go
@@ -151,17 +151,30 @@ func (h *Handler) applyWaitFollowDefaults(cmd *cobra.Command, defaultWait bool) 
 	}
 }
 
+// validateRegistryFlags auto-enables --internal-registry when --output is specified
+// without a push destination, then validates mutual exclusion and output-requires-push.
+func (h *Handler) validateRegistryFlags(pushFlagName, suggestion string) error {
+	if *h.opts.OutputDir != "" && *h.opts.ExportOCI == "" && !*h.opts.UseInternalRegistry {
+		*h.opts.UseInternalRegistry = true
+	}
+	if *h.opts.UseInternalRegistry && *h.opts.ExportOCI != "" {
+		return common.NewActionableError(
+			fmt.Errorf("--internal-registry cannot be used with %s", pushFlagName),
+			suggestion,
+		)
+	}
+	if !*h.opts.UseInternalRegistry {
+		if err := common.ValidateOutputRequiresPush(*h.opts.OutputDir, *h.opts.ExportOCI, pushFlagName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // validateBootcBuildFlags validates flag combinations for the build command.
 func (h *Handler) validateBootcBuildFlags() error {
 	if strings.TrimSpace(*h.opts.ServerURL) == "" {
 		return common.ServerURLRequiredError("caib image build --server <server-url>")
-	}
-
-	if *h.opts.UseInternalRegistry && *h.opts.ExportOCI != "" {
-		return common.NewActionableError(
-			fmt.Errorf("--internal-registry cannot be used with --push-disk"),
-			fmt.Sprintf("caib image build -m %s --push-disk %s", *h.opts.Manifest, *h.opts.ExportOCI),
-		)
 	}
 
 	if *h.opts.OutputDir != "" && !*h.opts.BuildDiskImage {
@@ -173,10 +186,9 @@ func (h *Handler) validateBootcBuildFlags() error {
 	if *h.opts.FlashAfterBuild && !*h.opts.BuildDiskImage {
 		*h.opts.BuildDiskImage = true
 	}
-	if !*h.opts.UseInternalRegistry {
-		if err := common.ValidateOutputRequiresPush(*h.opts.OutputDir, *h.opts.ExportOCI, "--push-disk"); err != nil {
-			return err
-		}
+	if err := h.validateRegistryFlags("--push-disk",
+		fmt.Sprintf("caib image build -m %s --push-disk %s", *h.opts.Manifest, *h.opts.ExportOCI)); err != nil {
+		return err
 	}
 
 	if err := h.validateReproducibleFlags(); err != nil {
@@ -914,20 +926,13 @@ func (h *Handler) RunBuildDev(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	if err := h.validateReproducibleFlags(); err != nil {
+	if err := h.validateRegistryFlags("--push",
+		fmt.Sprintf("caib image build-dev --push %s %s", *h.opts.ExportOCI, manifestPath)); err != nil {
 		h.handleError(err)
 		return
 	}
 
-	if *h.opts.UseInternalRegistry {
-		if *h.opts.ExportOCI != "" {
-			h.handleError(common.NewActionableError(
-				fmt.Errorf("--internal-registry cannot be used with --push"),
-				fmt.Sprintf("caib image build-dev --push %s %s", *h.opts.ExportOCI, manifestPath),
-			))
-			return
-		}
-	} else if err := common.ValidateOutputRequiresPush(*h.opts.OutputDir, *h.opts.ExportOCI, "--push"); err != nil {
+	if err := h.validateReproducibleFlags(); err != nil {
 		h.handleError(err)
 		return
 	}

--- a/cmd/caib/image/image.go
+++ b/cmd/caib/image/image.go
@@ -132,7 +132,7 @@ func NewImageCmd(opts Options) *cobra.Command {
 	buildCmd.Flags().StringVarP(opts.Architecture, "arch", "a", opts.GetDefaultArch(), "architecture (amd64, arm64)")
 	buildCmd.Flags().StringVar(opts.ContainerPush, "push", "", "push bootc container to registry (optional if --disk is used)")
 	buildCmd.Flags().BoolVar(opts.BuildDiskImage, "disk", false, "also build disk image from container")
-	buildCmd.Flags().StringVarP(opts.OutputDir, "output", "o", "", "download disk image to file from registry (implies --disk; requires --push-disk or --internal-registry)")
+	buildCmd.Flags().StringVarP(opts.OutputDir, "output", "o", "", "download disk image to file from registry (uses --disk and --internal-registry when no --push-disk given)")
 	buildCmd.Flags().StringVar(
 		opts.DiskFormat, "format", "", "disk image format (qcow2, raw, simg); inferred from output filename if not set",
 	)
@@ -200,7 +200,7 @@ func NewImageCmd(opts Options) *cobra.Command {
 	diskCmd.Flags().StringVar(opts.ServerURL, "server", defaultServer, "REST API server base URL")
 	diskCmd.Flags().StringVar(opts.AuthToken, "token", os.Getenv("CAIB_TOKEN"), "Bearer token for authentication")
 	diskCmd.Flags().StringVarP(opts.BuildName, "name", "n", "", "name for the build job (auto-generated if omitted)")
-	diskCmd.Flags().StringVarP(opts.OutputDir, "output", "o", "", "download disk image to file from registry (requires --push)")
+	diskCmd.Flags().StringVarP(opts.OutputDir, "output", "o", "", "download disk image to file from registry (uses --internal-registry when no --push given)")
 	diskCmd.Flags().StringVar(
 		opts.DiskFormat, "format", "", "disk image format (qcow2, raw, simg); inferred from output filename if not set",
 	)
@@ -249,7 +249,7 @@ func NewImageCmd(opts Options) *cobra.Command {
 	buildDevCmd.Flags().StringVarP(opts.Architecture, "arch", "a", opts.GetDefaultArch(), "architecture (amd64, arm64)")
 	buildDevCmd.Flags().StringVar(opts.Mode, "mode", "package", "build mode: image (ostree) or package (package-based)")
 	buildDevCmd.Flags().StringVar(opts.ExportFormat, "format", "", "export format: qcow2, raw, simg, etc.")
-	buildDevCmd.Flags().StringVarP(opts.OutputDir, "output", "o", "", "download artifact to file from registry (requires --push)")
+	buildDevCmd.Flags().StringVarP(opts.OutputDir, "output", "o", "", "download artifact to file from registry (uses --internal-registry when no --push given)")
 	buildDevCmd.Flags().StringVar(opts.CompressionAlgo, "compress", "gzip", "compression algorithm (gzip, lz4, xz)")
 	buildDevCmd.Flags().StringVar(opts.ExportOCI, "push", "", "push disk image as OCI artifact to registry")
 	buildDevCmd.Flags().StringVar(


### PR DESCRIPTION
When downloading with -o, do not require --push/--internal-registry and use --internal-registry implicitly to make command less confusing

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [X] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Output-only builds now automatically use the internal registry when no OCI push destination is provided.
  * Build, disk, and development build commands provide clearer guidance for output and push options.

* **Bug Fixes**
  * Improved validation for incompatible registry and push configurations.
  * Added clearer checks and suggestions when required output options are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->