### PR TITLE
fix(caib): workspace commands use RenderFormatted for structured output (fixes #4)

### DIFF
--- a/cmd/caib/root.go
+++ b/cmd/caib/root.go
@@ -88,7 +88,7 @@ func newRootCmd() *cobra.Command {
 		container.NewContainerCmd(),
 		catalog.NewCatalogCmd(),
 		authcmd.NewAuthCmd(),
-		workspace.NewWorkspaceCmd(),
+		workspace.NewWorkspaceCmd(&outputFormat),
 	)
 
 	return rootCmd

--- a/cmd/caib/workspace/workspace.go
+++ b/cmd/caib/workspace/workspace.go
@@ -36,6 +36,9 @@ var (
 	authToken       string
 	insecureSkipTLS bool
 
+	// output format pointer — set by NewWorkspaceCmd from the root command's flag
+	outputFormatPtr *string
+
 	// create flags
 	fromBuild        string
 	leaseID          string
@@ -59,7 +62,9 @@ var (
 )
 
 // NewWorkspaceCmd creates the workspace command with subcommands.
-func NewWorkspaceCmd() *cobra.Command {
+// outputFormat is a pointer to the root command's --output-format flag value.
+func NewWorkspaceCmd(outputFormat *string) *cobra.Command {
+	outputFormatPtr = outputFormat
 	cmd := &cobra.Command{
 		Use:   "workspace",
 		Short: "Manage developer workspaces for application building",
@@ -332,8 +337,13 @@ func runCreate(_ *cobra.Command, args []string) {
 func runList(_ *cobra.Command, _ []string) {
 	requireServer()
 
+	format, err := caibcommon.ResolveOutputFormat(outputFormatPtr)
+	if err != nil {
+		handleError(err)
+	}
+
 	var workspaces []buildapitypes.WorkspaceResponse
-	err := caibcommon.ExecuteWithReauth(serverURL, &authToken, insecureSkipTLS, func(client *buildapiclient.Client) error {
+	err = caibcommon.ExecuteWithReauth(serverURL, &authToken, insecureSkipTLS, func(client *buildapiclient.Client) error {
 		ws, cerr := client.ListWorkspaces(context.Background())
 		if cerr != nil {
 			return cerr
@@ -345,13 +355,24 @@ func runList(_ *cobra.Command, _ []string) {
 		handleError(fmt.Errorf("failed to list workspaces: %w", err))
 	}
 
-	if len(workspaces) == 0 {
-		fmt.Println("No workspaces found")
-		return
+	if workspaces == nil {
+		workspaces = []buildapitypes.WorkspaceResponse{}
 	}
 
+	caibcommon.RenderFormatted(format, workspaces, func() error {
+		if len(workspaces) == 0 {
+			fmt.Println("No workspaces found")
+			return nil
+		}
+		return printWorkspaceList(workspaces)
+	}, handleError)
+}
+
+func printWorkspaceList(workspaces []buildapitypes.WorkspaceResponse) error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintln(w, "NAME\tARCH\tPHASE\tLEASE\tAGE")
+	if _, err := fmt.Fprintln(w, "NAME\tARCH\tPHASE\tLEASE\tAGE"); err != nil {
+		return err
+	}
 	for _, ws := range workspaces {
 		lease := ws.Lease
 		if lease == "" {
@@ -361,17 +382,24 @@ func runList(_ *cobra.Command, _ []string) {
 		if age == "" {
 			age = "-"
 		}
-		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", ws.Name, ws.Arch, ws.Phase, lease, age)
+		if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", ws.Name, ws.Arch, ws.Phase, lease, age); err != nil {
+			return err
+		}
 	}
-	_ = w.Flush()
+	return w.Flush()
 }
 
 func runShow(_ *cobra.Command, args []string) {
 	requireServer()
 	name := args[0]
 
+	format, err := caibcommon.ResolveOutputFormat(outputFormatPtr)
+	if err != nil {
+		handleError(err)
+	}
+
 	var ws *buildapitypes.WorkspaceResponse
-	err := caibcommon.ExecuteWithReauth(serverURL, &authToken, insecureSkipTLS, func(client *buildapiclient.Client) error {
+	err = caibcommon.ExecuteWithReauth(serverURL, &authToken, insecureSkipTLS, func(client *buildapiclient.Client) error {
 		r, cerr := client.GetWorkspace(context.Background(), name)
 		if cerr != nil {
 			return cerr
@@ -383,6 +411,12 @@ func runShow(_ *cobra.Command, args []string) {
 		handleError(fmt.Errorf("failed to get workspace: %w", err))
 	}
 
+	caibcommon.RenderFormatted(format, ws, func() error {
+		return printWorkspaceDetails(ws)
+	}, handleError)
+}
+
+func printWorkspaceDetails(ws *buildapitypes.WorkspaceResponse) error {
 	fmt.Printf("Name:         %s\n", ws.Name)
 	fmt.Printf("Architecture: %s\n", ws.Arch)
 	fmt.Printf("Phase:        %s\n", ws.Phase)
@@ -397,6 +431,7 @@ func runShow(_ *cobra.Command, args []string) {
 	if ws.LastActivity != "" {
 		fmt.Printf("Last active:  %s\n", ws.LastActivity)
 	}
+	return nil
 }
 
 func runDelete(_ *cobra.Command, args []string) {
@@ -876,7 +911,7 @@ func newProgressReader(r io.Reader, total int64) *progressReader {
 	return &progressReader{
 		r:     r,
 		total: total,
-		isTTY: term.IsTerminal(int(os.Stdout.Fd())),
+		isTTY: term.IsTerminal(int(os.Stderr.Fd())),
 		last:  -1,
 	}
 }
@@ -895,20 +930,23 @@ func (p *progressReader) Read(b []byte) (int, error) {
 }
 
 func (p *progressReader) render(pct int) {
+	if clilog.IsQuiet() {
+		return
+	}
 	barWidth := 30
 	filled := barWidth * pct / 100
 	bar := strings.Repeat("█", filled) + strings.Repeat("░", barWidth-filled)
 	sizeInfo := fmt.Sprintf("%s / %s", humanSize(p.read), humanSize(p.total))
 	if p.isTTY {
-		_, _ = fmt.Fprintf(os.Stdout, "\r  Upload   │%s│ %3d%% %s", bar, pct, sizeInfo)
+		_, _ = fmt.Fprintf(os.Stderr, "\r  Upload   │%s│ %3d%% %s", bar, pct, sizeInfo)
 	} else if pct%25 == 0 || pct == 100 {
-		_, _ = fmt.Fprintf(os.Stdout, "  Upload: %d%% %s\n", pct, sizeInfo)
+		_, _ = fmt.Fprintf(os.Stderr, "  Upload: %d%% %s\n", pct, sizeInfo)
 	}
 }
 
 func (p *progressReader) finish() {
-	if p.total > 0 && p.isTTY {
-		_, _ = fmt.Fprintln(os.Stdout)
+	if p.total > 0 && p.isTTY && !clilog.IsQuiet() {
+		_, _ = fmt.Fprintln(os.Stderr)
 	}
 }
 

--- a/cmd/caib/workspace/workspace_test.go
+++ b/cmd/caib/workspace/workspace_test.go
@@ -1,0 +1,349 @@
+package workspace
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
+	caibcommon "github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/common"
+	buildapitypes "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi"
+	"gopkg.in/yaml.v3"
+)
+
+func TestRenderFormattedWorkspaceList(t *testing.T) {
+	workspaces := []buildapitypes.WorkspaceResponse{
+		{Name: "ws-1", Arch: "amd64", Phase: "Running", Lease: "lease-abc", Age: "5m"},
+		{Name: "ws-2", Arch: "arm64", Phase: "Stopped", Age: "1h"},
+	}
+
+	var gotErr error
+	handleErr := func(err error) { gotErr = err }
+
+	t.Run("json output contains all workspaces", func(t *testing.T) {
+		gotErr = nil
+		old := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		caibcommon.RenderFormatted("json", workspaces, nil, handleErr)
+
+		_ = w.Close()
+		os.Stdout = old
+
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+
+		if gotErr != nil {
+			t.Fatalf("unexpected error: %v", gotErr)
+		}
+
+		var parsed []buildapitypes.WorkspaceResponse
+		if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+			t.Fatalf("failed to parse JSON output: %v\noutput: %s", err, buf.String())
+		}
+		if len(parsed) != 2 {
+			t.Errorf("expected 2 workspaces, got %d", len(parsed))
+		}
+		if parsed[0].Name != "ws-1" {
+			t.Errorf("expected first workspace name 'ws-1', got %q", parsed[0].Name)
+		}
+	})
+
+	t.Run("yaml output contains all workspaces", func(t *testing.T) {
+		gotErr = nil
+		old := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		caibcommon.RenderFormatted("yaml", workspaces, nil, handleErr)
+
+		_ = w.Close()
+		os.Stdout = old
+
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+
+		if gotErr != nil {
+			t.Fatalf("unexpected error: %v", gotErr)
+		}
+
+		var parsed []map[string]any
+		if err := yaml.Unmarshal(buf.Bytes(), &parsed); err != nil {
+			t.Fatalf("failed to parse YAML output: %v\noutput: %s", err, buf.String())
+		}
+		if len(parsed) != 2 {
+			t.Errorf("expected 2 workspaces, got %d", len(parsed))
+		}
+	})
+
+	t.Run("empty list renders as empty JSON array", func(t *testing.T) {
+		gotErr = nil
+		empty := []buildapitypes.WorkspaceResponse{}
+		old := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		caibcommon.RenderFormatted("json", empty, func() error {
+			return nil
+		}, handleErr)
+
+		_ = w.Close()
+		os.Stdout = old
+
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+
+		if gotErr != nil {
+			t.Fatalf("unexpected error: %v", gotErr)
+		}
+
+		trimmed := strings.TrimSpace(buf.String())
+		if trimmed != "[]" {
+			t.Errorf("expected empty JSON array '[]', got %q", trimmed)
+		}
+	})
+}
+
+func TestRenderFormattedWorkspaceShow(t *testing.T) {
+	ws := &buildapitypes.WorkspaceResponse{
+		Name:             "test-ws",
+		Arch:             "amd64",
+		Phase:            "Running",
+		PodName:          "test-ws-pod",
+		Lease:            "lease-123",
+		Age:              "10m",
+		AutoPauseTimeout: "30m",
+		LastActivity:     "2m ago",
+	}
+
+	var gotErr error
+	handleErr := func(err error) { gotErr = err }
+
+	t.Run("json output contains all fields", func(t *testing.T) {
+		gotErr = nil
+		old := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		caibcommon.RenderFormatted("json", ws, nil, handleErr)
+
+		_ = w.Close()
+		os.Stdout = old
+
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+
+		if gotErr != nil {
+			t.Fatalf("unexpected error: %v", gotErr)
+		}
+
+		var parsed map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+			t.Fatalf("failed to parse JSON: %v\noutput: %s", err, buf.String())
+		}
+		if parsed["name"] != "test-ws" {
+			t.Errorf("expected name 'test-ws', got %q", parsed["name"])
+		}
+		if parsed["architecture"] != "amd64" {
+			t.Errorf("expected architecture 'amd64', got %q", parsed["architecture"])
+		}
+		if parsed["lease"] != "lease-123" {
+			t.Errorf("expected lease 'lease-123', got %q", parsed["lease"])
+		}
+	})
+}
+
+func TestPrintWorkspaceList(t *testing.T) {
+	workspaces := []buildapitypes.WorkspaceResponse{
+		{Name: "ws-1", Arch: "amd64", Phase: "Running", Lease: "lease-abc", Age: "5m"},
+		{Name: "ws-2", Arch: "arm64", Phase: "Stopped", Age: "1h"},
+	}
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := printWorkspaceList(workspaces)
+
+	_ = w.Close()
+	os.Stdout = old
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	output := buf.String()
+
+	if !strings.Contains(output, "NAME") || !strings.Contains(output, "ARCH") {
+		t.Error("expected table header with NAME and ARCH columns")
+	}
+	if !strings.Contains(output, "ws-1") {
+		t.Error("expected ws-1 in output")
+	}
+	if !strings.Contains(output, "ws-2") {
+		t.Error("expected ws-2 in output")
+	}
+	// ws-2 has no lease, should show "-"
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) < 3 {
+		t.Fatalf("expected at least 3 lines (header + 2 rows), got %d", len(lines))
+	}
+	if !strings.Contains(lines[2], "-") {
+		t.Error("expected '-' placeholder for empty lease in ws-2 row")
+	}
+}
+
+func TestPrintWorkspaceDetails(t *testing.T) {
+	ws := &buildapitypes.WorkspaceResponse{
+		Name:             "test-ws",
+		Arch:             "amd64",
+		Phase:            "Running",
+		PodName:          "test-ws-pod",
+		AutoPauseTimeout: "30m",
+	}
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := printWorkspaceDetails(ws)
+
+	_ = w.Close()
+	os.Stdout = old
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	output := buf.String()
+
+	if !strings.Contains(output, "Name:         test-ws") {
+		t.Error("expected Name field in output")
+	}
+	if !strings.Contains(output, "Architecture: amd64") {
+		t.Error("expected Architecture field in output")
+	}
+	if !strings.Contains(output, "Auto-pause:   30m") {
+		t.Error("expected Auto-pause field in output")
+	}
+	// Lease and Age are empty, should not appear
+	if strings.Contains(output, "Lease:") {
+		t.Error("empty Lease should not appear in output")
+	}
+	if strings.Contains(output, "Age:") {
+		t.Error("empty Age should not appear in output")
+	}
+}
+
+func TestProgressReaderQuietMode(t *testing.T) {
+	t.Run("render suppressed in quiet mode", func(t *testing.T) {
+		clilog.SetQuiet(true)
+		defer clilog.SetQuiet(false)
+
+		old := os.Stderr
+		r, w, _ := os.Pipe()
+		os.Stderr = w
+
+		pr := &progressReader{
+			total: 100,
+			read:  50,
+			isTTY: false,
+		}
+		pr.render(50)
+
+		_ = w.Close()
+		os.Stderr = old
+
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+
+		if buf.Len() > 0 {
+			t.Errorf("expected no output in quiet mode, got: %s", buf.String())
+		}
+	})
+
+	t.Run("render writes to stderr in non-quiet mode", func(t *testing.T) {
+		clilog.SetQuiet(false)
+
+		old := os.Stderr
+		r, w, _ := os.Pipe()
+		os.Stderr = w
+
+		pr := &progressReader{
+			total: 100,
+			read:  25,
+			isTTY: false,
+		}
+		pr.render(25)
+
+		_ = w.Close()
+		os.Stderr = old
+
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+
+		if buf.Len() == 0 {
+			t.Error("expected output at 25% boundary on non-TTY stderr")
+		}
+		if !strings.Contains(buf.String(), "Upload:") {
+			t.Errorf("expected 'Upload:' in progress output, got: %s", buf.String())
+		}
+	})
+
+	t.Run("non-TTY render skips non-boundary percentages", func(t *testing.T) {
+		clilog.SetQuiet(false)
+
+		old := os.Stderr
+		r, w, _ := os.Pipe()
+		os.Stderr = w
+
+		pr := &progressReader{
+			total: 100,
+			read:  33,
+			isTTY: false,
+		}
+		pr.render(33)
+
+		_ = w.Close()
+		os.Stderr = old
+
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+
+		if buf.Len() > 0 {
+			t.Errorf("expected no output at 33%% (only prints at 25%% intervals and 100%%), got: %s", buf.String())
+		}
+	})
+
+	t.Run("finish suppressed in quiet mode", func(t *testing.T) {
+		clilog.SetQuiet(true)
+		defer clilog.SetQuiet(false)
+
+		old := os.Stderr
+		r, w, _ := os.Pipe()
+		os.Stderr = w
+
+		pr := &progressReader{
+			total: 100,
+			isTTY: true,
+		}
+		pr.finish()
+
+		_ = w.Close()
+		os.Stderr = old
+
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+
+		if buf.Len() > 0 {
+			t.Errorf("expected no output from finish() in quiet mode, got: %s", buf.String())
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Workspace `list` and `show` commands now support `--output-format` (json/yaml/table) via `common.RenderFormatted`, consistent with other `caib` commands
- Progress indicators in `workspace sync` write to stderr instead of stdout and are suppressed in quiet mode (`-q`)

Related issue: https://github.com/mickume/automotive-dev-operator/issues/4

## Changes

| File | Change |
|------|--------|
| `cmd/caib/workspace/workspace.go` | `NewWorkspaceCmd` accepts `*string` output format; `runList`/`runShow` use `RenderFormatted`; table-printing extracted to `printWorkspaceList`/`printWorkspaceDetails`; progress reader writes to stderr and respects `clilog.IsQuiet()` |
| `cmd/caib/root.go` | Pass `&outputFormat` to `workspace.NewWorkspaceCmd()` |
| `cmd/caib/workspace/workspace_test.go` | New tests for JSON/YAML rendering, table output, and progress quiet-mode suppression |

## Tests

- `TestRenderFormattedWorkspaceList` — JSON, YAML, empty-list rendering
- `TestRenderFormattedWorkspaceShow` — JSON output with all fields
- `TestPrintWorkspaceList` — table output correctness
- `TestPrintWorkspaceDetails` — detail output correctness
- `TestProgressReaderQuietMode` — quiet suppression, stderr output, non-boundary skipping

## Verification

- All existing tests pass: ✅
- New tests pass: ✅
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*

@coderabbitai ignore
