### PR TITLE
fix(caib): route log streaming through quiet-aware writer (fixes #3)

### DIFF
--- a/cmd/caib/buildcmd/logs.go
+++ b/cmd/caib/buildcmd/logs.go
@@ -226,7 +226,7 @@ func (h *Handler) tryLogStreaming(ctx context.Context, logClient *http.Client, n
 				fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", closeErr)
 			}
 		}()
-		return logstream.StreamLogsToStdout(resp.Body, state, true)
+		return logstream.StreamLogs(logstream.LogWriter(), resp.Body, state, true)
 	}
 
 	return logstream.HandleLogStreamError(resp, state, maxLogRetries)

--- a/cmd/caib/buildcmd/logs.go
+++ b/cmd/caib/buildcmd/logs.go
@@ -219,13 +219,13 @@ func (h *Handler) tryLogStreaming(ctx context.Context, logClient *http.Client, n
 	if err != nil {
 		return fmt.Errorf("log request failed: %w", err)
 	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", closeErr)
+		}
+	}()
 
 	if resp.StatusCode == http.StatusOK {
-		defer func() {
-			if closeErr := resp.Body.Close(); closeErr != nil {
-				fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", closeErr)
-			}
-		}()
 		return logstream.StreamLogs(logstream.LogWriter(), resp.Body, state, true)
 	}
 

--- a/cmd/caib/container/logs.go
+++ b/cmd/caib/container/logs.go
@@ -17,11 +17,9 @@ limitations under the License.
 package container
 
 import (
-	"bufio"
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -174,10 +172,15 @@ func tryContainerLogStreaming(ctx context.Context, logClient *http.Client, name 
 	}()
 
 	if resp.StatusCode == http.StatusOK {
-		return containerStreamLogs(resp.Body, state)
+		state.LineHandler = func(line string) {
+			if strings.Contains(line, "Build completed") || strings.Contains(line, "Build failed") {
+				state.Completed = true
+			}
+		}
+		return logstream.StreamLogs(logstream.LogWriter(), resp.Body, state, false)
 	}
 
-	return handleContainerLogStreamError(resp, state)
+	return logstream.HandleLogStreamError(resp, state, maxLogRetries)
 }
 
 // buildContainerBuildLogURL builds the log streaming URL for container builds
@@ -194,53 +197,4 @@ func buildContainerBuildLogURL(buildName string, startTime time.Time, follow boo
 		logURL += sep + "since=" + url.QueryEscape(startTime.Format(time.RFC3339))
 	}
 	return logURL
-}
-
-func containerStreamLogs(body io.Reader, state *logstream.State) error {
-	if state.StartTime.IsZero() {
-		state.StartTime = time.Now()
-	}
-
-	w := logstream.LogWriter()
-	scanner := bufio.NewScanner(body)
-	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if _, err := fmt.Fprintln(w, line); err != nil {
-			return fmt.Errorf("writing log line: %w", err)
-		}
-
-		state.StartTime = time.Now()
-
-		if strings.Contains(line, "Build completed") || strings.Contains(line, "Build failed") {
-			state.Completed = true
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("error reading log stream: %w", err)
-	}
-
-	return nil
-}
-
-const maxLogErrorBodyBytes = 64 * 1024 // 64KB limit for error response bodies
-
-func handleContainerLogStreamError(resp *http.Response, state *logstream.State) error {
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxLogErrorBodyBytes))
-	msg := strings.TrimSpace(string(body))
-
-	if resp.StatusCode == http.StatusServiceUnavailable || resp.StatusCode == http.StatusGatewayTimeout {
-		if !state.WarningShown {
-			clilog.Infof("log stream not ready (HTTP %d). Retrying... (attempt %d/%d)\n",
-				resp.StatusCode, state.RetryCount+1, maxLogRetries)
-			state.WarningShown = true
-		}
-		return fmt.Errorf("log endpoint not ready (HTTP %d)", resp.StatusCode)
-	}
-
-	if msg != "" {
-		return fmt.Errorf("log stream failed: HTTP %d - %s", resp.StatusCode, msg)
-	}
-	return fmt.Errorf("log stream failed: HTTP %d", resp.StatusCode)
 }

--- a/cmd/caib/container/logs.go
+++ b/cmd/caib/container/logs.go
@@ -34,15 +34,8 @@ import (
 
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/config"
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/logstream"
 )
-
-// logStreamState encapsulates state for log streaming with automatic reconnection
-type logStreamState struct {
-	retryCount   int
-	warningShown bool
-	startTime    time.Time
-	completed    bool // Set when stream ends normally, prevents reconnection
-}
 
 const maxLogRetries = 24 // ~2 minutes at 5s intervals
 
@@ -101,7 +94,7 @@ func runContainerLogs(_ *cobra.Command, args []string) {
 		// Build is finished — fetch logs once without follow mode (pods may have been GC'd)
 		fetchCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
-		streamState := &logStreamState{}
+		streamState := &logstream.State{}
 		if err := tryContainerLogStreaming(fetchCtx, logClient, name, streamState, false); err != nil {
 			clilog.Infof("Could not retrieve logs (pods may have been cleaned up): %v\n", err)
 		}
@@ -128,10 +121,10 @@ func runContainerLogs(_ *cobra.Command, args []string) {
 	}
 
 	// Stream logs
-	streamState := &logStreamState{}
+	streamState := &logstream.State{}
 	for {
 		err := tryContainerLogStreaming(ctx, logClient, name, streamState, true)
-		if streamState.completed {
+		if streamState.Completed {
 			break
 		}
 		if ctx.Err() != nil {
@@ -141,8 +134,8 @@ func runContainerLogs(_ *cobra.Command, args []string) {
 			handleError(err)
 		}
 		// Stream ended (nil error with incomplete stream, or transient error) — retry
-		streamState.retryCount++
-		if streamState.retryCount > maxLogRetries {
+		streamState.RetryCount++
+		if streamState.RetryCount > maxLogRetries {
 			handleError(fmt.Errorf("log stream unavailable after %d retries", maxLogRetries))
 		}
 		time.Sleep(5 * time.Second)
@@ -159,8 +152,8 @@ func isNonRetryableLogError(err error) bool {
 
 // tryContainerLogStreaming attempts to stream logs and returns error if it fails.
 // When follow is true, the server keeps the connection open for live streaming.
-func tryContainerLogStreaming(ctx context.Context, logClient *http.Client, name string, state *logStreamState, follow bool) error {
-	logURL := buildContainerBuildLogURL(name, state.startTime, follow)
+func tryContainerLogStreaming(ctx context.Context, logClient *http.Client, name string, state *logstream.State, follow bool) error {
+	logURL := buildContainerBuildLogURL(name, state.StartTime, follow)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, logURL, nil)
 	if err != nil {
@@ -181,10 +174,10 @@ func tryContainerLogStreaming(ctx context.Context, logClient *http.Client, name 
 	}()
 
 	if resp.StatusCode == http.StatusOK {
-		return streamLogsToStdout(resp.Body, state)
+		return containerStreamLogs(resp.Body, state)
 	}
 
-	return handleLogStreamError(resp, state)
+	return handleContainerLogStreamError(resp, state)
 }
 
 // buildContainerBuildLogURL builds the log streaming URL for container builds
@@ -203,24 +196,24 @@ func buildContainerBuildLogURL(buildName string, startTime time.Time, follow boo
 	return logURL
 }
 
-// streamLogsToStdout streams logs from the response body to stdout
-func streamLogsToStdout(body io.Reader, state *logStreamState) error {
-	if state.startTime.IsZero() {
-		state.startTime = time.Now()
+func containerStreamLogs(body io.Reader, state *logstream.State) error {
+	if state.StartTime.IsZero() {
+		state.StartTime = time.Now()
 	}
 
+	w := logstream.LogWriter()
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
-		fmt.Println(line)
+		if _, err := fmt.Fprintln(w, line); err != nil {
+			return fmt.Errorf("writing log line: %w", err)
+		}
 
-		// Advance the cursor so reconnections resume from here
-		state.startTime = time.Now()
+		state.StartTime = time.Now()
 
-		// Check for completion markers
 		if strings.Contains(line, "Build completed") || strings.Contains(line, "Build failed") {
-			state.completed = true
+			state.Completed = true
 		}
 	}
 
@@ -233,16 +226,15 @@ func streamLogsToStdout(body io.Reader, state *logStreamState) error {
 
 const maxLogErrorBodyBytes = 64 * 1024 // 64KB limit for error response bodies
 
-// handleLogStreamError handles HTTP errors from log streaming
-func handleLogStreamError(resp *http.Response, state *logStreamState) error {
+func handleContainerLogStreamError(resp *http.Response, state *logstream.State) error {
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxLogErrorBodyBytes))
 	msg := strings.TrimSpace(string(body))
 
 	if resp.StatusCode == http.StatusServiceUnavailable || resp.StatusCode == http.StatusGatewayTimeout {
-		if !state.warningShown {
+		if !state.WarningShown {
 			clilog.Infof("log stream not ready (HTTP %d). Retrying... (attempt %d/%d)\n",
-				resp.StatusCode, state.retryCount+1, maxLogRetries)
-			state.warningShown = true
+				resp.StatusCode, state.RetryCount+1, maxLogRetries)
+			state.WarningShown = true
 		}
 		return fmt.Errorf("log endpoint not ready (HTTP %d)", resp.StatusCode)
 	}

--- a/cmd/caib/flashcmd/flash.go
+++ b/cmd/caib/flashcmd/flash.go
@@ -343,13 +343,13 @@ func (h *Handler) tryFlashLogStreaming(ctx context.Context, logClient *http.Clie
 	if err != nil {
 		return fmt.Errorf("log request failed: %w", err)
 	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", closeErr)
+		}
+	}()
 
 	if resp.StatusCode == http.StatusOK {
-		defer func() {
-			if closeErr := resp.Body.Close(); closeErr != nil {
-				fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", closeErr)
-			}
-		}()
 		return logstream.StreamLogs(logstream.LogWriter(), resp.Body, state, false)
 	}
 	return logstream.HandleLogStreamError(resp, state, maxLogRetries)

--- a/cmd/caib/flashcmd/flash.go
+++ b/cmd/caib/flashcmd/flash.go
@@ -350,7 +350,7 @@ func (h *Handler) tryFlashLogStreaming(ctx context.Context, logClient *http.Clie
 				fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", closeErr)
 			}
 		}()
-		return logstream.StreamLogsToStdout(resp.Body, state, false)
+		return logstream.StreamLogs(logstream.LogWriter(), resp.Body, state, false)
 	}
 	return logstream.HandleLogStreamError(resp, state, maxLogRetries)
 }

--- a/cmd/caib/logstream/logstream.go
+++ b/cmd/caib/logstream/logstream.go
@@ -40,8 +40,17 @@ func (s *State) Reset() {
 	s.WarningShown = false
 }
 
-// StreamLogsToStdout streams response body line-by-line to stdout.
-func StreamLogsToStdout(body io.Reader, state *State, captureLeaseID bool) error {
+// LogWriter returns the appropriate writer for log output: os.Stderr when
+// quiet mode is active (structured output requested), os.Stdout otherwise.
+func LogWriter() io.Writer {
+	if clilog.IsQuiet() {
+		return os.Stderr
+	}
+	return os.Stdout
+}
+
+// StreamLogs streams response body line-by-line to the provided writer.
+func StreamLogs(w io.Writer, body io.Reader, state *State, captureLeaseID bool) error {
 	if state == nil {
 		return fmt.Errorf("stream state is required")
 	}
@@ -58,7 +67,10 @@ func StreamLogsToStdout(body io.Reader, state *State, captureLeaseID bool) error
 	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
-		fmt.Println(line)
+		if _, err := fmt.Fprintln(w, line); err != nil {
+			state.Active = false
+			return fmt.Errorf("writing log line: %w", err)
+		}
 		state.StartTime = time.Now()
 
 		if !captureLeaseID {

--- a/cmd/caib/logstream/logstream.go
+++ b/cmd/caib/logstream/logstream.go
@@ -21,6 +21,7 @@ type State struct {
 	StartTime    time.Time
 	Completed    bool
 	LeaseID      string
+	LineHandler  func(line string)
 }
 
 // CanRetry reports whether another reconnect attempt should be made.
@@ -72,6 +73,9 @@ func StreamLogs(w io.Writer, body io.Reader, state *State, captureLeaseID bool) 
 			return fmt.Errorf("writing log line: %w", err)
 		}
 		state.StartTime = time.Now()
+		if state.LineHandler != nil {
+			state.LineHandler(line)
+		}
 
 		if !captureLeaseID {
 			continue
@@ -104,25 +108,21 @@ func StreamLogs(w io.Writer, body io.Reader, state *State, captureLeaseID bool) 
 	return nil
 }
 
+const maxLogErrorBodyBytes = 64 * 1024
+
 // HandleLogStreamError handles common stream endpoint failures.
+// Callers must close resp.Body themselves (typically via defer).
 func HandleLogStreamError(resp *http.Response, state *State, maxRetries int) error {
 	if resp == nil || resp.Body == nil {
 		return fmt.Errorf("log stream failed: empty response")
 	}
 
-	body, readErr := io.ReadAll(resp.Body)
-	closeErr := resp.Body.Close()
-	if readErr != nil {
-		return fmt.Errorf("failed to read log stream error body: %w", readErr)
-	}
-	if closeErr != nil {
-		return fmt.Errorf("failed to close log stream error body: %w", closeErr)
-	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxLogErrorBodyBytes))
 	msg := strings.TrimSpace(string(body))
 
 	if resp.StatusCode == http.StatusServiceUnavailable || resp.StatusCode == http.StatusGatewayTimeout {
 		if state != nil && !state.WarningShown {
-			fmt.Fprintf(os.Stderr, "log stream not ready (HTTP %d). Retrying... (attempt %d/%d)\n",
+			clilog.Infof("log stream not ready (HTTP %d). Retrying... (attempt %d/%d)\n",
 				resp.StatusCode, state.RetryCount+1, maxRetries)
 			state.WarningShown = true
 		}
@@ -130,9 +130,7 @@ func HandleLogStreamError(resp *http.Response, state *State, maxRetries int) err
 	}
 
 	if msg != "" {
-		fmt.Fprintf(os.Stderr, "log stream error (%d): %s\n", resp.StatusCode, msg)
-	} else {
-		fmt.Fprintf(os.Stderr, "log stream error: HTTP %d\n", resp.StatusCode)
+		return fmt.Errorf("log stream failed: HTTP %d - %s", resp.StatusCode, msg)
 	}
-	return fmt.Errorf("log stream failed with HTTP %d", resp.StatusCode)
+	return fmt.Errorf("log stream failed: HTTP %d", resp.StatusCode)
 }

--- a/cmd/caib/logstream/logstream_test.go
+++ b/cmd/caib/logstream/logstream_test.go
@@ -1,0 +1,87 @@
+package logstream
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
+)
+
+func TestStreamLogs_WritesToProvidedWriter(t *testing.T) {
+	var buf bytes.Buffer
+	state := &State{}
+	body := strings.NewReader("line1\nline2\nline3\n")
+
+	if err := StreamLogs(&buf, body, state, false); err != nil {
+		t.Fatalf("StreamLogs returned error: %v", err)
+	}
+
+	got := buf.String()
+	if !strings.Contains(got, "line1") || !strings.Contains(got, "line2") || !strings.Contains(got, "line3") {
+		t.Errorf("expected all lines in writer output, got: %q", got)
+	}
+}
+
+func TestStreamLogs_CapturesLeaseID(t *testing.T) {
+	var buf bytes.Buffer
+	state := &State{}
+	body := strings.NewReader("some output\njmp shell --lease abc-123 foo\nmore output\n")
+
+	if err := StreamLogs(&buf, body, state, true); err != nil {
+		t.Fatalf("StreamLogs returned error: %v", err)
+	}
+
+	if state.LeaseID != "abc-123" {
+		t.Errorf("expected LeaseID=abc-123, got %q", state.LeaseID)
+	}
+}
+
+func TestStreamLogs_NilStateReturnsError(t *testing.T) {
+	var buf bytes.Buffer
+	body := strings.NewReader("line\n")
+
+	if err := StreamLogs(&buf, body, nil, false); err == nil {
+		t.Error("expected error for nil state")
+	}
+}
+
+func TestLogWriter_ReturnsStderrWhenQuiet(t *testing.T) {
+	clilog.SetQuiet(true)
+	defer clilog.SetQuiet(false)
+
+	w := LogWriter()
+	// LogWriter should not return os.Stdout when quiet
+	// We can't easily compare io.Writer identity, but we can verify the function
+	// returns a non-nil writer that is stderr
+	if w == nil {
+		t.Fatal("LogWriter returned nil")
+	}
+}
+
+func TestLogWriter_ReturnsStdoutWhenNotQuiet(t *testing.T) {
+	clilog.SetQuiet(false)
+
+	w := LogWriter()
+	if w == nil {
+		t.Fatal("LogWriter returned nil")
+	}
+}
+
+func TestStreamLogs_QuietModeDoesNotWriteToStdout(t *testing.T) {
+	clilog.SetQuiet(true)
+	defer clilog.SetQuiet(false)
+
+	var buf bytes.Buffer
+	state := &State{}
+	body := strings.NewReader("log line 1\nlog line 2\n")
+
+	if err := StreamLogs(&buf, body, state, false); err != nil {
+		t.Fatalf("StreamLogs returned error: %v", err)
+	}
+
+	got := buf.String()
+	if !strings.Contains(got, "log line 1") || !strings.Contains(got, "log line 2") {
+		t.Errorf("expected log lines in provided writer, got: %q", got)
+	}
+}

--- a/cmd/caib/logstream/logstream_test.go
+++ b/cmd/caib/logstream/logstream_test.go
@@ -2,6 +2,7 @@ package logstream
 
 import (
 	"bytes"
+	"os"
 	"strings"
 	"testing"
 
@@ -51,11 +52,8 @@ func TestLogWriter_ReturnsStderrWhenQuiet(t *testing.T) {
 	defer clilog.SetQuiet(false)
 
 	w := LogWriter()
-	// LogWriter should not return os.Stdout when quiet
-	// We can't easily compare io.Writer identity, but we can verify the function
-	// returns a non-nil writer that is stderr
-	if w == nil {
-		t.Fatal("LogWriter returned nil")
+	if w != os.Stderr {
+		t.Errorf("expected os.Stderr in quiet mode, got %v", w)
 	}
 }
 
@@ -63,25 +61,25 @@ func TestLogWriter_ReturnsStdoutWhenNotQuiet(t *testing.T) {
 	clilog.SetQuiet(false)
 
 	w := LogWriter()
-	if w == nil {
-		t.Fatal("LogWriter returned nil")
+	if w != os.Stdout {
+		t.Errorf("expected os.Stdout in normal mode, got %v", w)
 	}
 }
 
-func TestStreamLogs_QuietModeDoesNotWriteToStdout(t *testing.T) {
-	clilog.SetQuiet(true)
-	defer clilog.SetQuiet(false)
-
+func TestStreamLogs_LineHandler(t *testing.T) {
 	var buf bytes.Buffer
 	state := &State{}
-	body := strings.NewReader("log line 1\nlog line 2\n")
+	var seen []string
+	state.LineHandler = func(line string) {
+		seen = append(seen, line)
+	}
+	body := strings.NewReader("alpha\nbeta\n")
 
 	if err := StreamLogs(&buf, body, state, false); err != nil {
 		t.Fatalf("StreamLogs returned error: %v", err)
 	}
 
-	got := buf.String()
-	if !strings.Contains(got, "log line 1") || !strings.Contains(got, "log line 2") {
-		t.Errorf("expected log lines in provided writer, got: %q", got)
+	if len(seen) != 2 || seen[0] != "alpha" || seen[1] != "beta" {
+		t.Errorf("LineHandler got %v, want [alpha beta]", seen)
 	}
 }

--- a/cmd/caib/sealedcmd/sealed.go
+++ b/cmd/caib/sealedcmd/sealed.go
@@ -2,7 +2,6 @@
 package sealedcmd
 
 import (
-	"bufio"
 	"context"
 	"crypto/tls"
 	"fmt"
@@ -14,6 +13,7 @@ import (
 
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	common "github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/common"
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/logstream"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/registryauth"
 	buildapitypes "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi"
 	buildapiclient "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi/client"
@@ -315,16 +315,8 @@ func (h *Handler) sealedStreamLogs(ctx context.Context, op buildapitypes.SealedO
 		return fmt.Errorf("log stream error: HTTP %d", resp.StatusCode)
 	}
 
-	clilog.Infoln("Streaming logs...")
-	scanner := bufio.NewScanner(resp.Body)
-	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
-	for scanner.Scan() {
-		fmt.Println(scanner.Text())
-	}
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("log stream interrupted: %w", err)
-	}
-	return nil
+	state := &logstream.State{}
+	return logstream.StreamLogs(logstream.LogWriter(), resp.Body, state, false)
 }
 
 // resolveSealedTwoRefs returns input and output refs from --input/--output flags or positionals (any order).


### PR DESCRIPTION
## Summary

Log streaming wrote directly to stdout via `fmt.Println`, corrupting structured JSON/YAML output when `--output-format json` was set. This PR renames `StreamLogsToStdout` → `StreamLogs` with an explicit `io.Writer` parameter, adds a `LogWriter()` helper that returns `os.Stderr` when quiet mode is active, and consolidates the duplicate implementation in `sealedcmd` to use the shared `logstream` package.

Related issue: https://github.com/mickume/automotive-dev-operator/issues/3

## Changes

| File | Change |
|------|--------|
| `cmd/caib/logstream/logstream.go` | Renamed `StreamLogsToStdout` → `StreamLogs(w io.Writer, ...)`, added `LogWriter()` helper |
| `cmd/caib/logstream/logstream_test.go` | New: 6 tests for writer routing, lease capture, nil state, quiet-mode behavior |
| `cmd/caib/buildcmd/logs.go` | Updated caller to `logstream.StreamLogs(logstream.LogWriter(), ...)` |
| `cmd/caib/flashcmd/flash.go` | Updated caller to `logstream.StreamLogs(logstream.LogWriter(), ...)` |
| `cmd/caib/container/logs.go` | Replaced local `logStreamState` with `logstream.State`, fixed output to use `logstream.LogWriter()` |
| `cmd/caib/sealedcmd/sealed.go` | Replaced inline scanning with `logstream.StreamLogs(logstream.LogWriter(), ...)` |

## Tests

- `cmd/caib/logstream/logstream_test.go`: 6 new tests covering `StreamLogs` and `LogWriter`

## Verification

- All existing tests pass: ✅
- New tests pass: ✅
- Linter / formatter: ✅ (no new issues)
- No regressions: ✅

---
*Auto-generated by `af-fix`.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streamed log handling across build, container, flash, and sealed operations.
  * Log output now respects quiet mode by directing messages to the appropriate output stream.
  * Improved handling of stream errors, write failures, retries, and oversized error responses.
  * Preserved lease ID extraction and completion tracking during log streaming.

* **Tests**
  * Added coverage for log output, quiet mode, lease ID extraction, error handling, and line processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->