### PR TITLE
fix(caib): derive server URL from Jumpstarter config in workspace commands (fixes #20)

### DIFF
--- a/cmd/caib/workspace/workspace.go
+++ b/cmd/caib/workspace/workspace.go
@@ -83,6 +83,12 @@ Examples:
   caib workspace sync my-app ./src
   caib workspace exec my-app -- make -j4
   caib workspace deploy my-app --artifact /workspace/src/build/app --dest /usr/local/bin/app`,
+		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+			if strings.TrimSpace(serverURL) == "" {
+				serverURL = config.DefaultServerWithDerive()
+			}
+			return nil
+		},
 	}
 
 	cmd.PersistentFlags().StringVar(&serverURL, "server", config.DefaultServer(), "REST API server base URL")

--- a/cmd/caib/workspace/workspace_test.go
+++ b/cmd/caib/workspace/workspace_test.go
@@ -13,6 +13,55 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func TestNewWorkspaceCmdDerivesServerURL(t *testing.T) {
+	origServer := os.Getenv("CAIB_SERVER")
+	defer func() {
+		if origServer != "" {
+			_ = os.Setenv("CAIB_SERVER", origServer)
+		} else {
+			_ = os.Unsetenv("CAIB_SERVER")
+		}
+	}()
+
+	t.Run("PersistentPreRunE populates serverURL from CAIB_SERVER env", func(t *testing.T) {
+		_ = os.Setenv("CAIB_SERVER", "https://env-server.example.com")
+		serverURL = ""
+
+		outputFmt := "table"
+		cmd := NewWorkspaceCmd(&outputFmt)
+
+		if cmd.PersistentPreRunE == nil {
+			t.Fatal("workspace command must have PersistentPreRunE set for server URL derivation")
+		}
+
+		if err := cmd.PersistentPreRunE(cmd, nil); err != nil {
+			t.Fatalf("PersistentPreRunE returned error: %v", err)
+		}
+
+		if serverURL != "https://env-server.example.com" {
+			t.Errorf("expected serverURL to be derived from CAIB_SERVER, got %q", serverURL)
+		}
+	})
+
+	t.Run("PersistentPreRunE preserves explicit --server flag value", func(t *testing.T) {
+		_ = os.Unsetenv("CAIB_SERVER")
+
+		outputFmt := "table"
+		cmd := NewWorkspaceCmd(&outputFmt)
+
+		// Simulate --server flag being set after flag parsing
+		serverURL = "https://explicit.example.com"
+
+		if err := cmd.PersistentPreRunE(cmd, nil); err != nil {
+			t.Fatalf("PersistentPreRunE returned error: %v", err)
+		}
+
+		if serverURL != "https://explicit.example.com" {
+			t.Errorf("expected explicit server URL to be preserved, got %q", serverURL)
+		}
+	})
+}
+
 func TestRenderFormattedWorkspaceList(t *testing.T) {
 	workspaces := []buildapitypes.WorkspaceResponse{
 		{Name: "ws-1", Arch: "amd64", Phase: "Running", Lease: "lease-abc", Age: "5m"},


### PR DESCRIPTION
## Summary

Added `PersistentPreRunE` to the workspace command that calls `config.DefaultServerWithDerive()` when the server URL is empty, aligning it with the `image` and `container` command groups. This eliminates the need for the `caib status` workaround in Tekton tasks.

Related issue: https://github.com/mickume/automotive-dev-operator/issues/20

## Changes

| File | Change |
|------|--------|
| `cmd/caib/workspace/workspace.go` | Added `PersistentPreRunE` with `DefaultServerWithDerive()` fallback |
| `cmd/caib/workspace/workspace_test.go` | Added regression tests for server URL derivation behavior |

## Tests

- `TestNewWorkspaceCmdDerivesServerURL/PersistentPreRunE_populates_serverURL_from_CAIB_SERVER_env` — verifies derivation runs when serverURL is empty
- `TestNewWorkspaceCmdDerivesServerURL/PersistentPreRunE_preserves_explicit_--server_flag_value` — verifies explicit flag takes precedence

## Verification

- All existing tests pass: ✅
- New tests pass: ✅
- Linter (golangci-lint): ✅
- No regressions: ✅

---
*Auto-generated by `af-fix`.*

@coderabbitai ignore