### PR TITLE
fix(caib): suppress auth flow stderr messages in quiet mode (fixes #8)

### DIFF
--- a/cmd/caib/clilog/clilog.go
+++ b/cmd/caib/clilog/clilog.go
@@ -30,6 +30,20 @@ func Infoln(a ...any) {
 	}
 }
 
+// Statusf prints a formatted status message to stderr unless quiet mode is enabled.
+func Statusf(format string, a ...any) {
+	if !quiet {
+		fmt.Fprintf(os.Stderr, format, a...)
+	}
+}
+
+// Statusln prints a status message line to stderr unless quiet mode is enabled.
+func Statusln(a ...any) {
+	if !quiet {
+		fmt.Fprintln(os.Stderr, a...)
+	}
+}
+
 // Warnf prints a formatted warning to stderr. Warnings are never suppressed by quiet mode.
 func Warnf(format string, a ...any) {
 	fmt.Fprintf(os.Stderr, "Warning: "+format, a...)

--- a/cmd/caib/clilog/clilog_test.go
+++ b/cmd/caib/clilog/clilog_test.go
@@ -71,3 +71,67 @@ func TestInfolnSuppressedWhenQuiet(t *testing.T) {
 		t.Errorf("expected empty output, got %q", out)
 	}
 }
+
+func captureStderr(fn func()) string {
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	fn()
+	_ = w.Close()
+	os.Stderr = old
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	return buf.String()
+}
+
+func TestStatusfOutputWhenNotQuiet(t *testing.T) {
+	SetQuiet(false)
+	out := captureStderr(func() {
+		Statusf("connecting to %s\n", "server")
+	})
+	if out != "connecting to server\n" {
+		t.Errorf("expected 'connecting to server\\n', got %q", out)
+	}
+}
+
+func TestStatusfSuppressedWhenQuiet(t *testing.T) {
+	SetQuiet(true)
+	defer SetQuiet(false)
+	out := captureStderr(func() {
+		Statusf("should not appear")
+	})
+	if out != "" {
+		t.Errorf("expected empty stderr, got %q", out)
+	}
+}
+
+func TestStatuslnOutputWhenNotQuiet(t *testing.T) {
+	SetQuiet(false)
+	out := captureStderr(func() {
+		Statusln("auth", "complete")
+	})
+	if out != "auth complete\n" {
+		t.Errorf("expected 'auth complete\\n', got %q", out)
+	}
+}
+
+func TestStatuslnSuppressedWhenQuiet(t *testing.T) {
+	SetQuiet(true)
+	defer SetQuiet(false)
+	out := captureStderr(func() {
+		Statusln("should not appear")
+	})
+	if out != "" {
+		t.Errorf("expected empty stderr, got %q", out)
+	}
+}
+
+func TestStatusfWritesToStderrNotStdout(t *testing.T) {
+	SetQuiet(false)
+	stdout := captureStdout(func() {
+		Statusf("stderr only\n")
+	})
+	if stdout != "" {
+		t.Errorf("Statusf should not write to stdout, got %q", stdout)
+	}
+}

--- a/cmd/caib/common/api_client.go
+++ b/cmd/caib/common/api_client.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/auth"
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	buildapiclient "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi/client"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -35,8 +36,8 @@ func CreateBuildAPIClient(serverURL string, authToken *string, insecureSkipTLS b
 	if !explicitToken {
 		token, didAuth, err := auth.GetTokenWithReauth(ctx, serverURL, "", insecureSkipTLS)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: OIDC authentication failed: %v\n", err)
-			fmt.Fprintln(os.Stderr, "Attempting kubeconfig fallback (this may use a different identity)")
+			clilog.Statusf("Error: OIDC authentication failed: %v\n", err)
+			clilog.Statusln("Attempting kubeconfig fallback (this may use a different identity)")
 			if tok, loadErr := LoadTokenFromKubeconfig(); loadErr == nil && strings.TrimSpace(tok) != "" {
 				setToken(tok)
 			} else {
@@ -45,7 +46,7 @@ func CreateBuildAPIClient(serverURL string, authToken *string, insecureSkipTLS b
 		} else if token != "" {
 			setToken(token)
 			if didAuth {
-				fmt.Fprintln(os.Stderr, "OIDC authentication successful")
+				clilog.Statusln("OIDC authentication successful")
 			}
 		} else if tok, loadErr := LoadTokenFromKubeconfig(); loadErr == nil && strings.TrimSpace(tok) != "" {
 			setToken(tok)
@@ -113,14 +114,14 @@ func ExecuteWithReauth(
 		return err
 	}
 
-	fmt.Fprintln(os.Stderr, "Authentication failed (401), re-authenticating...")
+	clilog.Statusln("Authentication failed (401), re-authenticating...")
 	newToken, _, err := auth.GetTokenWithReauth(ctx, serverURL, currentToken, insecureSkipTLS)
 	if err != nil {
 		return fmt.Errorf("re-authentication failed: %w", err)
 	}
 	setToken(newToken)
 
-	fmt.Fprintln(os.Stderr, "Retrying request...")
+	clilog.Statusln("Retrying request...")
 	err = runWithFreshClient()
 	if err == nil {
 		return nil
@@ -131,7 +132,7 @@ func ExecuteWithReauth(
 
 	if tok, loadErr := LoadTokenFromKubeconfig(); loadErr == nil && strings.TrimSpace(tok) != "" {
 		setToken(tok)
-		fmt.Fprintln(os.Stderr, "Attempting kubeconfig fallback...")
+		clilog.Statusln("Attempting kubeconfig fallback...")
 		return runWithFreshClient()
 	}
 

--- a/cmd/caib/config/config.go
+++ b/cmd/caib/config/config.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	"gopkg.in/yaml.v3"
 )
 
@@ -188,7 +189,7 @@ func DeriveServerFromJumpstarter() string {
 			continue
 		}
 
-		fmt.Fprintf(os.Stderr, "Using Build API server derived from Jumpstarter config: %s\n", apiURL)
+		clilog.Statusf("Using Build API server derived from Jumpstarter config: %s\n", apiURL)
 		if err := saveDerivedServerURL(apiURL, rawEndpoint); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: could not save derived server URL to config: %v\n", err)
 		}


### PR DESCRIPTION
## Summary

Extended `clilog` with `Statusf`/`Statusln` — quiet-aware functions that write to stderr and are suppressed when `--quiet` or `--output-format json/yaml` is active. Replaced all 7 raw `fmt.Fprintf/Fprintln(os.Stderr, ...)` auth-flow and config-derivation messages with the new functions, completing the `clilog` output matrix.

Related issue: https://github.com/mickume/automotive-dev-operator/issues/8

## Changes

| File | Change |
|------|--------|
| `cmd/caib/clilog/clilog.go` | Added `Statusf` and `Statusln` (stderr, quiet-suppressible) |
| `cmd/caib/clilog/clilog_test.go` | Added 5 tests covering output, suppression, and stderr-only behavior |
| `cmd/caib/common/api_client.go` | Replaced 6 raw stderr writes with `clilog.Statusf`/`Statusln` |
| `cmd/caib/config/config.go` | Replaced 1 raw stderr write with `clilog.Statusf` |

## Tests

- `cmd/caib/clilog/clilog_test.go`: 5 new tests for `Statusf`/`Statusln`

## Verification

- All existing tests pass: ✅
- New tests pass: ✅
- Linter / formatter: ✅ (no new issues)
- No regressions: ✅

---
*Auto-generated by `af-fix`.*