### PR TITLE
bump to go 1.26

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,7 +161,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v7
               with:
-                  go-version: "1.25"
+                  go-version: "1.26"
 
             - name: Install tkn CLI
               run: |
@@ -264,7 +264,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v7
               with:
-                  go-version: "1.25"
+                  go-version: "1.26"
 
             - name: Install operator-sdk
               run: |
@@ -319,7 +319,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v7
               with:
-                  go-version: "1.25"
+                  go-version: "1.26"
 
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v4
@@ -357,7 +357,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v7
               with:
-                  go-version: "1.25"
+                  go-version: "1.26"
 
             - name: Build CLI for ARM64
               run: |
@@ -383,7 +383,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v7
               with:
-                  go-version: "1.25"
+                  go-version: "1.26"
 
             - name: Build CLI for AMD64
               run: |
@@ -409,7 +409,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v7
               with:
-                  go-version: "1.25"
+                  go-version: "1.26"
 
             - name: Build CLI for darwin/arm64
               run: |
@@ -439,7 +439,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v7
               with:
-                  go-version: "1.25"
+                  go-version: "1.26"
 
             - name: Download all CLI artifacts
               uses: actions/download-artifact@v8

--- a/.github/workflows/e2e-lanes.yml
+++ b/.github/workflows/e2e-lanes.yml
@@ -11,7 +11,7 @@ permissions:
   statuses: write
 
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
   CLUSTER_NAME: automotive-dev-e2e
   REGISTRY_NAME: kind-registry
   REGISTRY_PORT: '5001'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,7 +20,7 @@ on:
         default: ''
 
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
   CLUSTER_NAME: automotive-dev-e2e
   REGISTRY_NAME: kind-registry
   REGISTRY_PORT: '5001'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
 
 jobs:
   lint:

--- a/.github/workflows/test-images.yml
+++ b/.github/workflows/test-images.yml
@@ -96,7 +96,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v7
               with:
-                  go-version: "1.25"
+                  go-version: "1.26"
 
             - name: Login to Quay.io
               uses: docker/login-action@v4

--- a/.tekton/bundle-pull-request.yaml
+++ b/.tekton/bundle-pull-request.yaml
@@ -251,7 +251,7 @@ spec:
               "${ARTIFACT}" \
               --output - | tar xz -C /var/workdir/source
         - name: prepare-bundle
-          image: registry.access.redhat.com/ubi10/go-toolset:1.25.9
+          image: registry.access.redhat.com/ubi10/go-toolset:1.26.5
           securityContext:
             runAsUser: 0
           script: |

--- a/.tekton/bundle-push.yaml
+++ b/.tekton/bundle-push.yaml
@@ -246,7 +246,7 @@ spec:
               "${ARTIFACT}" \
               --output - | tar xz -C /var/workdir/source
         - name: prepare-bundle
-          image: registry.access.redhat.com/ubi10/go-toolset:1.25.9
+          image: registry.access.redhat.com/ubi10/go-toolset:1.26.5
           securityContext:
             runAsUser: 0
           script: |

--- a/.tekton/catalog-pull-request.yaml
+++ b/.tekton/catalog-pull-request.yaml
@@ -224,7 +224,7 @@ spec:
           - use
           - $(params.SOURCE_ARTIFACT)=/var/workdir/source
         - name: generate-catalog
-          image: registry.access.redhat.com/ubi10/go-toolset:1.25.9
+          image: registry.access.redhat.com/ubi10/go-toolset:1.26.5
           env:
           - name: HOME
             value: /tekton/home

--- a/.tekton/catalog-push.yaml
+++ b/.tekton/catalog-push.yaml
@@ -230,7 +230,7 @@ spec:
           - use
           - $(params.SOURCE_ARTIFACT)=/var/workdir/source
         - name: generate-catalog
-          image: registry.access.redhat.com/ubi10/go-toolset:1.25.9
+          image: registry.access.redhat.com/ubi10/go-toolset:1.26.5
           env:
           - name: HOME
             value: /tekton/home

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BUILDPLATFORM
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi10/go-toolset:1.25.9 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi10/go-toolset:1.26.5 AS builder
 ARG TARGETOS=linux
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/centos-automotive-suite/automotive-dev-operator
 
-go 1.25.8
+go 1.26.5
 
 require (
 	github.com/containers/image/v5 v5.36.2


### PR DESCRIPTION
## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s Go runtime and build environment to version 1.26.
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->