### PR TITLE
fix(build): preserve PVC scratch subPath dirs during persistent cache cleanup

### DIFF
--- a/internal/common/tasks/scratch_volumes_test.go
+++ b/internal/common/tasks/scratch_volumes_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -263,6 +264,30 @@ func TestPVCScratchVolumes_BuildStepRewritten(t *testing.T) {
 
 // Tests for GetUsePVCScratchVolumes are in the api package
 // but we verify the BuildConfig bool integration here
+func TestPVCScratchSubPaths_PresentInBuildImageCleanupSkipList(t *testing.T) {
+	task := GenerateBuildAutomotiveImageTask("test-ns", &BuildConfig{
+		UsePVCScratchVolumes: true,
+	}, "")
+
+	subPaths := map[string]bool{}
+	for _, step := range task.Spec.Steps {
+		for _, vm := range step.VolumeMounts {
+			if vm.Name == workspaceVolumeRef && vm.SubPath != "" {
+				subPaths[vm.SubPath] = true
+			}
+		}
+	}
+
+	for sp := range subPaths {
+		if !strings.Contains(BuildImageScript, sp) {
+			t.Fatalf("scratch subPath %q used in task volume mounts but not referenced in BuildImageScript; the persistent-cache cleanup will destroy it", sp)
+		}
+		if !strings.Contains(FindManifestScript, sp) {
+			t.Fatalf("scratch subPath %q used in task volume mounts but not referenced in FindManifestScript; it will be unnecessarily copied", sp)
+		}
+	}
+}
+
 func TestBuildConfig_PVCScratchDefaultFalse(t *testing.T) {
 	cfg := &BuildConfig{}
 	if cfg.UsePVCScratchVolumes {

--- a/internal/common/tasks/scripts/build_image.sh
+++ b/internal/common/tasks/scripts/build_image.sh
@@ -70,7 +70,11 @@ if [ "$(params.use-persistent-cache)" = "true" ]; then
 
   echo "Cleaning up stale artifacts from persistent workspace..."
   for item in "$WORKSPACE_PATH"/*; do
-    [ "$(basename "$item")" = "build-cache" ] && continue
+    # Keep build-cache (osbuild store) and PVC-backed scratch subPath directories.
+    # Scratch names must match pvcScratchRedirects in tasks.go.
+    case "$(basename "$item")" in
+      build-cache|scratch-build|scratch-output|scratch-run) continue ;;
+    esac
     rm -rf "$item"
   done
 

--- a/internal/common/tasks/scripts/find_manifest.sh
+++ b/internal/common/tasks/scripts/find_manifest.sh
@@ -27,9 +27,10 @@ if [ -d "$SHARED_WS" ] && [ "$(ls -A "$SHARED_WS" 2>/dev/null)" ]; then
   echo "Copying uploaded files from $SHARED_WS to /manifest-work/"
   for item in "$SHARED_WS"/*; do
     base="$(basename "$item")"
-    # Skip build-cache (osbuild store) and known build artifacts from previous runs
+    # Skip build-cache, PVC-backed scratch subPaths (names match pvcScratchRedirects in tasks.go),
+    # and known build artifacts from previous runs
     case "$base" in
-      build-cache|aib-manifest.yml|image.json|disk.img|*-parts) continue ;;
+      build-cache|scratch-build|scratch-output|scratch-run|aib-manifest.yml|image.json|disk.img|*-parts) continue ;;
     esac
     cp -rv "$item" /manifest-work/ 2>/dev/null || true
   done


### PR DESCRIPTION
## Summary

Fixes persistent cache cleanup destroying PVC-backed scratch subPath mounts when using `--workspace` flag with `caib image build-dev`.

- The cleanup loop in `build_image.sh` now preserves `scratch-build`, `scratch-output`, and `scratch-run` directories alongside `build-cache`
- The copy skip-list in `find_manifest.sh` also skips these scratch directories to avoid wasted I/O

Related issue with full root cause analysis: https://github.com/mickume/automotive-dev-operator/issues/17

## Changes

| File | Change |
|------|--------|
| `internal/common/tasks/scripts/build_image.sh` | Add scratch subPath dirs to persistent cache cleanup skip-list |
| `internal/common/tasks/scripts/find_manifest.sh` | Add scratch subPath dirs to manifest copy skip-list |
| `internal/common/tasks/scratch_volumes_test.go` | Add regression test verifying scratch dir names match skip-lists |

## Test plan

- [ ] Verify `caib image build-dev` with `--workspace` no longer fails with `cp: cannot create regular file '/run/osbuild//osbuild': No such file or directory`
- [ ] Verify builds without `--workspace` are unaffected
- [ ] Verify stale artifacts (disk images, compressed files) are still cleaned up from the workspace

@coderabbitai ignore
