### PR TITLE
use clusterip instead of nodeport for dex

### DIFF
--- a/hack/e2e/dex.values.yaml
+++ b/hack/e2e/dex.values.yaml
@@ -32,10 +32,9 @@ volumeMounts:
   - name: tls
     mountPath: /etc/dex/tls
 service:
-  type: NodePort
+  type: ClusterIP
   ports:
     http:
       port: 5554
     https:
       port: 5556
-      nodePort: 32000


### PR DESCRIPTION
avoid port collision, and nodeport was unused regardless

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [X] CI/CD improvement
- [ ] Refactoring

## Testing
- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Dex service networking configuration to use internal cluster access.
  * Removed external node-port exposure from the HTTPS endpoint while retaining existing HTTP and HTTPS service ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->