### PR TITLE
fix(caib): catalog commands write warnings and prompts to stderr (fixes #5)

### DIFF
--- a/cmd/caib/catalog/add.go
+++ b/cmd/caib/catalog/add.go
@@ -150,7 +150,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			fmt.Printf("Warning: failed to close response body: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", err)
 		}
 	}()
 

--- a/cmd/caib/catalog/catalog.go
+++ b/cmd/caib/catalog/catalog.go
@@ -28,6 +28,9 @@ import (
 
 const (
 	outputFormatTable = "table"
+	outputFormatJSON  = "json"
+	outputFormatYAML  = "yaml"
+	outputFormatYML   = "yml"
 )
 
 var (

--- a/cmd/caib/catalog/catalog_test.go
+++ b/cmd/caib/catalog/catalog_test.go
@@ -144,6 +144,9 @@ func TestRemovePromptAutoDeclineInJSONMode(t *testing.T) {
 	if strings.Contains(stdout, "Are you sure") {
 		t.Error("prompt should not appear on stdout in json mode")
 	}
+	if strings.Contains(stdout, "Cancelled") {
+		t.Error("cancellation notice should not appear on stdout in json mode, it would corrupt structured output")
+	}
 }
 
 func TestRemovePromptWritesToStderr(t *testing.T) {

--- a/cmd/caib/catalog/catalog_test.go
+++ b/cmd/caib/catalog/catalog_test.go
@@ -1,15 +1,14 @@
 package catalog
 
 import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
 	"testing"
 
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	"github.com/spf13/cobra"
-)
-
-const (
-	testFormatTable = "table"
-	testFormatJSON  = "json"
-	testFormatYAML  = "yaml"
 )
 
 func TestGetOutputFormat_ReadsFromRoot(t *testing.T) {
@@ -20,31 +19,31 @@ func TestGetOutputFormat_ReadsFromRoot(t *testing.T) {
 	root.AddCommand(child)
 
 	// Default
-	if got := getOutputFormat(child); got != testFormatTable {
-		t.Errorf("expected default %q, got %q", testFormatTable, got)
+	if got := getOutputFormat(child); got != outputFormatTable {
+		t.Errorf("expected default %q, got %q", outputFormatTable, got)
 	}
 
 	// Set to json
-	if err := root.PersistentFlags().Set("output-format", testFormatJSON); err != nil {
+	if err := root.PersistentFlags().Set("output-format", outputFormatJSON); err != nil {
 		t.Fatal(err)
 	}
-	if got := getOutputFormat(child); got != testFormatJSON {
-		t.Errorf("expected %q, got %q", testFormatJSON, got)
+	if got := getOutputFormat(child); got != outputFormatJSON {
+		t.Errorf("expected %q, got %q", outputFormatJSON, got)
 	}
 
 	// Set to yaml
-	if err := root.PersistentFlags().Set("output-format", testFormatYAML); err != nil {
+	if err := root.PersistentFlags().Set("output-format", outputFormatYAML); err != nil {
 		t.Fatal(err)
 	}
-	if got := getOutputFormat(child); got != testFormatYAML {
-		t.Errorf("expected %q, got %q", testFormatYAML, got)
+	if got := getOutputFormat(child); got != outputFormatYAML {
+		t.Errorf("expected %q, got %q", outputFormatYAML, got)
 	}
 }
 
 func TestGetOutputFormat_FallbackWithoutFlag(t *testing.T) {
 	cmd := &cobra.Command{Use: "standalone"}
-	if got := getOutputFormat(cmd); got != testFormatTable {
-		t.Errorf("expected fallback %q, got %q", testFormatTable, got)
+	if got := getOutputFormat(cmd); got != outputFormatTable {
+		t.Errorf("expected fallback %q, got %q", outputFormatTable, got)
 	}
 }
 
@@ -66,5 +65,124 @@ func TestFormatBytes(t *testing.T) {
 				t.Errorf("formatBytes(%d) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+
+	fn()
+
+	_ = w.Close()
+	os.Stdout = old
+
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func withServerURL(t *testing.T, url string) {
+	t.Helper()
+	old := serverURL
+	serverURL = url
+	t.Cleanup(func() { serverURL = old })
+}
+
+func TestRemovePromptAutoDeclineInQuietMode(t *testing.T) {
+	withServerURL(t, "http://localhost:0")
+	clilog.SetQuiet(true)
+	defer clilog.SetQuiet(false)
+
+	removeForce = false
+	defer func() { removeForce = false }()
+
+	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().String("output-format", "table", "output format")
+	cmd := &cobra.Command{Use: "remove"}
+	root.AddCommand(cmd)
+
+	stdout := captureStdout(t, func() {
+		err := runRemove(cmd, []string{"test-image"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if strings.Contains(stdout, "Are you sure") {
+		t.Error("prompt should not appear on stdout in quiet mode")
+	}
+}
+
+func TestRemovePromptAutoDeclineInJSONMode(t *testing.T) {
+	withServerURL(t, "http://localhost:0")
+	clilog.SetQuiet(false)
+
+	removeForce = false
+	defer func() { removeForce = false }()
+
+	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().String("output-format", "table", "output format")
+	_ = root.PersistentFlags().Set("output-format", "json")
+	cmd := &cobra.Command{Use: "remove"}
+	root.AddCommand(cmd)
+
+	stdout := captureStdout(t, func() {
+		err := runRemove(cmd, []string{"test-image"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if strings.Contains(stdout, "Are you sure") {
+		t.Error("prompt should not appear on stdout in json mode")
+	}
+}
+
+func TestRemovePromptWritesToStderr(t *testing.T) {
+	withServerURL(t, "http://localhost:0")
+	clilog.SetQuiet(false)
+
+	removeForce = false
+	defer func() { removeForce = false }()
+
+	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().String("output-format", "table", "output format")
+	cmd := &cobra.Command{Use: "remove"}
+	root.AddCommand(cmd)
+
+	// Provide "n\n" on stdin to decline
+	oldStdin := os.Stdin
+	r, w, _ := os.Pipe()
+	_, _ = w.Write([]byte("n\n"))
+	_ = w.Close()
+	os.Stdin = r
+	defer func() { os.Stdin = oldStdin }()
+
+	var stderrBuf bytes.Buffer
+	oldStderr := os.Stderr
+	stderrR, stderrW, _ := os.Pipe()
+	os.Stderr = stderrW
+
+	stdout := captureStdout(t, func() {
+		_ = runRemove(cmd, []string{"test-image"})
+	})
+
+	_ = stderrW.Close()
+	os.Stderr = oldStderr
+	_, _ = io.Copy(&stderrBuf, stderrR)
+
+	if strings.Contains(stdout, "Are you sure") {
+		t.Error("prompt should not appear on stdout")
+	}
+	if !strings.Contains(stderrBuf.String(), "Are you sure") {
+		t.Error("prompt should appear on stderr")
 	}
 }

--- a/cmd/caib/catalog/get.go
+++ b/cmd/caib/catalog/get.go
@@ -77,7 +77,7 @@ func runGet(cmd *cobra.Command, args []string) error {
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			fmt.Printf("Warning: failed to close response body: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", err)
 		}
 	}()
 
@@ -97,14 +97,14 @@ func runGet(cmd *cobra.Command, args []string) error {
 
 	format := strings.ToLower(strings.TrimSpace(getOutputFormat(cmd)))
 	switch format {
-	case "json":
+	case outputFormatJSON:
 		var result map[string]any
 		if err := json.Unmarshal(body, &result); err != nil {
 			return fmt.Errorf("failed to parse JSON response: %w", err)
 		}
 		output, _ := json.MarshalIndent(result, "", "  ")
 		fmt.Println(string(output))
-	case "yaml", "yml":
+	case outputFormatYAML, outputFormatYML:
 		var result map[string]any
 		if err := json.Unmarshal(body, &result); err != nil {
 			return fmt.Errorf("failed to parse JSON response: %w", err)

--- a/cmd/caib/catalog/remove.go
+++ b/cmd/caib/catalog/remove.go
@@ -66,8 +66,13 @@ func runRemove(cmd *cobra.Command, args []string) error {
 
 	// Confirm deletion
 	if !removeForce {
+		format := strings.ToLower(strings.TrimSpace(getOutputFormat(cmd)))
+		if clilog.IsQuiet() || format == outputFormatJSON || format == outputFormatYAML || format == outputFormatYML {
+			clilog.Infoln("Cancelled (use --force to skip confirmation)")
+			return nil
+		}
 		clilog.Infof("Removing catalog image %q...\n", name)
-		fmt.Print("Are you sure you want to remove this image from the catalog? (y/N): ")
+		fmt.Fprint(os.Stderr, "Are you sure you want to remove this image from the catalog? (y/N): ")
 		reader := bufio.NewReader(os.Stdin)
 		response, _ := reader.ReadString('\n')
 		response = strings.TrimSpace(strings.ToLower(response))

--- a/cmd/caib/catalog/remove.go
+++ b/cmd/caib/catalog/remove.go
@@ -67,8 +67,14 @@ func runRemove(cmd *cobra.Command, args []string) error {
 	// Confirm deletion
 	if !removeForce {
 		format := strings.ToLower(strings.TrimSpace(getOutputFormat(cmd)))
-		if clilog.IsQuiet() || format == outputFormatJSON || format == outputFormatYAML || format == outputFormatYML {
-			clilog.Infoln("Cancelled (use --force to skip confirmation)")
+		structured := format == outputFormatJSON || format == outputFormatYAML || format == outputFormatYML
+		if clilog.IsQuiet() || structured {
+			// Structured output modes must keep stdout parseable, and quiet mode
+			// suppresses informational output, so send this notice to stderr
+			// instead of using clilog.Infoln (which writes to stdout).
+			if !clilog.IsQuiet() {
+				fmt.Fprintln(os.Stderr, "Cancelled (use --force to skip confirmation)")
+			}
 			return nil
 		}
 		clilog.Infof("Removing catalog image %q...\n", name)


### PR DESCRIPTION
## Summary

- `catalog add` and `catalog get`: redirect body-close warnings from stdout to stderr, matching the correct pattern already used in `catalog publish`
- `catalog remove`: redirect confirmation prompt to stderr; auto-decline when quiet mode or structured output format is active (safe default matching the "N" prompt default)
- Extract format string literals into package-level constants to satisfy `goconst` linter

Related issue: https://github.com/mickume/automotive-dev-operator/issues/5

## Changes

| File | Change |
|------|--------|
| `cmd/caib/catalog/add.go` | `fmt.Printf` → `fmt.Fprintf(os.Stderr, ...)` for body-close warning |
| `cmd/caib/catalog/get.go` | `fmt.Printf` → `fmt.Fprintf(os.Stderr, ...)`; use format constants |
| `cmd/caib/catalog/remove.go` | `fmt.Print` → `fmt.Fprint(os.Stderr, ...)`; auto-decline in quiet/structured mode |
| `cmd/caib/catalog/catalog.go` | Added `outputFormatJSON`, `outputFormatYAML`, `outputFormatYML` constants |
| `cmd/caib/catalog/list.go` | Use format constants |
| `cmd/caib/catalog/catalog_test.go` | 3 new tests; switched to package-level constants |

## Tests

- `TestRemovePromptAutoDeclineInQuietMode` — verifies no prompt in quiet mode
- `TestRemovePromptAutoDeclineInJSONMode` — verifies no prompt in JSON mode
- `TestRemovePromptWritesToStderr` — verifies prompt writes to stderr, not stdout

## Verification

- All existing tests pass: ✅
- New tests pass: ✅
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSON, YAML, and YML output format support across catalog commands.
* **Bug Fixes**
  * Improved command output by sending warnings and confirmation prompts to standard error.
  * Prevented accidental removals in quiet and structured-output modes; deletion now requires `--force` in these modes.
  * Without `--force`, removal is cancelled instead of proceeding when confirmation cannot be shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->