### PR TITLE
fix(caib): inspect provenance output respects --quiet flag (fixes #7)

### DIFF
--- a/cmd/caib/inspectcmd/inspect.go
+++ b/cmd/caib/inspectcmd/inspect.go
@@ -249,6 +249,9 @@ func splitReference(ref string) string {
 }
 
 func (h *Handler) printProvenance(ociRef, digest string, annotations map[string]string, _ []referrerInfo, referrerTypes map[string]bool) {
+	if clilog.IsQuiet() {
+		return
+	}
 	bold := func(a ...any) string { return fmt.Sprint(a...) }
 	green := func(a ...any) string { return fmt.Sprint(a...) }
 	yellow := func(a ...any) string { return fmt.Sprint(a...) }

--- a/cmd/caib/inspectcmd/inspect_test.go
+++ b/cmd/caib/inspectcmd/inspect_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	"gopkg.in/yaml.v3"
 )
 
@@ -338,5 +339,24 @@ func TestPrintProvenance_NoAnnotations(t *testing.T) {
 
 	if !strings.Contains(out, "No automotive build annotations found") {
 		t.Error("should show no-annotations message")
+	}
+}
+
+func TestPrintProvenance_QuietMode(t *testing.T) {
+	clilog.SetQuiet(true)
+	defer clilog.SetQuiet(false)
+
+	h := NewHandler(Options{})
+	annotations := fullAnnotations()
+	referrerTypes := map[string]bool{
+		"application/vnd.automotive.manifest.v1+yaml": true,
+	}
+
+	out := captureStdout(t, func() {
+		h.printProvenance("quay.io/org/repo:v1", "sha256:abc", annotations, nil, referrerTypes)
+	})
+
+	if out != "" {
+		t.Errorf("expected no output in quiet mode, got: %s", out)
 	}
 }


### PR DESCRIPTION
## Summary

- `printProvenance` now checks `clilog.IsQuiet()` and returns early, so `caib image inspect --quiet <ref>` no longer dumps provenance text to stdout
- Structured JSON/YAML output is unaffected (uses a separate code path)

Related issue: https://github.com/mickume/automotive-dev-operator/issues/7

## Changes

| File | Change |
|------|--------|
| `cmd/caib/inspectcmd/inspect.go` | Added `clilog.IsQuiet()` guard at top of `printProvenance` |
| `cmd/caib/inspectcmd/inspect_test.go` | Added `TestPrintProvenance_QuietMode` regression test |

## Tests

- `TestPrintProvenance_QuietMode` — verifies quiet mode produces no stdout output from provenance display

## Verification

- All existing tests pass: ✅
- New test passes: ✅
- Linter / formatter: ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*

@coderabbitai ignore
