### PR TITLE
refactor(caib): consolidate output format handling and formatAge

### DIFF
--- a/cmd/caib/catalog/catalog_test.go
+++ b/cmd/caib/catalog/catalog_test.go
@@ -2,7 +2,6 @@ package catalog
 
 import (
 	"testing"
-	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -46,37 +45,6 @@ func TestGetOutputFormat_FallbackWithoutFlag(t *testing.T) {
 	cmd := &cobra.Command{Use: "standalone"}
 	if got := getOutputFormat(cmd); got != testFormatTable {
 		t.Errorf("expected fallback %q, got %q", testFormatTable, got)
-	}
-}
-
-func TestFormatAge(t *testing.T) {
-	tests := []struct {
-		name   string
-		offset time.Duration
-		want   string
-	}{
-		{"seconds ago", 30 * time.Second, "30s"},
-		{"minutes ago", 5 * time.Minute, "5m"},
-		{"hours ago", 3 * time.Hour, "3h"},
-		{"days ago", 2 * 24 * time.Hour, "2d"},
-		{"months ago", 60 * 24 * time.Hour, "2mo"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ts := time.Now().Add(-tt.offset).Format(time.RFC3339)
-			got := formatAge(ts)
-			if got != tt.want {
-				t.Errorf("formatAge(%q) = %q, want %q", ts, got, tt.want)
-			}
-		})
-	}
-}
-
-func TestFormatAge_InvalidTimestamp(t *testing.T) {
-	got := formatAge("not-a-timestamp")
-	if got != "not-a-timestamp" {
-		t.Errorf("expected raw string passthrough, got %q", got)
 	}
 }
 

--- a/cmd/caib/catalog/list.go
+++ b/cmd/caib/catalog/list.go
@@ -20,17 +20,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
 	"text/tabwriter"
-	"time"
 
+	caibcommon "github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/common"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/config"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -192,22 +190,18 @@ func runList(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	// Output in requested format
-	format := strings.ToLower(strings.TrimSpace(getOutputFormat(cmd)))
-	switch format {
-	case "json":
-		output, _ := json.MarshalIndent(result, "", "  ")
-		fmt.Println(string(output))
-	case "yaml", "yml":
-		output, _ := yaml.Marshal(result)
-		fmt.Println(string(output))
-	case outputFormatTable:
-		printTable(result.Items, listTags != "")
-	default:
-		return fmt.Errorf("invalid output format %q (supported: table, json, yaml)", format)
+	rawFormat := getOutputFormat(cmd)
+	format, fmtErr := caibcommon.ResolveOutputFormat(&rawFormat)
+	if fmtErr != nil {
+		return fmtErr
 	}
 
-	return nil
+	var renderErr error
+	caibcommon.RenderFormatted(format, result, func() error {
+		printTable(result.Items, listTags != "")
+		return nil
+	}, func(err error) { renderErr = err })
+	return renderErr
 }
 
 func printTable(items []CatalogImageResponse, tagsFiltered bool) {
@@ -239,7 +233,7 @@ func printTable(items []CatalogImageResponse, tagsFiltered bool) {
 			target = img.Targets[0].Name
 		}
 
-		age := formatAge(img.CreatedAt)
+		age := caibcommon.FormatAge(img.CreatedAt)
 
 		if tagsFiltered {
 			if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
@@ -276,34 +270,4 @@ func printTable(items []CatalogImageResponse, tagsFiltered bool) {
 
 	_, _ = fmt.Fprintf(w, "\n")
 	_, _ = fmt.Fprintf(os.Stderr, "%d image(s)\n", len(items))
-}
-
-// formatAge converts an RFC3339 timestamp to a human-readable relative duration.
-func formatAge(timestamp string) string {
-	t, err := time.Parse(time.RFC3339, timestamp)
-	if err != nil {
-		return timestamp
-	}
-
-	d := time.Since(t)
-	if d < 0 {
-		return "future"
-	}
-
-	switch {
-	case d < time.Minute:
-		return fmt.Sprintf("%ds", int(d.Seconds()))
-	case d < time.Hour:
-		return fmt.Sprintf("%dm", int(d.Minutes()))
-	case d < 24*time.Hour:
-		return fmt.Sprintf("%dh", int(d.Hours()))
-	case d < 30*24*time.Hour:
-		return fmt.Sprintf("%dd", int(math.Floor(d.Hours()/24)))
-	default:
-		months := int(math.Floor(d.Hours() / (24 * 30)))
-		if months < 12 {
-			return fmt.Sprintf("%dmo", months)
-		}
-		return fmt.Sprintf("%dy", int(math.Floor(d.Hours()/(24*365))))
-	}
 }

--- a/cmd/caib/common/format_age.go
+++ b/cmd/caib/common/format_age.go
@@ -1,0 +1,41 @@
+package caibcommon
+
+import (
+	"fmt"
+	"math"
+	"time"
+)
+
+// FormatAge converts an RFC3339 timestamp to a human-readable relative duration.
+func FormatAge(timestamp string) string {
+	return formatAgeFrom(timestamp, time.Now())
+}
+
+func formatAgeFrom(timestamp string, now time.Time) string {
+	t, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		return timestamp
+	}
+
+	d := now.Sub(t)
+	if d < 0 {
+		return "future"
+	}
+
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	case d < 30*24*time.Hour:
+		return fmt.Sprintf("%dd", int(math.Floor(d.Hours()/24)))
+	default:
+		months := int(math.Floor(d.Hours() / (24 * 30)))
+		if months < 12 {
+			return fmt.Sprintf("%dmo", months)
+		}
+		return fmt.Sprintf("%dy", int(math.Floor(d.Hours()/(24*365))))
+	}
+}

--- a/cmd/caib/common/format_age_test.go
+++ b/cmd/caib/common/format_age_test.go
@@ -1,0 +1,41 @@
+package caibcommon
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFormatAge(t *testing.T) {
+	ref := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name   string
+		offset time.Duration
+		want   string
+	}{
+		{"seconds ago", 30 * time.Second, "30s"},
+		{"minutes ago", 5 * time.Minute, "5m"},
+		{"hours ago", 3 * time.Hour, "3h"},
+		{"days ago", 2 * 24 * time.Hour, "2d"},
+		{"months ago", 60 * 24 * time.Hour, "2mo"},
+		{"years ago", 400 * 24 * time.Hour, "1y"},
+		{"future", -30 * time.Second, "future"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := ref.Add(-tt.offset).Format(time.RFC3339)
+			got := formatAgeFrom(ts, ref)
+			if got != tt.want {
+				t.Errorf("formatAgeFrom(%q, ref) = %q, want %q", ts, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatAge_InvalidTimestamp(t *testing.T) {
+	got := FormatAge("not-a-timestamp")
+	if got != "not-a-timestamp" {
+		t.Errorf("expected raw string passthrough, got %q", got)
+	}
+}

--- a/cmd/caib/querycmd/query.go
+++ b/cmd/caib/querycmd/query.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strings"
 	"text/tabwriter"
-	"time"
 
 	common "github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/common"
 	buildapitypes "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi"
@@ -220,7 +219,7 @@ func printBuildList(items []buildapitypes.BuildListItem) error {
 			"%s\t%s\t%s\t%s\t%s\n",
 			it.Name,
 			it.Phase,
-			formatAge(it.CreatedAt),
+			common.FormatAge(it.CreatedAt),
 			it.RequestedBy,
 			artifact,
 		); err != nil {
@@ -282,22 +281,4 @@ func valueOrDash(v string) string {
 		return "-"
 	}
 	return v
-}
-
-func formatAge(rfcTime string) string {
-	t, err := time.Parse(time.RFC3339, rfcTime)
-	if err != nil {
-		return rfcTime
-	}
-	d := time.Since(t)
-	switch {
-	case d < time.Minute:
-		return fmt.Sprintf("%ds", int(d.Seconds()))
-	case d < time.Hour:
-		return fmt.Sprintf("%dm", int(d.Minutes()))
-	case d < 24*time.Hour:
-		return fmt.Sprintf("%dh", int(d.Hours()))
-	default:
-		return fmt.Sprintf("%dd", int(d.Hours()/24))
-	}
 }

--- a/cmd/caib/querycmd/query_test.go
+++ b/cmd/caib/querycmd/query_test.go
@@ -317,11 +317,3 @@ func TestValueOrDash(t *testing.T) {
 		}
 	}
 }
-
-func TestFormatAge(t *testing.T) {
-	// non-RFC3339 input should be returned as-is
-	got := formatAge("not-a-date")
-	if got != "not-a-date" {
-		t.Errorf("formatAge(invalid) = %q, want %q", got, "not-a-date")
-	}
-}

--- a/cmd/caib/status.go
+++ b/cmd/caib/status.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"crypto/tls"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -10,10 +9,10 @@ import (
 	"text/tabwriter"
 	"time"
 
+	caibcommon "github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/common"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/config"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -54,28 +53,17 @@ type serverInfo struct {
 }
 
 func runStatus(_ *cobra.Command, _ []string) {
-	info := gatherStatus()
-
-	switch strings.ToLower(statusOutputFormat) {
-	case "json":
-		out, err := json.MarshalIndent(info, "", "  ")
-		if err != nil {
-			handleError(fmt.Errorf("error rendering JSON: %w", err))
-			return
-		}
-		fmt.Println(string(out))
-	case "yaml", "yml":
-		out, err := yaml.Marshal(info)
-		if err != nil {
-			handleError(fmt.Errorf("error rendering YAML: %w", err))
-			return
-		}
-		fmt.Print(string(out))
-	case "table":
-		printStatusTable(info)
-	default:
-		handleError(fmt.Errorf("invalid output format %q (supported: table, json, yaml)", statusOutputFormat))
+	format, err := caibcommon.ResolveOutputFormat(&statusOutputFormat)
+	if err != nil {
+		handleError(err)
+		return
 	}
+
+	info := gatherStatus()
+	caibcommon.RenderFormatted(format, info, func() error {
+		printStatusTable(info)
+		return nil
+	}, handleError)
 }
 
 func gatherStatus() statusInfo {


### PR DESCRIPTION
Extract FormatAge to cmd/caib/common/ using the richer catalog implementation (months, years, future timestamps). Replace inline format switching in status.go and catalog/list.go with shared ResolveOutputFormat + RenderFormatted utilities.

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [X] Refactoring

## Testing
- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent relative-age formatting across catalog and query results, including seconds, minutes, hours, days, months, and years.
  * Future timestamps are displayed as “future,” while invalid timestamps remain unchanged.
* **Improvements**
  * Standardized JSON, YAML, and table output handling for catalog and status commands.
  * Improved consistency in formatted command-line output across supported views.
  * Consolidated output formatting and age display behavior for a more uniform command-line experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->