### PR TITLE
feat(catalog): flash by CatalogImage name

### DIFF
--- a/cmd/caib/flashcmd/flash.go
+++ b/cmd/caib/flashcmd/flash.go
@@ -109,12 +109,48 @@ func (h *Handler) RunFlash(cmd *cobra.Command, args []string) {
 	h.applyWaitFollowDefaults(cmd, true, false)
 
 	ctx := context.Background()
-	imageRef := args[0]
+	arg := args[0]
 	server := strings.TrimSpace(*h.opts.ServerURL)
 
 	if server == "" {
 		h.handleError(fmt.Errorf("server URL required (use --server, CAIB_SERVER, run 'caib login <server-url>' or 'jmp login <endpoint>')"))
 		return
+	}
+
+	api, err := caibcommon.CreateBuildAPIClient(server, h.opts.AuthToken, *h.opts.InsecureSkipTLS)
+	if err != nil {
+		h.handleError(err)
+		return
+	}
+
+	req := buildapitypes.FlashRequest{
+		Name:             *h.opts.FlashName,
+		Target:           *h.opts.Target,
+		ExporterSelector: *h.opts.ExporterSelector,
+		LeaseName:        *h.opts.LeaseName,
+		FlashCmd:         *h.opts.FlashCmd,
+	}
+
+	imageRef := arg
+	if isCatalogName(arg) {
+		req.CatalogImage = arg
+		img, getErr := api.GetCatalogImage(ctx, arg)
+		if getErr != nil {
+			h.handleError(getErr)
+			return
+		}
+		if img.Phase != "Available" {
+			h.handleError(fmt.Errorf("catalog image %q is not Available (phase: %s)", arg, img.Phase))
+			return
+		}
+		if img.RegistryURL == "" {
+			h.handleError(fmt.Errorf("catalog image %q has no registry URL", arg))
+			return
+		}
+		imageRef = buildapitypes.PinFlashDigest(img.RegistryURL, img.Digest)
+		clilog.Infof("Using catalog image %s (%s)\n", arg, imageRef)
+	} else {
+		req.ImageRef = arg
 	}
 
 	// Resolve Jumpstarter client config (explicit path or auto-detect)
@@ -129,6 +165,7 @@ func (h *Handler) RunFlash(cmd *cobra.Command, args []string) {
 	if strings.TrimSpace(*h.opts.Target) == "" && strings.TrimSpace(*h.opts.ExporterSelector) == "" {
 		if detected := h.resolveTargetFromAnnotations(imageRef); detected != "" {
 			*h.opts.Target = detected
+			req.Target = detected
 			clilog.Infof("Auto-detected target from image annotations: %s\n", detected)
 		} else {
 			h.handleError(fmt.Errorf("either --target or --exporter is required (target auto-detection from image annotations failed or annotation not present)"))
@@ -142,12 +179,6 @@ func (h *Handler) RunFlash(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	api, err := caibcommon.CreateBuildAPIClient(server, h.opts.AuthToken, *h.opts.InsecureSkipTLS)
-	if err != nil {
-		h.handleError(err)
-		return
-	}
-
 	clientConfigB64 := base64.StdEncoding.EncodeToString(clientInfo.Data)
 
 	leaseTags, err := caibcommon.ValidateAndJoinLeaseTags(h.opts.LeaseTags)
@@ -156,16 +187,8 @@ func (h *Handler) RunFlash(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	req := buildapitypes.FlashRequest{
-		Name:             *h.opts.FlashName,
-		ImageRef:         imageRef,
-		Target:           *h.opts.Target,
-		ExporterSelector: *h.opts.ExporterSelector,
-		ClientConfig:     clientConfigB64,
-		LeaseName:        *h.opts.LeaseName,
-		FlashCmd:         *h.opts.FlashCmd,
-		LeaseTags:        leaseTags,
-	}
+	req.ClientConfig = clientConfigB64
+	req.LeaseTags = leaseTags
 	if req.LeaseName == "" {
 		req.LeaseDuration = *h.opts.LeaseDuration
 	}
@@ -195,6 +218,14 @@ func (h *Handler) RunFlash(cmd *cobra.Command, args []string) {
 	if *h.opts.WaitForBuild || *h.opts.FollowLogs {
 		h.waitForFlashCompletion(ctx, api, resp.Name)
 	}
+}
+
+// isCatalogName reports whether ref is a CatalogImage name rather than an OCI
+// image reference. Kubernetes object names are RFC 1123 labels and cannot
+// contain "/", while registry refs always include at least one "/" (e.g.
+// quay.io/org/image:tag or localhost/image@sha256:...).
+func isCatalogName(ref string) bool {
+	return !strings.Contains(ref, "/")
 }
 
 // parseLeaseDuration converts HH:MM:SS format to time.Duration.

--- a/cmd/caib/flashcmd/resolve_target_test.go
+++ b/cmd/caib/flashcmd/resolve_target_test.go
@@ -69,3 +69,20 @@ func TestResolveTargetFromAnnotations_PassesImageRef(t *testing.T) {
 		t.Errorf("expected imageRef passed through, got %q", receivedRef)
 	}
 }
+
+func TestIsCatalogName(t *testing.T) {
+	tests := []struct {
+		ref  string
+		want bool
+	}{
+		{"qa-ebbr", true},
+		{"bootc-matrix-test-qemu", true},
+		{"quay.io/bzlotnik/qa:disk-ebbr", false},
+		{"localhost:5000/foo:tag", false},
+	}
+	for _, tt := range tests {
+		if got := isCatalogName(tt.ref); got != tt.want {
+			t.Errorf("isCatalogName(%q) = %v, want %v", tt.ref, got, tt.want)
+		}
+	}
+}

--- a/cmd/caib/image/image.go
+++ b/cmd/caib/image/image.go
@@ -432,9 +432,13 @@ Examples:
 
 func newFlashCmd(opts Options) *cobra.Command {
 	return &cobra.Command{
-		Use:   "flash <oci-registry-reference>",
+		Use:   "flash <oci-registry-reference|catalog-image-name>",
 		Short: "Flash a disk image to hardware via Jumpstarter",
-		Long: `Flash a disk image from an OCI registry to a hardware device using Jumpstarter.
+		Long: `Flash a disk image from an OCI registry or catalog name to a hardware device using Jumpstarter.
+
+A name without '/' is treated as a CatalogImage (for example qa-ebbr). The API
+resolves it to a digest-pinned registry URL. A value containing '/' is an OCI
+reference (quay.io/org/disk:v1).
 
 This command connects to a Jumpstarter exporter to flash the specified disk image
 onto physical hardware. The Jumpstarter client config is auto-detected from
@@ -444,6 +448,9 @@ If --target and --exporter are both omitted, the target is auto-detected from th
 OCI image manifest annotations (set by the operator during image push).
 
 Examples:
+  # Flash a catalog head by name
+  caib image flash qa-ebbr --target j784s4evm
+
   # Flash with auto-detected target (from image annotations)
   caib image flash quay.io/org/disk:v1
 

--- a/internal/buildapi/client/client.go
+++ b/internal/buildapi/client/client.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi"
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi/catalog"
 	"github.com/gorilla/websocket"
 )
 
@@ -377,6 +378,39 @@ func (c *Client) GetFlash(ctx context.Context, name string) (*buildapi.FlashResp
 		return nil, fmt.Errorf("get flash failed: %s: %s", resp.Status, string(b))
 	}
 	var out buildapi.FlashResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// GetCatalogImage retrieves a catalog image by name.
+func (c *Client) GetCatalogImage(ctx context.Context, name string) (*catalog.CatalogImageResponse, error) {
+	endpoint := c.resolve(path.Join("/v1/catalog/images", url.PathEscape(name)))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	if c.authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.authToken)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", err)
+		}
+	}()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("catalog image %q not found", name)
+	}
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("get catalog image failed: %s: %s", resp.Status, string(b))
+	}
+	var out catalog.CatalogImageResponse
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		return nil, err
 	}

--- a/internal/buildapi/flash.go
+++ b/internal/buildapi/flash.go
@@ -33,10 +33,6 @@ func (a *APIServer) createFlash(c *gin.Context) {
 	}
 
 	// Validate required fields
-	if req.ImageRef == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "imageRef is required"})
-		return
-	}
 	if req.ClientConfig == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "clientConfig is required"})
 		return
@@ -64,13 +60,20 @@ func (a *APIServer) createFlash(c *gin.Context) {
 	if err != nil {
 		return
 	}
+
+	ctx := c.Request.Context()
+	namespace := resolveNamespace()
+
+	if httpErr := a.applyFlashImageSource(ctx, k8sClient, namespace, &req); httpErr != nil {
+		c.JSON(httpErr.code, gin.H{"error": httpErr.message})
+		return
+	}
+
 	clientset, err := getClientsetOrFail(c)
 	if err != nil {
 		return
 	}
 
-	ctx := c.Request.Context()
-	namespace := resolveNamespace()
 	requestedBy := a.resolveRequester(c)
 
 	// Load OperatorConfig for target mappings, image overrides, and lease duration defaults
@@ -232,6 +235,21 @@ func (a *APIServer) createFlash(c *gin.Context) {
 		RequestedBy: requestedBy,
 		TaskRunName: taskRun.Name,
 	})
+}
+
+func (a *APIServer) applyFlashImageSource(ctx context.Context, k8sClient client.Client, namespace string, req *FlashRequest) *httpError {
+	if req.CatalogImage != "" {
+		ref, httpErr := resolveFlashImageFromCatalog(ctx, k8sClient, namespace, req.CatalogImage)
+		if httpErr != nil {
+			return httpErr
+		}
+		req.ImageRef = ref
+		a.log.Info("resolved catalog image for flash", "catalogImage", req.CatalogImage, "imageRef", req.ImageRef)
+	}
+	if req.ImageRef == "" {
+		return &httpError{code: http.StatusBadRequest, message: "imageRef or catalogImage is required"}
+	}
+	return nil
 }
 
 func (a *APIServer) listFlash(c *gin.Context) {

--- a/internal/buildapi/flash_helpers.go
+++ b/internal/buildapi/flash_helpers.go
@@ -19,7 +19,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type httpError struct {
@@ -55,6 +57,47 @@ func resolveFlashTargetConfig(req FlashRequest, operatorConfig *automotivev1alph
 		}
 	}
 	return exporterSelector, flashCmd
+}
+
+// PinFlashDigest appends @digest to a registry URL when the URL is not already digest-pinned.
+func PinFlashDigest(registryURL, digest string) string {
+	if registryURL == "" || digest == "" {
+		return registryURL
+	}
+	if strings.Contains(registryURL, "@") {
+		return registryURL
+	}
+	return registryURL + "@" + digest
+}
+
+func catalogFlashDigest(img *automotivev1alpha1.CatalogImage) string {
+	if img.Spec.Digest != "" {
+		return img.Spec.Digest
+	}
+	if img.Status.RegistryMetadata != nil {
+		return img.Status.RegistryMetadata.ResolvedDigest
+	}
+	return ""
+}
+
+func resolveFlashImageFromCatalog(ctx context.Context, k8sClient client.Client, namespace, name string) (string, *httpError) {
+	img := &automotivev1alpha1.CatalogImage{}
+	if err := k8sClient.Get(ctx, k8stypes.NamespacedName{Name: name, Namespace: namespace}, img); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return "", &httpError{code: http.StatusNotFound, message: fmt.Sprintf("catalog image %q not found", name)}
+		}
+		return "", &httpError{code: http.StatusInternalServerError, message: "failed to get catalog image"}
+	}
+	if img.Status.Phase != automotivev1alpha1.CatalogImagePhaseAvailable {
+		return "", &httpError{
+			code:    http.StatusBadRequest,
+			message: fmt.Sprintf("catalog image %q is not Available (phase: %s)", name, img.Status.Phase),
+		}
+	}
+	if img.Spec.RegistryURL == "" {
+		return "", &httpError{code: http.StatusBadRequest, message: fmt.Sprintf("catalog image %q has no registry URL", name)}
+	}
+	return PinFlashDigest(img.Spec.RegistryURL, catalogFlashDigest(img)), nil
 }
 
 // readImageAnnotationsFn reads OCI manifest annotations for a given image reference.

--- a/internal/buildapi/flash_helpers_test.go
+++ b/internal/buildapi/flash_helpers_test.go
@@ -3,11 +3,17 @@ package buildapi
 import (
 	"context"
 	"fmt"
+	"net/http"
 
+	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
 	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/oci"
 	"github.com/containers/image/v5/types"
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // Dot import is standard for Ginkgo
 	. "github.com/onsi/gomega"    //nolint:revive // Dot import is standard for Gomega
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("BuildLeaseTags", func() {
@@ -93,5 +99,73 @@ var _ = Describe("resolveTargetFromImage", func() {
 			return nil, c.Err()
 		}
 		Expect(resolveTargetFromImage(ctx, "quay.io/test/image:v1", nil)).To(BeEmpty())
+	})
+})
+
+var _ = Describe("pinFlashDigest", func() {
+	DescribeTable("pins digest onto a registry URL",
+		func(registryURL, digest, expected string) {
+			Expect(PinFlashDigest(registryURL, digest)).To(Equal(expected))
+		},
+		Entry("empty digest", "quay.io/org/img:tag", "", "quay.io/org/img:tag"),
+		Entry("empty url", "", "sha256:abc", ""),
+		Entry("appends digest", "quay.io/org/img:tag", "sha256:abc", "quay.io/org/img:tag@sha256:abc"),
+		Entry("already pinned", "quay.io/org/img@sha256:abc", "sha256:def", "quay.io/org/img@sha256:abc"),
+	)
+})
+
+var _ = Describe("resolveFlashImageFromCatalog", func() {
+	newCatalogClient := func(objs ...ctrlclient.Object) ctrlclient.Client {
+		scheme := runtime.NewScheme()
+		Expect(automotivev1alpha1.AddToScheme(scheme)).To(Succeed())
+		return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	}
+
+	It("pins spec digest for an Available catalog image", func() {
+		img := &automotivev1alpha1.CatalogImage{
+			ObjectMeta: metav1.ObjectMeta{Name: "qa-ebbr", Namespace: "test-ns"},
+			Spec: automotivev1alpha1.CatalogImageSpec{
+				RegistryURL: "quay.io/bzlotnik/qa:disk-ebbr",
+				Digest:      "sha256:abc123",
+			},
+			Status: automotivev1alpha1.CatalogImageStatus{
+				Phase: automotivev1alpha1.CatalogImagePhaseAvailable,
+			},
+		}
+		ref, httpErr := resolveFlashImageFromCatalog(context.Background(), newCatalogClient(img), "test-ns", "qa-ebbr")
+		Expect(httpErr).To(BeNil())
+		Expect(ref).To(Equal("quay.io/bzlotnik/qa:disk-ebbr@sha256:abc123"))
+	})
+
+	It("falls back to resolved digest from registry metadata", func() {
+		img := &automotivev1alpha1.CatalogImage{
+			ObjectMeta: metav1.ObjectMeta{Name: "qa-ebbr", Namespace: "test-ns"},
+			Spec:       automotivev1alpha1.CatalogImageSpec{RegistryURL: "quay.io/bzlotnik/qa:disk-ebbr"},
+			Status: automotivev1alpha1.CatalogImageStatus{
+				Phase:            automotivev1alpha1.CatalogImagePhaseAvailable,
+				RegistryMetadata: &automotivev1alpha1.RegistryMetadata{ResolvedDigest: "sha256:from-status"},
+			},
+		}
+		ref, httpErr := resolveFlashImageFromCatalog(context.Background(), newCatalogClient(img), "test-ns", "qa-ebbr")
+		Expect(httpErr).To(BeNil())
+		Expect(ref).To(Equal("quay.io/bzlotnik/qa:disk-ebbr@sha256:from-status"))
+	})
+
+	It("returns 404 when the catalog image is missing", func() {
+		_, httpErr := resolveFlashImageFromCatalog(context.Background(), newCatalogClient(), "test-ns", "missing")
+		Expect(httpErr).NotTo(BeNil())
+		Expect(httpErr.code).To(Equal(http.StatusNotFound))
+	})
+
+	It("rejects catalog images that are not Available", func() {
+		img := &automotivev1alpha1.CatalogImage{
+			ObjectMeta: metav1.ObjectMeta{Name: "qa-ebbr", Namespace: "test-ns"},
+			Spec:       automotivev1alpha1.CatalogImageSpec{RegistryURL: "quay.io/bzlotnik/qa:disk-ebbr"},
+			Status:     automotivev1alpha1.CatalogImageStatus{Phase: automotivev1alpha1.CatalogImagePhaseFailed},
+		}
+		_, httpErr := resolveFlashImageFromCatalog(context.Background(), newCatalogClient(img), "test-ns", "qa-ebbr")
+		Expect(httpErr).NotTo(BeNil())
+		Expect(httpErr.code).To(Equal(http.StatusBadRequest))
+		Expect(httpErr.message).To(ContainSubstring("not Available"))
 	})
 })

--- a/internal/buildapi/types.go
+++ b/internal/buildapi/types.go
@@ -241,7 +241,10 @@ type FlashRequest struct {
 	// Name is the flash job name (auto-generated if omitted)
 	Name string `json:"name"`
 	// ImageRef is the OCI registry reference of the disk image to flash
-	ImageRef string `json:"imageRef"`
+	ImageRef string `json:"imageRef,omitempty"`
+	// CatalogImage is a CatalogImage resource name. When set, the API resolves
+	// it to a digest-pinned registry URL and overwrites ImageRef.
+	CatalogImage string `json:"catalogImage,omitempty"`
 	// Target is the target platform for exporter lookup from OperatorConfig
 	Target string `json:"target,omitempty"`
 	// ExporterSelector is the direct label selector for Jumpstarter exporters (alternative to Target)


### PR DESCRIPTION
## Summary

Flash an Available catalog head by name, with digest pin on the API.

- `POST /v1/flash` accepts `catalogImage`. The API loads that CatalogImage, requires phase Available, and overwrites `imageRef` with `registryUrl@digest`. Existing `imageRef` clients are unchanged.
- `caib image flash qa-ebbr` treats a name without `/` as a CatalogImage. A value containing `/` stays an OCI ref (`quay.io/org/disk:v1`).
