### PR TITLE
fix(build): preserve PVC scratch subPath dirs during persistent cache cleanup (fixes #17)

### DIFF
--- a/internal/common/tasks/scratch_volumes_test.go
+++ b/internal/common/tasks/scratch_volumes_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -263,6 +264,30 @@ func TestPVCScratchVolumes_BuildStepRewritten(t *testing.T) {
 
 // Tests for GetUsePVCScratchVolumes are in the api package
 // but we verify the BuildConfig bool integration here
+func TestPVCScratchSubPaths_PresentInBuildImageCleanupSkipList(t *testing.T) {
+	task := GenerateBuildAutomotiveImageTask("test-ns", &BuildConfig{
+		UsePVCScratchVolumes: true,
+	}, "")
+
+	subPaths := map[string]bool{}
+	for _, step := range task.Spec.Steps {
+		for _, vm := range step.VolumeMounts {
+			if vm.Name == workspaceVolumeRef && vm.SubPath != "" {
+				subPaths[vm.SubPath] = true
+			}
+		}
+	}
+
+	for sp := range subPaths {
+		if !strings.Contains(BuildImageScript, sp) {
+			t.Fatalf("scratch subPath %q used in task volume mounts but not referenced in BuildImageScript; the persistent-cache cleanup will destroy it", sp)
+		}
+		if !strings.Contains(FindManifestScript, sp) {
+			t.Fatalf("scratch subPath %q used in task volume mounts but not referenced in FindManifestScript; it will be unnecessarily copied", sp)
+		}
+	}
+}
+
 func TestBuildConfig_PVCScratchDefaultFalse(t *testing.T) {
 	cfg := &BuildConfig{}
 	if cfg.UsePVCScratchVolumes {

--- a/internal/common/tasks/scripts/build_image.sh
+++ b/internal/common/tasks/scripts/build_image.sh
@@ -70,7 +70,11 @@ if [ "$(params.use-persistent-cache)" = "true" ]; then
 
   echo "Cleaning up stale artifacts from persistent workspace..."
   for item in "$WORKSPACE_PATH"/*; do
-    [ "$(basename "$item")" = "build-cache" ] && continue
+    # Keep build-cache (osbuild store) and PVC-backed scratch subPath directories.
+    # Scratch names must match pvcScratchRedirects in tasks.go.
+    case "$(basename "$item")" in
+      build-cache|scratch-build|scratch-output|scratch-run) continue ;;
+    esac
     rm -rf "$item"
   done
 

--- a/internal/common/tasks/scripts/find_manifest.sh
+++ b/internal/common/tasks/scripts/find_manifest.sh
@@ -27,9 +27,10 @@ if [ -d "$SHARED_WS" ] && [ "$(ls -A "$SHARED_WS" 2>/dev/null)" ]; then
   echo "Copying uploaded files from $SHARED_WS to /manifest-work/"
   for item in "$SHARED_WS"/*; do
     base="$(basename "$item")"
-    # Skip build-cache (osbuild store) and known build artifacts from previous runs
+    # Skip build-cache, PVC-backed scratch subPaths (names match pvcScratchRedirects in tasks.go),
+    # and known build artifacts from previous runs
     case "$base" in
-      build-cache|aib-manifest.yml|image.json|disk.img|*-parts) continue ;;
+      build-cache|scratch-build|scratch-output|scratch-run|aib-manifest.yml|image.json|disk.img|*-parts) continue ;;
     esac
     cp -rv "$item" /manifest-work/ 2>/dev/null || true
   done


### PR DESCRIPTION
## Summary

The persistent cache cleanup in `build_image.sh` removed all workspace items except `build-cache`, including the `scratch-build`/`scratch-output`/`scratch-run` directories that back subPath volume mounts when `UsePVCScratchVolumes` is enabled. This broke every workspace-backed build with ENOENT on `/run/osbuild`.

Related issue: https://github.com/mickume/automotive-dev-operator/issues/17

## Changes

| File | Change |
|------|--------|
| `internal/common/tasks/scripts/build_image.sh` | Replace single-name `build-cache` check with `case` that also skips `scratch-build\|scratch-output\|scratch-run` |
| `internal/common/tasks/scripts/find_manifest.sh` | Add `scratch-build\|scratch-output\|scratch-run` to copy skip-list |
| `internal/common/tasks/scratch_volumes_test.go` | Add drift-detection test ensuring subPath names from `tasks.go` appear in both scripts |

## Tests

- `TestPVCScratchSubPaths_PresentInBuildImageCleanupSkipList`: verifies every subPath name from `pvcScratchRedirects` in `tasks.go` is referenced in both `BuildImageScript` and `FindManifestScript` — catches future drift when new scratch volumes are added

## Verification

- All existing tests pass: ✅
- New test passes: ✅
- Linter: ✅ (0 issues)
- No regressions: ✅

---
*Auto-generated by `af-fix`.*

@coderabbitai ignore