### PR TITLE
feat: infer target from OCI annotation

### DIFF
--- a/internal/buildapi/flash.go
+++ b/internal/buildapi/flash.go
@@ -82,6 +82,14 @@ func (a *APIServer) createFlash(c *gin.Context) {
 		operatorConfig = &automotivev1alpha1.OperatorConfig{}
 	}
 
+	// Auto-detect target from OCI image annotations when not specified
+	if req.Target == "" && req.ExporterSelector == "" {
+		if detected := resolveTargetFromImage(ctx, req.ImageRef, req.RegistryCredentials); detected != "" {
+			req.Target = detected
+			a.log.Info("auto-detected target from image annotations", "target", detected, "image", req.ImageRef)
+		}
+	}
+
 	// Resolve exporter selector and flash command from OperatorConfig
 	exporterSelector, flashCmd := resolveFlashTargetConfig(req, operatorConfig)
 	if exporterSelector == "" {

--- a/internal/buildapi/flash_helpers.go
+++ b/internal/buildapi/flash_helpers.go
@@ -7,9 +7,14 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
+
+	"github.com/containers/image/v5/docker"
+	"github.com/containers/image/v5/types"
 
 	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
 	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/labels"
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/oci"
 	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/registryutil"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -50,6 +55,71 @@ func resolveFlashTargetConfig(req FlashRequest, operatorConfig *automotivev1alph
 		}
 	}
 	return exporterSelector, flashCmd
+}
+
+// readImageAnnotationsFn reads OCI manifest annotations for a given image reference.
+// Overridable for testing.
+var readImageAnnotationsFn = readImageAnnotations
+
+func readImageAnnotations(ctx context.Context, imageRef string, sysCtx *types.SystemContext) (map[string]string, error) {
+	ref, err := docker.ParseReference("//" + imageRef)
+	if err != nil {
+		return nil, fmt.Errorf("parse reference: %w", err)
+	}
+
+	if sysCtx == nil {
+		sysCtx = &types.SystemContext{}
+	}
+
+	src, err := ref.NewImageSource(ctx, sysCtx)
+	if err != nil {
+		return nil, fmt.Errorf("open image source: %w", err)
+	}
+	defer func() { _ = src.Close() }()
+
+	rawManifest, _, err := src.GetManifest(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("get manifest: %w", err)
+	}
+
+	var parsed struct {
+		Annotations map[string]string `json:"annotations"`
+	}
+	if err := json.Unmarshal(rawManifest, &parsed); err != nil {
+		return nil, fmt.Errorf("parse manifest: %w", err)
+	}
+	return parsed.Annotations, nil
+}
+
+// systemContextFromCredentials builds a types.SystemContext with Docker auth
+// from FlashRequest registry credentials. Returns nil if no credentials.
+func systemContextFromCredentials(creds *RegistryCredentials) *types.SystemContext {
+	if creds == nil || !creds.Enabled {
+		return nil
+	}
+	username, password, err := extractOCICredentials(creds)
+	if err != nil || username == "" {
+		return nil
+	}
+	return &types.SystemContext{
+		DockerAuthConfig: &types.DockerAuthConfig{
+			Username: username,
+			Password: password,
+		},
+	}
+}
+
+// resolveTargetFromImage inspects OCI image annotations and returns the target name if present.
+func resolveTargetFromImage(ctx context.Context, imageRef string, creds *RegistryCredentials) string {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	sysCtx := systemContextFromCredentials(creds)
+	annotations, err := readImageAnnotationsFn(ctx, imageRef, sysCtx)
+	if err != nil {
+		return ""
+	}
+	return annotations[oci.Get().AnnotationKey("target")]
 }
 
 // createFlashClientConfigSecret creates the Jumpstarter client config secret for a standalone flash job.

--- a/internal/buildapi/flash_helpers_test.go
+++ b/internal/buildapi/flash_helpers_test.go
@@ -1,6 +1,11 @@
 package buildapi
 
 import (
+	"context"
+	"fmt"
+
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/oci"
+	"github.com/containers/image/v5/types"
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // Dot import is standard for Ginkgo
 	. "github.com/onsi/gomega"    //nolint:revive // Dot import is standard for Gomega
 )
@@ -26,4 +31,67 @@ var _ = Describe("BuildLeaseTags", func() {
 			"platform=caib,cluster=prod", "test-build", "team=eng",
 			"platform=caib,cluster=prod,build-name=test-build,team=eng"),
 	)
+})
+
+var _ = Describe("resolveTargetFromImage", func() {
+	var originalFn func(context.Context, string, *types.SystemContext) (map[string]string, error)
+
+	BeforeEach(func() {
+		originalFn = readImageAnnotationsFn
+	})
+
+	AfterEach(func() {
+		readImageAnnotationsFn = originalFn
+	})
+
+	It("should return target from image annotations", func() {
+		readImageAnnotationsFn = func(_ context.Context, _ string, _ *types.SystemContext) (map[string]string, error) {
+			return map[string]string{
+				oci.Get().AnnotationKey("target"): "j784s4evm",
+			}, nil
+		}
+		Expect(resolveTargetFromImage(context.Background(), "quay.io/test/image:v1", nil)).To(Equal("j784s4evm"))
+	})
+
+	It("should return empty when annotation is missing", func() {
+		readImageAnnotationsFn = func(_ context.Context, _ string, _ *types.SystemContext) (map[string]string, error) {
+			return map[string]string{}, nil
+		}
+		Expect(resolveTargetFromImage(context.Background(), "quay.io/test/image:v1", nil)).To(BeEmpty())
+	})
+
+	It("should return empty on error", func() {
+		readImageAnnotationsFn = func(_ context.Context, _ string, _ *types.SystemContext) (map[string]string, error) {
+			return nil, fmt.Errorf("connection refused")
+		}
+		Expect(resolveTargetFromImage(context.Background(), "quay.io/test/image:v1", nil)).To(BeEmpty())
+	})
+
+	It("should pass credentials as SystemContext", func() {
+		var receivedSysCtx *types.SystemContext
+		readImageAnnotationsFn = func(_ context.Context, _ string, sysCtx *types.SystemContext) (map[string]string, error) {
+			receivedSysCtx = sysCtx
+			return map[string]string{}, nil
+		}
+		creds := &RegistryCredentials{
+			Enabled:  true,
+			AuthType: authTypeUsernamePassword,
+			Username: "user",
+			Password: "pass",
+		}
+		resolveTargetFromImage(context.Background(), "quay.io/test/image:v1", creds)
+		Expect(receivedSysCtx).NotTo(BeNil())
+		Expect(receivedSysCtx.DockerAuthConfig).NotTo(BeNil())
+		Expect(receivedSysCtx.DockerAuthConfig.Username).To(Equal("user"))
+		Expect(receivedSysCtx.DockerAuthConfig.Password).To(Equal("pass"))
+	})
+
+	It("should respect context cancellation", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		readImageAnnotationsFn = func(c context.Context, _ string, _ *types.SystemContext) (map[string]string, error) {
+			return nil, c.Err()
+		}
+		Expect(resolveTargetFromImage(ctx, "quay.io/test/image:v1", nil)).To(BeEmpty())
+	})
 })


### PR DESCRIPTION
This exists for caib but not for the backend

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Flash operations can automatically identify their target from OCI image metadata when no target is explicitly provided.
  * Improved compatibility with image-based workflows by reading target configuration directly from image annotations.
  * Supports authenticated image registries when resolving target information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->