### PR TITLE
fix: remove OLM dependency from deploy script

### DIFF
--- a/hack/deploy-catalog.sh
+++ b/hack/deploy-catalog.sh
@@ -368,23 +368,6 @@ entries:
 EOF
 ./bin/opm render bundle/ --output yaml >> catalog/automotive-dev-operator.yaml
 
-# Add openshift-pipelines dependency (opm render doesn't include dependencies.yaml)
-# Use awk for portable multi-line insertion after the olm.package version line
-awk '
-/^- type: olm\.package$/ { in_pkg=1 }
-in_pkg && /version:/ {
-    print
-    print "- type: olm.package.required"
-    print "  value:"
-    print "    packageName: openshift-pipelines-operator-rh"
-    print "    versionRange: \">=1.12.0\""
-    in_pkg=0
-    next
-}
-{ print }
-' catalog/automotive-dev-operator.yaml > catalog/automotive-dev-operator.yaml.tmp
-mv catalog/automotive-dev-operator.yaml.tmp catalog/automotive-dev-operator.yaml
-
 # Update bundle image reference to internal registry (handles both empty and existing image refs)
 sed -i.bak "s|^image:.*|image: ${BUNDLE_IMG_INTERNAL}|g" catalog/automotive-dev-operator.yaml
 rm -f catalog/automotive-dev-operator.yaml.bak


### PR DESCRIPTION
This causes issues with existing installations

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Catalog generation no longer adds an unintended `openshift-pipelines-operator-rh` dependency.
  * Catalog image references continue to be rewritten as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->