### PR TITLE
chore: add make bump-go target to centralize Go version updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
             - "v*"
 
 env:
+    GO_VERSION: "1.26"
     REGISTRY: quay.io
     REPOSITORY: ${{ vars.REPOSITORY }}
     OPERATOR_IMAGE: ${{ vars.REGISTRY }}/${{ vars.REPOSITORY }}/automotive-dev-operator
@@ -161,7 +162,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v7
               with:
-                  go-version: "1.26"
+                  go-version: ${{ env.GO_VERSION }}
 
             - name: Install tkn CLI
               run: |
@@ -264,7 +265,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v7
               with:
-                  go-version: "1.26"
+                  go-version: ${{ env.GO_VERSION }}
 
             - name: Install operator-sdk
               run: |
@@ -319,7 +320,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v7
               with:
-                  go-version: "1.26"
+                  go-version: ${{ env.GO_VERSION }}
 
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v4
@@ -357,7 +358,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v7
               with:
-                  go-version: "1.26"
+                  go-version: ${{ env.GO_VERSION }}
 
             - name: Build CLI for ARM64
               run: |
@@ -383,7 +384,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v7
               with:
-                  go-version: "1.26"
+                  go-version: ${{ env.GO_VERSION }}
 
             - name: Build CLI for AMD64
               run: |
@@ -409,7 +410,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v7
               with:
-                  go-version: "1.26"
+                  go-version: ${{ env.GO_VERSION }}
 
             - name: Build CLI for darwin/arm64
               run: |
@@ -439,7 +440,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v7
               with:
-                  go-version: "1.26"
+                  go-version: ${{ env.GO_VERSION }}
 
             - name: Download all CLI artifacts
               uses: actions/download-artifact@v8

--- a/.github/workflows/test-images.yml
+++ b/.github/workflows/test-images.yml
@@ -9,6 +9,7 @@ on:
                 default: "test"
 
 env:
+    GO_VERSION: "1.26"
     REGISTRY: quay.io
     REPOSITORY: ${{ vars.REPOSITORY }}
     OPERATOR_IMAGE: ${{ vars.REGISTRY }}/${{ vars.REPOSITORY }}/automotive-dev-operator
@@ -96,7 +97,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v7
               with:
-                  go-version: "1.26"
+                  go-version: ${{ env.GO_VERSION }}
 
             - name: Login to Quay.io
               uses: docker/login-action@v4

--- a/Makefile
+++ b/Makefile
@@ -445,6 +445,33 @@ community-operators-bundle: bundle ## Prepare bundle for community-operators-pro
 	fi
 	@echo "Bundle prepared at: community-operators-prod/operators/automotive-dev-operator/$(VERSION)"
 
+.PHONY: bump-go
+bump-go: ## Update Go version everywhere (usage: make bump-go GO_PATCH_VERSION=1.26.3)
+	@if [ -z "$(GO_PATCH_VERSION)" ]; then \
+		echo "Usage: make bump-go GO_PATCH_VERSION=1.26.3"; exit 1; \
+	fi
+	@if ! echo "$(GO_PATCH_VERSION)" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$$'; then \
+		echo "Error: GO_PATCH_VERSION must be in X.Y.Z format (got '$(GO_PATCH_VERSION)')"; exit 1; \
+	fi
+	$(eval GO_MINOR_VERSION := $(shell echo $(GO_PATCH_VERSION) | cut -d. -f1,2))
+	@echo "Bumping Go: minor=$(GO_MINOR_VERSION) patch=$(GO_PATCH_VERSION)"
+	@perl -pi -e "s/(GO_VERSION: ['\"]?)[0-9]+\.[0-9]+(['\"]?)/\$${1}$(GO_MINOR_VERSION)\$${2}/" \
+		.github/workflows/build.yml \
+		.github/workflows/e2e-lanes.yml \
+		.github/workflows/e2e.yml \
+		.github/workflows/lint.yml \
+		.github/workflows/test-images.yml
+	@perl -pi -e 's/go-toolset:[0-9]+\.[0-9]+\.[0-9]+/go-toolset:$(GO_PATCH_VERSION)/' \
+		.tekton/bundle-pull-request.yaml \
+		.tekton/bundle-push.yaml \
+		.tekton/catalog-pull-request.yaml \
+		.tekton/catalog-push.yaml \
+		Dockerfile
+	@perl -pi -e 's/^go [0-9]+\.[0-9]+\.[0-9]+/go $(GO_PATCH_VERSION)/' go.mod
+	@echo "Running go mod tidy and make generate manifests..."
+	go mod tidy
+	$(MAKE) generate manifests
+
 .PHONY: release-images
 release-images: docker-buildx bundle-build bundle-push catalog-build catalog-push ## Build and push all release images (operator, bundle, catalog)
 


### PR DESCRIPTION
Consolidate Go version references across CI workflows, Tekton pipelines, Dockerfile, and go.mod into a single make target. Replaces hardcoded go-version values in build.yml and test-images.yml with env var references.

Usage: `make bump-go GO_PATCH_VERSION=1.26.5`


reference: https://github.com/centos-automotive-suite/automotive-dev-operator/pull/518#discussion_r3758941433

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [X] CI/CD improvement
- [ ] Refactoring

## Testing
- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [X] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the Go version used across automated builds and image tests.
  * Added a streamlined command for updating the project’s Go patch version across development and deployment configuration.
  * The update process now refreshes dependencies and regenerated manifests automatically, helping keep project artifacts consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->