### PR TITLE
feat(catalog): default list to Available heads per schedule

### DIFF
--- a/cmd/caib/catalog/catalog_test.go
+++ b/cmd/caib/catalog/catalog_test.go
@@ -48,6 +48,15 @@ func TestGetOutputFormat_FallbackWithoutFlag(t *testing.T) {
 	}
 }
 
+func TestCatalogAgeTimestamp(t *testing.T) {
+	if got := catalogAgeTimestamp("created", "published"); got != "published" {
+		t.Errorf("catalogAgeTimestamp() = %q, want published", got)
+	}
+	if got := catalogAgeTimestamp("created", ""); got != "created" {
+		t.Errorf("catalogAgeTimestamp() = %q, want created", got)
+	}
+}
+
 func TestFormatBytes(t *testing.T) {
 	tests := []struct {
 		input int64

--- a/cmd/caib/catalog/get.go
+++ b/cmd/caib/catalog/get.go
@@ -144,6 +144,7 @@ func printImageDetails(img CatalogImageResponse) {
 	rows := [][2]string{
 		{"Name", img.Name},
 		{"Registry URL", img.RegistryURL},
+		{"Digest", img.Digest},
 		{"Phase", img.Phase},
 		{"Architecture", img.Architecture},
 		{"Distro", img.Distro},
@@ -151,6 +152,7 @@ func printImageDetails(img CatalogImageResponse) {
 		{"Build Mode", img.BuildMode},
 		{"Export Format", img.ExportFormat},
 		{"Created At", img.CreatedAt},
+		{"Published At", img.PublishedAt},
 	}
 	if img.ScheduleName != "" {
 		rows = append(rows, [2]string{"Schedule", img.ScheduleName})

--- a/cmd/caib/catalog/list.go
+++ b/cmd/caib/catalog/list.go
@@ -39,6 +39,7 @@ var (
 	listTags         string
 	listSort         string
 	listLatest       bool
+	listAll          bool
 	listLimit        int
 )
 
@@ -47,8 +48,9 @@ func newListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List images in the catalog",
 		Long: `List images in the catalog with optional filtering by architecture, distribution,
-target, and phase. Use --latest to show only the newest image per schedule
-(or per distro/arch/target group for non-scheduled images).`,
+target, and phase. By default the API returns Available heads (newest per schedule,
+or per distro/arch/target for unscheduled images). Use --all to list every catalog
+image regardless of phase.`,
 		RunE: runList,
 	}
 
@@ -56,10 +58,11 @@ target, and phase. Use --latest to show only the newest image per schedule
 	cmd.Flags().StringVar(&listArchitecture, "architecture", "", "Filter by architecture (amd64, arm64)")
 	cmd.Flags().StringVar(&listDistro, "distro", "", "Filter by distribution (cs9, autosd10-sig)")
 	cmd.Flags().StringVar(&listTarget, "target", "", "Filter by hardware target (qemu, raspberry-pi)")
-	cmd.Flags().StringVar(&listPhase, "phase", "", "Filter by phase (Available, Unavailable, etc)")
+	cmd.Flags().StringVar(&listPhase, "phase", "", "Filter by phase (Available, Unavailable, Failed, all)")
 	cmd.Flags().StringVar(&listTags, "tags", "", "Filter by tags (comma-separated)")
 	cmd.Flags().StringVar(&listSort, "sort", "created", "Sort order: created (newest first), name")
-	cmd.Flags().BoolVar(&listLatest, "latest", false, "Show only the latest image per schedule or distro/arch/target group")
+	cmd.Flags().BoolVar(&listLatest, "latest", false, "Show only the latest image per schedule or distro/arch/target group (API default)")
+	cmd.Flags().BoolVar(&listAll, "all", false, "List all catalog images (all phases, not only latest heads)")
 	cmd.Flags().IntVar(&listLimit, "limit", 20, "Maximum results to show")
 
 	return cmd
@@ -130,8 +133,16 @@ func runList(cmd *cobra.Command, _ []string) error {
 	if listTarget != "" {
 		params.Set("target", listTarget)
 	}
-	if listPhase != "" {
-		params.Set("phase", listPhase)
+	if listAll {
+		params.Set("phase", "all")
+		params.Set("latest", "false")
+	} else {
+		if listPhase != "" {
+			params.Set("phase", listPhase)
+		}
+		if listLatest {
+			params.Set("latest", "true")
+		}
 	}
 	if listTags != "" {
 		params.Set("tags", listTags)
@@ -141,9 +152,6 @@ func runList(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("invalid --sort value %q (supported: created, name)", listSort)
 		}
 		params.Set("sort", listSort)
-	}
-	if listLatest {
-		params.Set("latest", "true")
 	}
 	if listLimit > 0 {
 		params.Set("limit", fmt.Sprintf("%d", listLimit))

--- a/cmd/caib/catalog/list.go
+++ b/cmd/caib/catalog/list.go
@@ -87,6 +87,7 @@ type CatalogImageResponse struct {
 	Architecture     string            `json:"architecture,omitempty"`
 	Distro           string            `json:"distro,omitempty"`
 	Targets          []Target          `json:"targets,omitempty"`
+	Digest           string            `json:"digest,omitempty"`
 	Tags             []string          `json:"tags,omitempty"`
 	SourceType       string            `json:"sourceType,omitempty"`
 	SourceImageBuild string            `json:"sourceImageBuild,omitempty"`
@@ -97,6 +98,7 @@ type CatalogImageResponse struct {
 	SizeBytes        int64             `json:"sizeBytes,omitempty"`
 	DownloadURL      string            `json:"downloadUrl,omitempty"`
 	CreatedAt        string            `json:"createdAt"`
+	PublishedAt      string            `json:"publishedAt,omitempty"`
 	StatusReason     string            `json:"statusReason,omitempty"`
 	StatusMessage    string            `json:"statusMessage,omitempty"`
 }
@@ -241,7 +243,7 @@ func printTable(items []CatalogImageResponse, tagsFiltered bool) {
 			target = img.Targets[0].Name
 		}
 
-		age := caibcommon.FormatAge(img.CreatedAt)
+		age := caibcommon.FormatAge(catalogAgeTimestamp(img.CreatedAt, img.PublishedAt))
 
 		if tagsFiltered {
 			if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
@@ -278,4 +280,11 @@ func printTable(items []CatalogImageResponse, tagsFiltered bool) {
 
 	_, _ = fmt.Fprintf(w, "\n")
 	_, _ = fmt.Fprintf(os.Stderr, "%d image(s)\n", len(items))
+}
+
+func catalogAgeTimestamp(createdAt, publishedAt string) string {
+	if publishedAt != "" {
+		return publishedAt
+	}
+	return createdAt
 }

--- a/internal/buildapi/catalog/handlers.go
+++ b/internal/buildapi/catalog/handlers.go
@@ -32,8 +32,10 @@ import (
 )
 
 const (
-	sortByCreated = "created"
-	sortByName    = "name"
+	sortByCreated    = "created"
+	sortByName       = "name"
+	phaseAll         = "all"
+	defaultListPhase = string(automotivev1alpha1.CatalogImagePhaseAvailable)
 )
 
 // Handler handles catalog API requests
@@ -65,11 +67,10 @@ func (h *Handler) HandleListCatalogImages(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid query parameters", "details": err.Error()})
 		return
 	}
+	normalizeListParams(&params)
 
 	// Build list options
-	listOpts := []client.ListOption{}
-
-	listOpts = append(listOpts, client.InNamespace(h.defaultNamespace))
+	listOpts := []client.ListOption{client.InNamespace(h.defaultNamespace)}
 
 	// Build label selector for filtering
 	labelRequirements := []string{}
@@ -100,7 +101,7 @@ func (h *Handler) HandleListCatalogImages(c *gin.Context) {
 		return
 	}
 
-	needsPostProcessing := params.Sort != "" || params.Latest
+	needsPostProcessing := listNeedsPostProcessing(params)
 
 	if !needsPostProcessing {
 		listOpts = append(listOpts, client.Limit(int64(effectiveLimit(params.Limit))))
@@ -365,6 +366,32 @@ func effectiveLimit(limit int) int {
 	return 20
 }
 
+//go:fix inline
+func boolPtr(v bool) *bool { return new(v) }
+
+func latestEnabled(params ListQueryParams) bool {
+	if params.Latest == nil {
+		return true
+	}
+	return *params.Latest
+}
+
+func normalizeListParams(params *ListQueryParams) {
+	if params.Phase == "" {
+		params.Phase = defaultListPhase
+	}
+	if strings.EqualFold(params.Phase, phaseAll) {
+		params.Phase = ""
+	}
+	if params.Latest == nil {
+		params.Latest = new(true)
+	}
+}
+
+func listNeedsPostProcessing(params ListQueryParams) bool {
+	return params.Sort != "" || latestEnabled(params) || params.Phase != "" || params.Tags != ""
+}
+
 func postFilterAndSort(items []automotivev1alpha1.CatalogImage, params ListQueryParams) []automotivev1alpha1.CatalogImage {
 	if params.Phase != "" {
 		filtered := []automotivev1alpha1.CatalogImage{}
@@ -387,7 +414,7 @@ func postFilterAndSort(items []automotivev1alpha1.CatalogImage, params ListQuery
 		items = filtered
 	}
 
-	if params.Latest {
+	if latestEnabled(params) {
 		sort.Slice(items, func(i, j int) bool {
 			return items[i].CreationTimestamp.After(items[j].CreationTimestamp.Time)
 		})

--- a/internal/buildapi/catalog/handlers.go
+++ b/internal/buildapi/catalog/handlers.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/go-logr/logr"
@@ -366,9 +367,6 @@ func effectiveLimit(limit int) int {
 	return 20
 }
 
-//go:fix inline
-func boolPtr(v bool) *bool { return new(v) }
-
 func latestEnabled(params ListQueryParams) bool {
 	if params.Latest == nil {
 		return true
@@ -416,7 +414,7 @@ func postFilterAndSort(items []automotivev1alpha1.CatalogImage, params ListQuery
 
 	if latestEnabled(params) {
 		sort.Slice(items, func(i, j int) bool {
-			return items[i].CreationTimestamp.After(items[j].CreationTimestamp.Time)
+			return catalogTime(items[i]).After(catalogTime(items[j]))
 		})
 		seen := map[string]bool{}
 		filtered := []automotivev1alpha1.CatalogImage{}
@@ -437,7 +435,7 @@ func postFilterAndSort(items []automotivev1alpha1.CatalogImage, params ListQuery
 	switch sortBy {
 	case sortByCreated:
 		sort.Slice(items, func(i, j int) bool {
-			return items[i].CreationTimestamp.After(items[j].CreationTimestamp.Time)
+			return catalogTime(items[i]).After(catalogTime(items[j]))
 		})
 	case sortByName:
 		sort.Slice(items, func(i, j int) bool {
@@ -461,6 +459,15 @@ func latestGroupKey(img *automotivev1alpha1.CatalogImage) string {
 		return "name:" + img.Name
 	}
 	return distro + "/" + arch + "/" + target
+}
+
+// catalogTime is when the catalog row last became the published head.
+// Overwrite-in-place does not bump creationTimestamp.
+func catalogTime(img automotivev1alpha1.CatalogImage) time.Time {
+	if img.Status.PublishedAt != nil && !img.Status.PublishedAt.Time.IsZero() {
+		return img.Status.PublishedAt.Time
+	}
+	return img.CreationTimestamp.Time
 }
 
 // hasAllTags checks if the image has all the requested tags

--- a/internal/buildapi/catalog/handlers_test.go
+++ b/internal/buildapi/catalog/handlers_test.go
@@ -94,6 +94,9 @@ func TestHandleListCatalogImages_SortByCreated(t *testing.T) {
 			CreationTimestamp: metav1.Time{Time: metav1.Now().Add(-2 * 24 * time.Hour)},
 		},
 		Spec: automotivev1alpha1.CatalogImageSpec{RegistryURL: "quay.io/test/older:v1"},
+		Status: automotivev1alpha1.CatalogImageStatus{
+			Phase: automotivev1alpha1.CatalogImagePhaseAvailable,
+		},
 	}
 	newer := &automotivev1alpha1.CatalogImage{
 		ObjectMeta: metav1.ObjectMeta{
@@ -102,6 +105,9 @@ func TestHandleListCatalogImages_SortByCreated(t *testing.T) {
 			CreationTimestamp: metav1.Time{Time: metav1.Now().Time},
 		},
 		Spec: automotivev1alpha1.CatalogImageSpec{RegistryURL: "quay.io/test/newer:v1"},
+		Status: automotivev1alpha1.CatalogImageStatus{
+			Phase: automotivev1alpha1.CatalogImagePhaseAvailable,
+		},
 	}
 
 	h, _ := newTestHandler(older, newer)
@@ -170,6 +176,9 @@ func TestHandleListCatalogImages_Latest(t *testing.T) {
 					},
 				},
 				Spec: automotivev1alpha1.CatalogImageSpec{RegistryURL: "quay.io/test/older:v1"},
+				Status: automotivev1alpha1.CatalogImageStatus{
+					Phase: automotivev1alpha1.CatalogImagePhaseAvailable,
+				},
 			}
 			newer := &automotivev1alpha1.CatalogImage{
 				ObjectMeta: metav1.ObjectMeta{
@@ -181,6 +190,9 @@ func TestHandleListCatalogImages_Latest(t *testing.T) {
 					},
 				},
 				Spec: automotivev1alpha1.CatalogImageSpec{RegistryURL: "quay.io/test/newer:v1"},
+				Status: automotivev1alpha1.CatalogImageStatus{
+					Phase: automotivev1alpha1.CatalogImagePhaseAvailable,
+				},
 			}
 
 			h, _ := newTestHandler(older, newer)
@@ -208,6 +220,149 @@ func TestHandleListCatalogImages_Latest(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHandleListCatalogImages_DefaultAvailableLatest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	pending := &automotivev1alpha1.CatalogImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "pending-head",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: metav1.Now().Time},
+			Labels: map[string]string{
+				automotivev1alpha1.LabelScheduledImageBuildName: "nightly-qemu",
+			},
+		},
+		Spec:   automotivev1alpha1.CatalogImageSpec{RegistryURL: "quay.io/test/pending:v1"},
+		Status: automotivev1alpha1.CatalogImageStatus{Phase: automotivev1alpha1.CatalogImagePhasePending},
+	}
+	olderAvailable := &automotivev1alpha1.CatalogImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "older-available",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: metav1.Now().Add(-48 * time.Hour)},
+			Labels: map[string]string{
+				automotivev1alpha1.LabelScheduledImageBuildName: "nightly-qemu",
+			},
+		},
+		Spec:   automotivev1alpha1.CatalogImageSpec{RegistryURL: "quay.io/test/older:v1"},
+		Status: automotivev1alpha1.CatalogImageStatus{Phase: automotivev1alpha1.CatalogImagePhaseAvailable},
+	}
+	newerAvailable := &automotivev1alpha1.CatalogImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "newer-available",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: metav1.Now().Add(-24 * time.Hour)},
+			Labels: map[string]string{
+				automotivev1alpha1.LabelScheduledImageBuildName: "nightly-qemu",
+			},
+		},
+		Spec:   automotivev1alpha1.CatalogImageSpec{RegistryURL: "quay.io/test/newer:v1"},
+		Status: automotivev1alpha1.CatalogImageStatus{Phase: automotivev1alpha1.CatalogImagePhaseAvailable},
+	}
+	otherSchedule := &automotivev1alpha1.CatalogImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "other-schedule",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: metav1.Now().Add(-12 * time.Hour)},
+			Labels: map[string]string{
+				automotivev1alpha1.LabelScheduledImageBuildName: "nightly-ebbr",
+			},
+		},
+		Spec:   automotivev1alpha1.CatalogImageSpec{RegistryURL: "quay.io/test/ebbr:v1"},
+		Status: automotivev1alpha1.CatalogImageStatus{Phase: automotivev1alpha1.CatalogImagePhaseAvailable},
+	}
+
+	h, _ := newTestHandler(pending, olderAvailable, newerAvailable, otherSchedule)
+	router := gin.New()
+	router.GET("/catalog/images", h.HandleListCatalogImages)
+
+	req := httptest.NewRequest(http.MethodGet, "/catalog/images", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp CatalogImageListResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Items) != 2 {
+		t.Fatalf("expected 2 Available heads, got %d: %+v", len(resp.Items), namesOf(resp.Items))
+	}
+	got := map[string]bool{}
+	for _, item := range resp.Items {
+		got[item.Name] = true
+		if item.Phase != string(automotivev1alpha1.CatalogImagePhaseAvailable) {
+			t.Errorf("expected Available, got %s for %s", item.Phase, item.Name)
+		}
+	}
+	if !got["newer-available"] || !got["other-schedule"] {
+		t.Errorf("expected newer-available and other-schedule, got %v", namesOf(resp.Items))
+	}
+	if got["pending-head"] || got["older-available"] {
+		t.Errorf("default list should omit pending and superseded heads, got %v", namesOf(resp.Items))
+	}
+}
+
+func TestHandleListCatalogImages_PhaseAllLatestFalse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	pending := &automotivev1alpha1.CatalogImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "pending-head",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: metav1.Now().Time},
+			Labels: map[string]string{
+				automotivev1alpha1.LabelScheduledImageBuildName: "nightly-qemu",
+			},
+		},
+		Spec:   automotivev1alpha1.CatalogImageSpec{RegistryURL: "quay.io/test/pending:v1"},
+		Status: automotivev1alpha1.CatalogImageStatus{Phase: automotivev1alpha1.CatalogImagePhasePending},
+	}
+	available := &automotivev1alpha1.CatalogImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "available-head",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: metav1.Now().Add(-24 * time.Hour)},
+			Labels: map[string]string{
+				automotivev1alpha1.LabelScheduledImageBuildName: "nightly-qemu",
+			},
+		},
+		Spec:   automotivev1alpha1.CatalogImageSpec{RegistryURL: "quay.io/test/available:v1"},
+		Status: automotivev1alpha1.CatalogImageStatus{Phase: automotivev1alpha1.CatalogImagePhaseAvailable},
+	}
+
+	h, _ := newTestHandler(pending, available)
+	router := gin.New()
+	router.GET("/catalog/images", h.HandleListCatalogImages)
+
+	req := httptest.NewRequest(http.MethodGet, "/catalog/images?phase=all&latest=false", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp CatalogImageListResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Items) != 2 {
+		t.Fatalf("expected 2 items with phase=all&latest=false, got %d: %v", len(resp.Items), namesOf(resp.Items))
+	}
+}
+
+func namesOf(items []CatalogImageResponse) []string {
+	names := make([]string, len(items))
+	for i, item := range items {
+		names[i] = item.Name
+	}
+	return names
 }
 
 func TestLatestGroupKey(t *testing.T) {

--- a/internal/buildapi/catalog/handlers_test.go
+++ b/internal/buildapi/catalog/handlers_test.go
@@ -135,6 +135,142 @@ func TestHandleListCatalogImages_SortByCreated(t *testing.T) {
 	}
 }
 
+func TestHandleListCatalogImages_SortByPublishedAt(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	oldCreate := metav1.NewTime(metav1.Now().Add(-48 * time.Hour))
+	newerPublish := metav1.NewTime(metav1.Now().Add(-time.Hour))
+	olderPublish := metav1.NewTime(metav1.Now().Add(-24 * time.Hour))
+
+	staleCreate := &automotivev1alpha1.CatalogImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "published-recently",
+			Namespace:         "default",
+			CreationTimestamp: oldCreate,
+		},
+		Spec: automotivev1alpha1.CatalogImageSpec{RegistryURL: "quay.io/test/old-create:v1"},
+		Status: automotivev1alpha1.CatalogImageStatus{
+			Phase:       automotivev1alpha1.CatalogImagePhaseAvailable,
+			PublishedAt: &newerPublish,
+		},
+	}
+	freshCreate := &automotivev1alpha1.CatalogImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "created-later",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: metav1.Now().Add(-2 * time.Hour)},
+		},
+		Spec: automotivev1alpha1.CatalogImageSpec{RegistryURL: "quay.io/test/new-create:v1"},
+		Status: automotivev1alpha1.CatalogImageStatus{
+			Phase:       automotivev1alpha1.CatalogImagePhaseAvailable,
+			PublishedAt: &olderPublish,
+		},
+	}
+
+	h, _ := newTestHandler(staleCreate, freshCreate)
+	router := gin.New()
+	router.GET("/catalog/images", h.HandleListCatalogImages)
+
+	req := httptest.NewRequest(http.MethodGet, "/catalog/images?sort=created&latest=false", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp CatalogImageListResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(resp.Items))
+	}
+	if resp.Items[0].Name != "published-recently" {
+		t.Errorf("expected published-recently first (newer publishedAt), got %s", resp.Items[0].Name)
+	}
+}
+
+func TestHandleListCatalogImages_LatestUsesPublishedAt(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	oldCreate := metav1.NewTime(metav1.Now().Add(-48 * time.Hour))
+	newerPublish := metav1.NewTime(metav1.Now().Add(-time.Hour))
+
+	olderHead := &automotivev1alpha1.CatalogImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "overwritten-head",
+			Namespace:         "default",
+			CreationTimestamp: oldCreate,
+			Labels: map[string]string{
+				automotivev1alpha1.LabelScheduledImageBuildName: "nightly-qemu",
+			},
+		},
+		Spec: automotivev1alpha1.CatalogImageSpec{RegistryURL: "quay.io/test/head:v2"},
+		Status: automotivev1alpha1.CatalogImageStatus{
+			Phase:       automotivev1alpha1.CatalogImagePhaseAvailable,
+			PublishedAt: &newerPublish,
+		},
+	}
+	newerCreate := &automotivev1alpha1.CatalogImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "legacy-timestamped",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: metav1.Now().Add(-2 * time.Hour)},
+			Labels: map[string]string{
+				automotivev1alpha1.LabelScheduledImageBuildName: "nightly-qemu",
+			},
+		},
+		Spec: automotivev1alpha1.CatalogImageSpec{RegistryURL: "quay.io/test/legacy:v1"},
+		Status: automotivev1alpha1.CatalogImageStatus{
+			Phase: automotivev1alpha1.CatalogImagePhaseAvailable,
+		},
+	}
+
+	h, _ := newTestHandler(olderHead, newerCreate)
+	router := gin.New()
+	router.GET("/catalog/images", h.HandleListCatalogImages)
+
+	req := httptest.NewRequest(http.MethodGet, "/catalog/images", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp CatalogImageListResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Items) != 1 {
+		t.Fatalf("expected 1 latest head, got %d: %v", len(resp.Items), namesOf(resp.Items))
+	}
+	if resp.Items[0].Name != "overwritten-head" {
+		t.Errorf("expected overwritten-head (newer publishedAt), got %s", resp.Items[0].Name)
+	}
+}
+
+func TestToCatalogImageResponse_DigestFallsBackToResolved(t *testing.T) {
+	img := &automotivev1alpha1.CatalogImage{
+		ObjectMeta: metav1.ObjectMeta{Name: "img", Namespace: "default"},
+		Spec:       automotivev1alpha1.CatalogImageSpec{RegistryURL: "quay.io/test/img:latest"},
+		Status: automotivev1alpha1.CatalogImageStatus{
+			RegistryMetadata: &automotivev1alpha1.RegistryMetadata{ResolvedDigest: "sha256:from-status"},
+		},
+	}
+	resp := ToCatalogImageResponse(img)
+	if resp.Digest != "sha256:from-status" {
+		t.Errorf("digest = %q, want resolved digest from status", resp.Digest)
+	}
+
+	img.Spec.Digest = "sha256:from-spec"
+	resp = ToCatalogImageResponse(img)
+	if resp.Digest != "sha256:from-spec" {
+		t.Errorf("digest = %q, want spec digest to win", resp.Digest)
+	}
+}
+
 func TestHandleListCatalogImages_Latest(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/internal/buildapi/catalog/models.go
+++ b/internal/buildapi/catalog/models.go
@@ -126,7 +126,7 @@ type ListQueryParams struct {
 	Phase        string `form:"phase"`
 	Tags         string `form:"tags"`
 	Sort         string `form:"sort"`
-	Latest       bool   `form:"latest"`
+	Latest       *bool  `form:"latest"`
 	Limit        int    `form:"limit,default=20"`
 	Continue     string `form:"continue"`
 }

--- a/internal/buildapi/catalog/models.go
+++ b/internal/buildapi/catalog/models.go
@@ -136,7 +136,7 @@ func ToCatalogImageResponse(catalogImage *automotivev1alpha1.CatalogImage) Catal
 	response := CatalogImageResponse{
 		Name:        catalogImage.Name,
 		RegistryURL: catalogImage.Spec.RegistryURL,
-		Digest:      catalogImage.Spec.Digest,
+		Digest:      catalogDigest(catalogImage),
 		Tags:        catalogImage.Spec.Tags,
 		Phase:       string(catalogImage.Status.Phase),
 		Labels:      catalogImage.Labels,
@@ -247,6 +247,16 @@ func resolveDownloadURL(catalogImage *automotivev1alpha1.CatalogImage) string {
 
 	// Default to registry URL
 	return catalogImage.Spec.RegistryURL
+}
+
+func catalogDigest(catalogImage *automotivev1alpha1.CatalogImage) string {
+	if catalogImage.Spec.Digest != "" {
+		return catalogImage.Spec.Digest
+	}
+	if catalogImage.Status.RegistryMetadata != nil {
+		return catalogImage.Status.RegistryMetadata.ResolvedDigest
+	}
+	return ""
 }
 
 // ToCatalogImageListResponse converts a list of CatalogImage CRs to an API response

--- a/internal/controller/catalogimage/publisher.go
+++ b/internal/controller/catalogimage/publisher.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/containers/image/v5/types"
 	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -104,8 +105,8 @@ type PublishResult struct {
 }
 
 // Publish creates or updates a CatalogImage and optionally verifies registry accessibility.
-// When a CatalogImage with the same registry URL already exists (common for scheduled builds
-// that push to a fixed tag), the existing entry is updated with the new build's metadata.
+// Existing entries are resolved by stable name first, then by registry URL (fixed-tag
+// scheduled builds). A URL match under a different name is re-homed to opts.Name.
 func (p *Publisher) Publish(ctx context.Context, opts PublishOptions) (*PublishResult, error) {
 	log := p.log.WithValues("name", opts.Name, "namespace", opts.Namespace, "registryURL", opts.RegistryURL)
 	log.Info("Publishing image to catalog")
@@ -121,7 +122,7 @@ func (p *Publisher) Publish(ctx context.Context, opts PublishOptions) (*PublishR
 		}
 	}
 
-	catalogImage, err := p.findExistingByRegistryURL(ctx, opts.Namespace, opts.RegistryURL)
+	catalogImage, stale, err := p.resolveExisting(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -137,9 +138,30 @@ func (p *Publisher) Publish(ctx context.Context, opts PublishOptions) (*PublishR
 		catalogImage = p.buildCatalogImage(opts)
 
 		if err := p.client.Create(ctx, catalogImage); err != nil {
-			return nil, fmt.Errorf("failed to create CatalogImage: %w", err)
+			if !apierrors.IsAlreadyExists(err) {
+				return nil, fmt.Errorf("failed to create CatalogImage: %w", err)
+			}
+			existing := &automotivev1alpha1.CatalogImage{}
+			if getErr := p.client.Get(ctx, client.ObjectKey{Name: opts.Name, Namespace: opts.Namespace}, existing); getErr != nil {
+				return nil, fmt.Errorf("failed to create CatalogImage: %w", err)
+			}
+			p.updateCatalogImage(existing, opts)
+			if updErr := p.client.Update(ctx, existing); updErr != nil {
+				return nil, fmt.Errorf("failed to update CatalogImage: %w", updErr)
+			}
+			catalogImage = existing
+			log.Info("Updated existing CatalogImage after create conflict", "name", catalogImage.Name, "verified", verified)
+		} else {
+			log.Info("Successfully created CatalogImage", "verified", verified)
 		}
-		log.Info("Successfully created CatalogImage", "verified", verified)
+	}
+
+	if stale != nil && stale.Name != catalogImage.Name {
+		if delErr := p.client.Delete(ctx, stale); delErr != nil && !apierrors.IsNotFound(delErr) {
+			log.Error(delErr, "Failed to delete stale CatalogImage after re-home", "staleName", stale.Name)
+		} else {
+			log.Info("Deleted stale CatalogImage after re-home", "staleName", stale.Name, "name", catalogImage.Name)
+		}
 	}
 
 	if p.auditRecorder != nil {
@@ -241,6 +263,44 @@ func (p *Publisher) PublishFromImageBuild(
 	})
 }
 
+// resolveExisting finds a CatalogImage to update. Prefer the stable name; fall back to
+// registry URL. A URL match with a different name is returned as stale so Publish can
+// create/update opts.Name and delete the leftover.
+func (p *Publisher) resolveExisting(
+	ctx context.Context,
+	opts PublishOptions,
+) (current *automotivev1alpha1.CatalogImage, stale *automotivev1alpha1.CatalogImage, err error) {
+	var named *automotivev1alpha1.CatalogImage
+	if opts.Name != "" {
+		got := &automotivev1alpha1.CatalogImage{}
+		getErr := p.client.Get(ctx, client.ObjectKey{Name: opts.Name, Namespace: opts.Namespace}, got)
+		if getErr == nil {
+			named = got
+		} else if client.IgnoreNotFound(getErr) != nil {
+			return nil, nil, fmt.Errorf("failed to get catalog image %s: %w", opts.Name, getErr)
+		}
+	}
+
+	byURL, err := p.findExistingByRegistryURL(ctx, opts.Namespace, opts.RegistryURL)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if named != nil {
+		if byURL != nil && byURL.Name != named.Name {
+			return named, byURL, nil
+		}
+		return named, nil, nil
+	}
+	if byURL != nil {
+		if opts.Name != "" && byURL.Name != opts.Name {
+			return nil, byURL, nil
+		}
+		return byURL, nil, nil
+	}
+	return nil, nil, nil
+}
+
 // findExistingByRegistryURL returns an existing CatalogImage with the same registry URL, or nil.
 func (p *Publisher) findExistingByRegistryURL(ctx context.Context, namespace, registryURL string) (*automotivev1alpha1.CatalogImage, error) {
 	lister := NewCatalogImageLister(p.client)
@@ -256,6 +316,7 @@ func (p *Publisher) findExistingByRegistryURL(ctx context.Context, namespace, re
 
 // updateCatalogImage applies new PublishOptions to an existing CatalogImage.
 func (p *Publisher) updateCatalogImage(catalogImage *automotivev1alpha1.CatalogImage, opts PublishOptions) {
+	catalogImage.Spec.RegistryURL = opts.RegistryURL
 	catalogImage.Spec.Digest = opts.Digest
 	catalogImage.Spec.Tags = opts.Tags
 	catalogImage.Spec.AuthSecretRef = opts.AuthSecretRef

--- a/internal/controller/catalogimage/publisher.go
+++ b/internal/controller/catalogimage/publisher.go
@@ -121,6 +121,9 @@ func (p *Publisher) Publish(ctx context.Context, opts PublishOptions) (*PublishR
 			log.Error(err, "Failed to verify registry accessibility")
 		}
 	}
+	if registryMetadata != nil && opts.Digest == "" && registryMetadata.ResolvedDigest != "" {
+		opts.Digest = registryMetadata.ResolvedDigest
+	}
 
 	catalogImage, stale, err := p.resolveExisting(ctx, opts)
 	if err != nil {
@@ -168,21 +171,17 @@ func (p *Publisher) Publish(ctx context.Context, opts PublishOptions) (*PublishR
 		p.auditRecorder.RecordPublished(ctx, catalogImage, string(opts.Source))
 	}
 
-	statusChanged := false
+	catalogImage.Status.PublishedAt = GetCurrentTime()
 	if opts.SourceImageBuildName != "" {
 		catalogImage.Status.SourceImageBuild = opts.SourceImageBuildName
-		statusChanged = true
 	}
 	if verified && registryMetadata != nil {
 		catalogImage.Status.RegistryMetadata = registryMetadata
 		catalogImage.Status.LastVerificationTime = GetCurrentTime()
 		catalogImage.Status.Phase = automotivev1alpha1.CatalogImagePhaseAvailable
-		statusChanged = true
 	}
-	if statusChanged {
-		if err := p.client.Status().Update(ctx, catalogImage); err != nil {
-			log.Error(err, "Failed to update status")
-		}
+	if err := p.client.Status().Update(ctx, catalogImage); err != nil {
+		log.Error(err, "Failed to update status")
 	}
 
 	return &PublishResult{

--- a/internal/controller/catalogimage/publisher_test.go
+++ b/internal/controller/catalogimage/publisher_test.go
@@ -19,6 +19,7 @@ package catalogimage
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/containers/image/v5/types"
 	"github.com/go-logr/logr"
@@ -72,7 +73,7 @@ func (s *stubRegistryClient) VerifyImageAccessible(_ context.Context, _ string, 
 }
 
 func (s *stubRegistryClient) GetImageMetadata(_ context.Context, _ string, _ *types.DockerAuthConfig) (*automotivev1alpha1.RegistryMetadata, error) {
-	return &automotivev1alpha1.RegistryMetadata{SizeBytes: 1024}, nil
+	return &automotivev1alpha1.RegistryMetadata{SizeBytes: 1024, ResolvedDigest: "sha256:abc123"}, nil
 }
 
 func (s *stubRegistryClient) VerifyDigest(_ context.Context, _ string, _ string, _ *types.DockerAuthConfig) (bool, string, error) {
@@ -118,6 +119,12 @@ func TestPublishFromImageBuild_PropagatesScheduleName(t *testing.T) {
 	}
 	if got := res.CatalogImage.Labels[automotivev1alpha1.LabelScheduledImageBuildName]; got != "nightly-autosd-qemu" {
 		t.Errorf("expected schedule label propagated, got %q", got)
+	}
+	if res.CatalogImage.Spec.Digest != "sha256:abc123" {
+		t.Errorf("expected digest persisted from registry, got %q", res.CatalogImage.Spec.Digest)
+	}
+	if res.CatalogImage.Status.PublishedAt == nil {
+		t.Error("expected PublishedAt to be set")
 	}
 }
 
@@ -218,6 +225,49 @@ func TestPublish_CreatesNewWhenNoExisting(t *testing.T) {
 
 	if result.CatalogImage.Name != "fresh-build" {
 		t.Errorf("expected name %q, got %q", "fresh-build", result.CatalogImage.Name)
+	}
+}
+
+func TestPublish_RefreshesPublishedAtOnOverwrite(t *testing.T) {
+	old := metav1.NewTime(time.Now().Add(-30 * 24 * time.Hour))
+	existing := &automotivev1alpha1.CatalogImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "nightly-qemu",
+			Namespace:         "default",
+			CreationTimestamp: old,
+		},
+		Spec: automotivev1alpha1.CatalogImageSpec{
+			RegistryURL: "quay.io/test/img:nightly",
+		},
+		Status: automotivev1alpha1.CatalogImageStatus{
+			PublishedAt: &old,
+			Phase:       automotivev1alpha1.CatalogImagePhaseAvailable,
+		},
+	}
+
+	pub := newFakePublisher(existing)
+	_, err := pub.Publish(context.Background(), PublishOptions{
+		Name:        "nightly-qemu",
+		Namespace:   "default",
+		RegistryURL: "quay.io/test/img:nightly",
+		Source:      PublishSourceScheduled,
+	})
+	if err != nil {
+		t.Fatalf("Publish() error: %v", err)
+	}
+
+	got := &automotivev1alpha1.CatalogImage{}
+	if err := pub.client.Get(context.Background(), client.ObjectKey{Name: "nightly-qemu", Namespace: "default"}, got); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status.PublishedAt == nil {
+		t.Fatal("expected PublishedAt to be set")
+	}
+	if !got.Status.PublishedAt.After(old.Time) {
+		t.Errorf("PublishedAt %v was not refreshed past %v", got.Status.PublishedAt.Time, old.Time)
+	}
+	if time.Since(got.CreationTimestamp.Time) < 24*time.Hour {
+		t.Errorf("creationTimestamp should remain the original create time, got %v", got.CreationTimestamp.Time)
 	}
 }
 

--- a/internal/controller/catalogimage/publisher_test.go
+++ b/internal/controller/catalogimage/publisher_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/containers/image/v5/types"
 	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -180,14 +181,20 @@ func TestPublish_UpdatesExistingOnDuplicateRegistryURL(t *testing.T) {
 		t.Fatalf("Publish() error: %v", err)
 	}
 
-	if result.CatalogImage.Name != "old-build-xyz" {
-		t.Errorf("expected existing CatalogImage name %q, got %q", "old-build-xyz", result.CatalogImage.Name)
+	if result.CatalogImage.Name != "new-build-abc" {
+		t.Errorf("expected CatalogImage re-homed to %q, got %q", "new-build-abc", result.CatalogImage.Name)
 	}
 	if len(result.CatalogImage.Spec.Tags) != 1 || result.CatalogImage.Spec.Tags[0] != "updated-tag" {
 		t.Errorf("expected tags [updated-tag], got %v", result.CatalogImage.Spec.Tags)
 	}
 	if result.CatalogImage.Spec.Metadata.Architecture != "aarch64" {
 		t.Errorf("expected arch aarch64, got %q", result.CatalogImage.Spec.Metadata.Architecture)
+	}
+
+	stale := &automotivev1alpha1.CatalogImage{}
+	err = pub.client.Get(context.Background(), client.ObjectKey{Name: "old-build-xyz", Namespace: "default"}, stale)
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("expected stale CatalogImage to be deleted, got err=%v", err)
 	}
 }
 

--- a/internal/controller/scheduledimagebuild/controller.go
+++ b/internal/controller/scheduledimagebuild/controller.go
@@ -49,6 +49,7 @@ const (
 
 	AnnotationCatalogPublished      = "automotive.sdv.cloud.redhat.com/catalog-published"
 	AnnotationCatalogPublishedValue = "true"
+	AnnotationCatalogImageName      = "automotive.sdv.cloud.redhat.com/catalog-image-name"
 
 	ConditionScheduled            = "Scheduled"
 	ConditionLastBuildSucceeded   = "LastBuildSucceeded"
@@ -84,7 +85,7 @@ type Reconciler struct {
 // +kubebuilder:rbac:groups=automotive.sdv.cloud.redhat.com,namespace=system,resources=scheduledimagebuilds/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=automotive.sdv.cloud.redhat.com,namespace=system,resources=scheduledimagebuilds/finalizers,verbs=update
 // +kubebuilder:rbac:groups=automotive.sdv.cloud.redhat.com,namespace=system,resources=imagebuilds,verbs=get;list;watch;create;delete;update;patch
-// +kubebuilder:rbac:groups=automotive.sdv.cloud.redhat.com,namespace=system,resources=catalogimages,verbs=get;list;create
+// +kubebuilder:rbac:groups=automotive.sdv.cloud.redhat.com,namespace=system,resources=catalogimages,verbs=get;list;create;update;patch;delete
 // +kubebuilder:rbac:groups="",namespace=system,resources=events,verbs=create;patch
 
 // Reconcile handles a single ScheduledImageBuild reconciliation loop.
@@ -351,7 +352,7 @@ func (r *Reconciler) publishToCatalog(ctx context.Context, sib *automotivev1alph
 		authSecretRef = sib.Spec.PublishToCatalog.AuthSecretRef
 	}
 
-	result, err := r.Publisher.PublishFromImageBuild(ctx, build, "", tags, authSecretRef)
+	result, err := r.Publisher.PublishFromImageBuild(ctx, build, catalogNameForPublish(sib, build), tags, authSecretRef)
 	if err != nil {
 		log.Error(err, "Failed to publish to catalog")
 		r.Recorder.Eventf(sib, corev1.EventTypeWarning, "PublishFailed",
@@ -573,6 +574,7 @@ func (r *Reconciler) createSingleImageBuild(ctx context.Context, sib *automotive
 
 	annotations := make(map[string]string)
 	maps.Copy(annotations, sib.Spec.ImageBuildTemplate.Metadata.Annotations)
+	annotations[AnnotationCatalogImageName] = catalogImageName(sib, combo)
 
 	spec := sib.Spec.ImageBuildTemplate.Spec.DeepCopy()
 	if combo.Architecture != "" {
@@ -696,6 +698,19 @@ func appendOCITagSuffix(ref, suffix string) string {
 		return ref[:i] + ":" + ref[i+1:] + suffix
 	}
 	return ref + ":latest" + suffix
+}
+
+func catalogImageName(sib *automotivev1alpha1.ScheduledImageBuild, combo matrixCombo) string {
+	return safeDerivedName(sib.Name, combo.suffix())
+}
+
+func catalogNameForPublish(sib *automotivev1alpha1.ScheduledImageBuild, build *automotivev1alpha1.ImageBuild) string {
+	if build.Annotations != nil {
+		if name := build.Annotations[AnnotationCatalogImageName]; name != "" {
+			return name
+		}
+	}
+	return sib.Name
 }
 
 func safeDerivedName(baseName, suffix string) string {

--- a/internal/controller/scheduledimagebuild/controller_test.go
+++ b/internal/controller/scheduledimagebuild/controller_test.go
@@ -454,8 +454,11 @@ func TestReconcile_AutoPublish(t *testing.T) {
 
 	published := false
 	publisher := &mockPublisher{
-		publishFn: func(_ context.Context, _ *automotivev1alpha1.ImageBuild, _ string, tags []string, _ *automotivev1alpha1.AuthSecretReference) (*catalogimage.PublishResult, error) {
+		publishFn: func(_ context.Context, _ *automotivev1alpha1.ImageBuild, name string, tags []string, _ *automotivev1alpha1.AuthSecretReference) (*catalogimage.PublishResult, error) {
 			published = true
+			if name != "test-publish" {
+				t.Errorf("Expected catalog name %q, got %q", "test-publish", name)
+			}
 			if len(tags) != 1 || tags[0] != "nightly" {
 				t.Errorf("Expected tags [nightly], got %v", tags)
 			}
@@ -552,6 +555,9 @@ func TestReconcile_TemplateLabelsAndAnnotations(t *testing.T) {
 	}
 	if build.Annotations["note"] != "nightly" {
 		t.Errorf("Expected annotation note=nightly, got %v", build.Annotations)
+	}
+	if build.Annotations[AnnotationCatalogImageName] != "test-meta" {
+		t.Errorf("Expected catalog-image-name %q, got %q", "test-meta", build.Annotations[AnnotationCatalogImageName])
 	}
 }
 
@@ -819,6 +825,11 @@ func TestReconcile_MatrixCreatesMultipleBuilds(t *testing.T) {
 		if b.Labels[automotivev1alpha1.LabelArchitecture] == "" {
 			t.Errorf("Missing architecture label on build %s", b.Name)
 		}
+		wantCatalog := catalogImageName(sib, matrixCombo{Architecture: b.Spec.Architecture})
+		if b.Annotations[AnnotationCatalogImageName] != wantCatalog {
+			t.Errorf("build %s: expected catalog-image-name %q, got %q",
+				b.Name, wantCatalog, b.Annotations[AnnotationCatalogImageName])
+		}
 	}
 	if !archSeen[archX86] || !archSeen[archARM] {
 		t.Errorf("Expected both architectures, got %v", archSeen)
@@ -898,6 +909,9 @@ func TestReconcile_NoMatrixBackwardCompatible(t *testing.T) {
 	}
 	if buildList.Items[0].Spec.Architecture != archX86 {
 		t.Errorf("Expected template architecture x86_64, got %s", buildList.Items[0].Spec.Architecture)
+	}
+	if got := buildList.Items[0].Annotations[AnnotationCatalogImageName]; got != "test-no-matrix" {
+		t.Errorf("Expected catalog-image-name %q, got %q", "test-no-matrix", got)
 	}
 }
 

--- a/test/e2e/catalog_discovery_test.go
+++ b/test/e2e/catalog_discovery_test.go
@@ -137,12 +137,13 @@ spec:
 			waitForCatalogPhase(newerName, "Available")
 		})
 
-		It("should sort by created date (newest first) by default", func() {
+		It("should sort by created date (newest first) with --all", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 
 			output, err := runCaibCommand(ctx,
 				"catalog", "list",
+				"--all",
 				"--tags", "nightly",
 				"--output-format", "json",
 			)
@@ -335,6 +336,7 @@ spec:
 
 			output, err := runCaibCommand(ctx,
 				"catalog", "list",
+				"--all",
 				"--distro", "autosd",
 				"--sort", "name",
 				"--output-format", "json",


### PR DESCRIPTION
Catalog is the current head, not the ImageBuild archive.

* GET /v1/catalog/images defaults to Available + latest (newest per schedule, or per distro/arch/target for unscheduled images). Full archive: phase=all&latest=false or caib catalog list --all.
* Scheduled publish overwrites one CatalogImage per schedule (plus matrix suffix) under a stable name, and deletes leftover URL matches.
* Overwrite refreshes publishedAt. List latest / sort=created and caib AGE use that (fall back to creationTimestamp).
* Verification copies the registry digest onto spec.digest. List/get expose it (status fallback for older CRs) so consumers can pin flashes.

<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an `--all` option to catalog listings to include images from every phase.
  - Catalog results now display image digests and publication timestamps.
  - Catalog listings default to available, latest images and support explicit filtering.
- **Improvements**
  - Sorting and “latest” selection now prioritize publication time, with creation time as a fallback.
  - Published images now reliably retain resolved digests and refresh publication details when overwritten.
  - Scheduled image builds now preserve their catalog image names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->