### PR TITLE
fix(build): mount workspace PVC in build pod for file:// access

### DIFF
--- a/api/v1alpha1/imagebuild_types.go
+++ b/api/v1alpha1/imagebuild_types.go
@@ -93,6 +93,12 @@ type ImageBuildSpec struct {
 	// +optional
 	Workspace string `json:"workspace,omitempty"`
 
+	// WorkspacePVC is the name of the workspace PVC to mount at /workspace/src
+	// in the build pod, giving AIB direct filesystem access to files synced
+	// via `caib workspace sync`.
+	// +optional
+	WorkspacePVC string `json:"workspacePVC,omitempty"`
+
 	// SecureBuild enables supply chain security for this build.
 	// When true, pipeline tasks are resolved from the signed Tekton Bundle
 	// specified in TaskBundleRef instead of cluster-installed tasks.

--- a/config/crd/bases/automotive.sdv.cloud.redhat.com_imagebuilds.yaml
+++ b/config/crd/bases/automotive.sdv.cloud.redhat.com_imagebuilds.yaml
@@ -298,6 +298,12 @@ spec:
                   When set, the controller writes the acquired lease back to the workspace
                   on completion so subsequent builds can reuse it.
                 type: string
+              workspacePVC:
+                description: |-
+                  WorkspacePVC is the name of the workspace PVC to mount at /workspace/src
+                  in the build pod, giving AIB direct filesystem access to files synced
+                  via `caib workspace sync`.
+                type: string
             type: object
             x-kubernetes-validations:
             - message: reproducible builds require secureBuild to be true

--- a/config/crd/bases/automotive.sdv.cloud.redhat.com_scheduledimagebuilds.yaml
+++ b/config/crd/bases/automotive.sdv.cloud.redhat.com_scheduledimagebuilds.yaml
@@ -363,6 +363,12 @@ spec:
                           When set, the controller writes the acquired lease back to the workspace
                           on completion so subsequent builds can reuse it.
                         type: string
+                      workspacePVC:
+                        description: |-
+                          WorkspacePVC is the name of the workspace PVC to mount at /workspace/src
+                          in the build pod, giving AIB direct filesystem access to files synced
+                          via `caib workspace sync`.
+                        type: string
                     type: object
                     x-kubernetes-validations:
                     - message: reproducible builds require secureBuild to be true

--- a/internal/buildapi/server.go
+++ b/internal/buildapi/server.go
@@ -957,8 +957,8 @@ func resolveOCIRepoImages(req *BuildRequest) error {
 // - Creates/finds a build-cache PVC for osbuild checkpoint persistence
 // - Forwards the workspace's lease if the build has flash enabled but no explicit lease
 // - Starts an HTTP file server in the workspace pod and injects workspace_url as a custom define
-// Returns the build-cache PVC name.
-func (a *APIServer) resolveWorkspaceForBuild(ctx context.Context, k8sClient client.Client, restCfg *rest.Config, namespace, wsName, requester string, req *BuildRequest) (string, error) {
+// Returns the build-cache PVC name and the workspace PVC name (for mounting /workspace/src in the build pod).
+func (a *APIServer) resolveWorkspaceForBuild(ctx context.Context, k8sClient client.Client, restCfg *rest.Config, namespace, wsName, requester string, req *BuildRequest) (string, string, error) {
 	operatorConfig, _ := loadOperatorConfigFn(ctx, k8sClient, namespace)
 	var wsConfig *automotivev1alpha1.WorkspacesConfig
 	if operatorConfig != nil {
@@ -969,7 +969,7 @@ func (a *APIServer) resolveWorkspaceForBuild(ctx context.Context, k8sClient clie
 	err := k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: wsName}, ws)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
-			return "", fmt.Errorf("checking workspace %q: %w", wsName, err)
+			return "", "", fmt.Errorf("checking workspace %q: %w", wsName, err)
 		}
 		// Auto-create workspace with defaults from OperatorConfig
 		ws = &automotivev1alpha1.Workspace{
@@ -985,14 +985,16 @@ func (a *APIServer) resolveWorkspaceForBuild(ctx context.Context, k8sClient clie
 			},
 		}
 		if err := k8sClient.Create(ctx, ws); err != nil {
-			return "", fmt.Errorf("creating workspace %q: %w", wsName, err)
+			return "", "", fmt.Errorf("creating workspace %q: %w", wsName, err)
 		}
 		a.log.Info("Auto-created workspace for build", "workspace", wsName, "requester", requester)
 	} else {
 		if ws.Spec.Owner != requester {
-			return "", fmt.Errorf("workspace %q not found", wsName)
+			return "", "", fmt.Errorf("workspace %q not found", wsName)
 		}
 	}
+
+	workspacePVCName := ws.Status.PVCName
 
 	// Forward workspace lease if flash is enabled and no explicit lease was provided
 	if req.FlashEnabled && req.FlashLeaseName == "" && ws.Spec.LeaseID != "" {
@@ -1028,11 +1030,11 @@ func (a *APIServer) resolveWorkspaceForBuild(ctx context.Context, k8sClient clie
 		client.InNamespace(namespace),
 		client.MatchingLabels(buildCacheLabels),
 	); err != nil {
-		return "", fmt.Errorf("listing build-cache PVCs: %w", err)
+		return "", "", fmt.Errorf("listing build-cache PVCs: %w", err)
 	}
 	for i := range pvcList.Items {
 		if pvcList.Items[i].DeletionTimestamp == nil {
-			return pvcList.Items[i].Name, nil
+			return pvcList.Items[i].Name, workspacePVCName, nil
 		}
 	}
 
@@ -1049,7 +1051,7 @@ func (a *APIServer) resolveWorkspaceForBuild(ctx context.Context, k8sClient clie
 	}
 	cacheSizeQty, err := resource.ParseQuantity(cacheSize)
 	if err != nil {
-		return "", fmt.Errorf("invalid buildCacheSize %q: %w", cacheSize, err)
+		return "", "", fmt.Errorf("invalid buildCacheSize %q: %w", cacheSize, err)
 	}
 
 	pvc := &corev1.PersistentVolumeClaim{
@@ -1077,11 +1079,11 @@ func (a *APIServer) resolveWorkspaceForBuild(ctx context.Context, k8sClient clie
 		},
 	}
 	if err := k8sClient.Create(ctx, pvc); err != nil {
-		return "", fmt.Errorf("creating build-cache PVC: %w", err)
+		return "", "", fmt.Errorf("creating build-cache PVC: %w", err)
 	}
 
 	a.log.Info("Created build-cache PVC", "workspace", wsName, "pvc", pvc.Name, "size", cacheSize)
-	return pvc.Name, nil
+	return pvc.Name, workspacePVCName, nil
 }
 
 // buildAIBSpec creates AIBSpec configuration from build request
@@ -1278,7 +1280,7 @@ func (a *APIServer) createBuild(c *gin.Context) {
 	}
 
 	// Resolve --workspace: create/find build-cache PVC, forward lease, start file server
-	var buildCachePVCName string
+	var buildCachePVCName, workspacePVCName string
 	if req.Workspace != "" {
 		restCfg, restErr := getRESTConfigFromRequest(c)
 		if restErr != nil {
@@ -1286,13 +1288,14 @@ func (a *APIServer) createBuild(c *gin.Context) {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get kubernetes config"})
 			return
 		}
-		pvcName, wsErr := a.resolveWorkspaceForBuild(ctx, k8sClient, restCfg, namespace, req.Workspace, requestedBy, &req)
+		cachePVC, wsPVC, wsErr := a.resolveWorkspaceForBuild(ctx, k8sClient, restCfg, namespace, req.Workspace, requestedBy, &req)
 		if wsErr != nil {
 			spanError(span, wsErr)
 			c.JSON(http.StatusBadRequest, gin.H{"error": wsErr.Error()})
 			return
 		}
-		buildCachePVCName = pvcName
+		buildCachePVCName = cachePVC
+		workspacePVCName = wsPVC
 	}
 
 	existing := &automotivev1alpha1.ImageBuild{}
@@ -1386,6 +1389,7 @@ func (a *APIServer) createBuild(c *gin.Context) {
 			Export:            buildExportSpec(&req),
 			Flash:             flashSpec,
 			BuildCachePVC:     buildCachePVCName,
+			WorkspacePVC:      workspacePVCName,
 			Workspace:         req.Workspace,
 			SecureBuild:       req.SecureBuild,
 			Reproducible:      req.Reproducible,

--- a/internal/common/tasks/pipeline_test.go
+++ b/internal/common/tasks/pipeline_test.go
@@ -770,6 +770,53 @@ func TestPipeline_S3AuthWorkspace_Optional(t *testing.T) {
 	t.Fatal("pipeline should declare s3-auth workspace")
 }
 
+func TestBuildTask_WorkspaceSrc_Optional(t *testing.T) {
+	task := GenerateBuildAutomotiveImageTask("test-ns", nil, "")
+
+	for _, ws := range task.Spec.Workspaces {
+		if ws.Name == WorkspaceNameSrc {
+			if !ws.Optional {
+				t.Error("workspace-src should be optional on the build task")
+			}
+			if ws.MountPath != "/workspace/src" {
+				t.Errorf("workspace-src mount path = %q, want /workspace/src", ws.MountPath)
+			}
+			return
+		}
+	}
+	t.Fatal("build task should declare workspace-src workspace")
+}
+
+func TestPipeline_WorkspaceSrc_Optional(t *testing.T) {
+	pipeline := GenerateTektonPipeline("test-pipeline", "test-ns", &BuildConfig{})
+
+	for _, ws := range pipeline.Spec.Workspaces {
+		if ws.Name == WorkspaceNameSrc {
+			if !ws.Optional {
+				t.Error("pipeline workspace-src should be optional")
+			}
+			return
+		}
+	}
+	t.Fatal("pipeline should declare workspace-src workspace")
+}
+
+func TestPipeline_BuildImageTask_WorkspaceSrcBinding(t *testing.T) {
+	pipeline := GenerateTektonPipeline("test-pipeline", "test-ns", &BuildConfig{})
+
+	buildTask := findPipelineTask(pipeline.Spec.Tasks, PipelineTaskBuildImage)
+	if buildTask == nil {
+		t.Fatal("pipeline missing build-image task")
+	}
+
+	for _, ws := range buildTask.Workspaces {
+		if ws.Name == WorkspaceNameSrc && ws.Workspace == WorkspaceNameSrc {
+			return
+		}
+	}
+	t.Error("build-image pipeline task should bind workspace-src workspace")
+}
+
 // TestImagesResultFormat verifies the image@digest format Chains expects
 func TestImagesResultFormat(t *testing.T) {
 	// Simulate what the collect-images script produces

--- a/internal/common/tasks/pipeline_test.go
+++ b/internal/common/tasks/pipeline_test.go
@@ -770,38 +770,49 @@ func TestPipeline_S3AuthWorkspace_Optional(t *testing.T) {
 	t.Fatal("pipeline should declare s3-auth workspace")
 }
 
-func TestBuildTask_WorkspaceSrc_Optional(t *testing.T) {
+func TestBuildTask_WorkspaceSrc_VolumeMount(t *testing.T) {
 	task := GenerateBuildAutomotiveImageTask("test-ns", nil, "")
 
+	// workspace-src should NOT be a Tekton workspace (avoids multi-PVC affinity conflict)
 	for _, ws := range task.Spec.Workspaces {
 		if ws.Name == WorkspaceNameSrc {
-			if !ws.Optional {
-				t.Error("workspace-src should be optional on the build task")
-			}
-			if ws.MountPath != "/workspace/src" {
-				t.Errorf("workspace-src mount path = %q, want /workspace/src", ws.MountPath)
-			}
-			return
+			t.Fatal("workspace-src must not be a Tekton workspace; use podTemplate volume instead")
 		}
 	}
-	t.Fatal("build task should declare workspace-src workspace")
+
+	// workspace-src should be a volumeMount on the build-image step
+	for _, step := range task.Spec.Steps {
+		if step.Name != PipelineTaskBuildImage {
+			continue
+		}
+		for _, vm := range step.VolumeMounts {
+			if vm.Name == WorkspaceNameSrc {
+				if vm.MountPath != "/workspace/src" {
+					t.Errorf("workspace-src mount path = %q, want /workspace/src", vm.MountPath)
+				}
+				if !vm.ReadOnly {
+					t.Error("workspace-src should be read-only")
+				}
+				return
+			}
+		}
+		t.Fatal("build-image step should have workspace-src volumeMount")
+	}
+	t.Fatal("build task should have build-image step")
 }
 
-func TestPipeline_WorkspaceSrc_Optional(t *testing.T) {
+func TestPipeline_WorkspaceSrc_NotDeclared(t *testing.T) {
 	pipeline := GenerateTektonPipeline("test-pipeline", "test-ns", &BuildConfig{})
 
+	// workspace-src must not be a pipeline workspace (volume is provided via podTemplate)
 	for _, ws := range pipeline.Spec.Workspaces {
 		if ws.Name == WorkspaceNameSrc {
-			if !ws.Optional {
-				t.Error("pipeline workspace-src should be optional")
-			}
-			return
+			t.Fatal("pipeline must not declare workspace-src; use podTemplate volume instead")
 		}
 	}
-	t.Fatal("pipeline should declare workspace-src workspace")
 }
 
-func TestPipeline_BuildImageTask_WorkspaceSrcBinding(t *testing.T) {
+func TestPipeline_BuildImageTask_NoWorkspaceSrcBinding(t *testing.T) {
 	pipeline := GenerateTektonPipeline("test-pipeline", "test-ns", &BuildConfig{})
 
 	buildTask := findPipelineTask(pipeline.Spec.Tasks, PipelineTaskBuildImage)
@@ -810,11 +821,10 @@ func TestPipeline_BuildImageTask_WorkspaceSrcBinding(t *testing.T) {
 	}
 
 	for _, ws := range buildTask.Workspaces {
-		if ws.Name == WorkspaceNameSrc && ws.Workspace == WorkspaceNameSrc {
-			return
+		if ws.Name == WorkspaceNameSrc {
+			t.Fatal("build-image pipeline task must not bind workspace-src; volume comes from podTemplate")
 		}
 	}
-	t.Error("build-image pipeline task should bind workspace-src workspace")
 }
 
 // TestImagesResultFormat verifies the image@digest format Chains expects

--- a/internal/common/tasks/pipeline_test.go
+++ b/internal/common/tasks/pipeline_test.go
@@ -790,6 +790,9 @@ func TestBuildTask_WorkspaceSrc_VolumeMount(t *testing.T) {
 				if vm.MountPath != "/workspace/src" {
 					t.Errorf("workspace-src mount path = %q, want /workspace/src", vm.MountPath)
 				}
+				if vm.SubPath != "src" {
+					t.Errorf("workspace-src subPath = %q, want \"src\"", vm.SubPath)
+				}
 				if !vm.ReadOnly {
 					t.Error("workspace-src should be read-only")
 				}

--- a/internal/common/tasks/scratch_volumes_test.go
+++ b/internal/common/tasks/scratch_volumes_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -263,6 +264,30 @@ func TestPVCScratchVolumes_BuildStepRewritten(t *testing.T) {
 
 // Tests for GetUsePVCScratchVolumes are in the api package
 // but we verify the BuildConfig bool integration here
+func TestPVCScratchSubPaths_PresentInBuildImageCleanupSkipList(t *testing.T) {
+	task := GenerateBuildAutomotiveImageTask("test-ns", &BuildConfig{
+		UsePVCScratchVolumes: true,
+	}, "")
+
+	subPaths := map[string]bool{}
+	for _, step := range task.Spec.Steps {
+		for _, vm := range step.VolumeMounts {
+			if vm.Name == workspaceVolumeRef && vm.SubPath != "" {
+				subPaths[vm.SubPath] = true
+			}
+		}
+	}
+
+	for sp := range subPaths {
+		if !strings.Contains(BuildImageScript, sp) {
+			t.Fatalf("scratch subPath %q used in task volume mounts but not referenced in BuildImageScript; the persistent-cache cleanup will destroy it", sp)
+		}
+		if !strings.Contains(FindManifestScript, sp) {
+			t.Fatalf("scratch subPath %q used in task volume mounts but not referenced in FindManifestScript; it will be unnecessarily copied", sp)
+		}
+	}
+}
+
 func TestBuildConfig_PVCScratchDefaultFalse(t *testing.T) {
 	cfg := &BuildConfig{}
 	if cfg.UsePVCScratchVolumes {

--- a/internal/common/tasks/scripts/build_image.sh
+++ b/internal/common/tasks/scripts/build_image.sh
@@ -70,7 +70,11 @@ if [ "$(params.use-persistent-cache)" = "true" ]; then
 
   echo "Cleaning up stale artifacts from persistent workspace..."
   for item in "$WORKSPACE_PATH"/*; do
-    [ "$(basename "$item")" = "build-cache" ] && continue
+    # Keep build-cache (osbuild store) and PVC-backed scratch subPath directories.
+    # Scratch names must match pvcScratchRedirects in tasks.go.
+    case "$(basename "$item")" in
+      build-cache|scratch-build|scratch-output|scratch-run) continue ;;
+    esac
     rm -rf "$item"
   done
 

--- a/internal/common/tasks/scripts/find_manifest.sh
+++ b/internal/common/tasks/scripts/find_manifest.sh
@@ -27,9 +27,10 @@ if [ -d "$SHARED_WS" ] && [ "$(ls -A "$SHARED_WS" 2>/dev/null)" ]; then
   echo "Copying uploaded files from $SHARED_WS to /manifest-work/"
   for item in "$SHARED_WS"/*; do
     base="$(basename "$item")"
-    # Skip build-cache (osbuild store) and known build artifacts from previous runs
+    # Skip build-cache, PVC-backed scratch subPaths (names match pvcScratchRedirects in tasks.go),
+    # and known build artifacts from previous runs
     case "$base" in
-      build-cache|aib-manifest.yml|image.json|disk.img|*-parts) continue ;;
+      build-cache|scratch-build|scratch-output|scratch-run|aib-manifest.yml|image.json|disk.img|*-parts) continue ;;
     esac
     cp -rv "$item" /manifest-work/ 2>/dev/null || true
   done

--- a/internal/common/tasks/tasks.go
+++ b/internal/common/tasks/tasks.go
@@ -998,9 +998,13 @@ func GenerateBuildAutomotiveImageTask(namespace string, buildConfig *BuildConfig
 				},
 				// workspace-src: provides file:// access to content synced via `caib workspace sync`.
 				// Volume is provided at PipelineRun time via PodTemplate (PVC or emptyDir fallback).
+				// SubPath "src" is required because the workspace PVC root is mounted at /workspace
+				// in the workspace pod, and sync writes into /workspace/src/ — so the files live
+				// under the "src" subdirectory of the PVC.
 				corev1.VolumeMount{
 					Name:      WorkspaceNameSrc,
 					MountPath: "/workspace/src",
+					SubPath:   "src",
 					ReadOnly:  true,
 				},
 			)

--- a/internal/common/tasks/tasks.go
+++ b/internal/common/tasks/tasks.go
@@ -852,12 +852,6 @@ func GenerateBuildAutomotiveImageTask(namespace string, buildConfig *BuildConfig
 					MountPath:   "/workspace/registry-auth",
 					Optional:    true,
 				},
-				{
-					Name:        WorkspaceNameSrc,
-					Description: "Optional: Workspace PVC for file:// access to synced content",
-					MountPath:   "/workspace/src",
-					Optional:    true,
-				},
 			},
 			Steps: []tektonv1.Step{
 				{
@@ -996,11 +990,20 @@ func GenerateBuildAutomotiveImageTask(namespace string, buildConfig *BuildConfig
 	// The actual Volume definition is provided at PipelineRun time via PodTemplate.
 	for i := range task.Spec.Steps {
 		if task.Spec.Steps[i].Name == PipelineTaskBuildImage {
-			task.Spec.Steps[i].VolumeMounts = append(task.Spec.Steps[i].VolumeMounts, corev1.VolumeMount{
-				Name:      OCIRepoVolumeName,
-				MountPath: OCIRepoMountPath,
-				ReadOnly:  true,
-			})
+			task.Spec.Steps[i].VolumeMounts = append(task.Spec.Steps[i].VolumeMounts,
+				corev1.VolumeMount{
+					Name:      OCIRepoVolumeName,
+					MountPath: OCIRepoMountPath,
+					ReadOnly:  true,
+				},
+				// workspace-src: provides file:// access to content synced via `caib workspace sync`.
+				// Volume is provided at PipelineRun time via PodTemplate (PVC or emptyDir fallback).
+				corev1.VolumeMount{
+					Name:      WorkspaceNameSrc,
+					MountPath: "/workspace/src",
+					ReadOnly:  true,
+				},
+			)
 			break
 		}
 	}
@@ -1471,7 +1474,6 @@ func GenerateTektonPipeline(name, namespace string, buildConfig *BuildConfig) *t
 				{Name: "s3-auth", Optional: true},
 				{Name: "flash-oci-auth", Optional: true},
 				{Name: "jumpstarter-client", Optional: true},
-				{Name: WorkspaceNameSrc, Optional: true},
 			},
 			Results: []tektonv1.PipelineResult{
 				{
@@ -1551,7 +1553,6 @@ func GenerateTektonPipeline(name, namespace string, buildConfig *BuildConfig) *t
 						{Name: workspaceNameShared, Workspace: workspaceNameShared},
 						{Name: "manifest-config-workspace", Workspace: "manifest-config-workspace"},
 						{Name: "registry-auth", Workspace: "registry-auth"},
-						{Name: WorkspaceNameSrc, Workspace: WorkspaceNameSrc},
 					},
 					Timeout: &metav1.Duration{Duration: time.Duration(buildConfig.getBuildTimeoutMinutes()) * time.Minute},
 				},

--- a/internal/common/tasks/tasks.go
+++ b/internal/common/tasks/tasks.go
@@ -181,6 +181,9 @@ const volumeNameContainerStorage = "container-storage"
 // workspaceNameShared is the Tekton workspace name for the shared PVC workspace.
 const workspaceNameShared = "shared-workspace"
 
+// WorkspaceNameSrc is the Tekton workspace name for the workspace source PVC.
+const WorkspaceNameSrc = "workspace-src"
+
 // workspaceVolumeRef is the Tekton variable reference for the shared workspace volume name.
 // Tekton resolves this at runtime to the actual volume name in the pod spec.
 const workspaceVolumeRef = "$(workspaces." + workspaceNameShared + ".volume)"
@@ -849,6 +852,12 @@ func GenerateBuildAutomotiveImageTask(namespace string, buildConfig *BuildConfig
 					MountPath:   "/workspace/registry-auth",
 					Optional:    true,
 				},
+				{
+					Name:        WorkspaceNameSrc,
+					Description: "Optional: Workspace PVC for file:// access to synced content",
+					MountPath:   "/workspace/src",
+					Optional:    true,
+				},
 			},
 			Steps: []tektonv1.Step{
 				{
@@ -1462,6 +1471,7 @@ func GenerateTektonPipeline(name, namespace string, buildConfig *BuildConfig) *t
 				{Name: "s3-auth", Optional: true},
 				{Name: "flash-oci-auth", Optional: true},
 				{Name: "jumpstarter-client", Optional: true},
+				{Name: WorkspaceNameSrc, Optional: true},
 			},
 			Results: []tektonv1.PipelineResult{
 				{
@@ -1541,6 +1551,7 @@ func GenerateTektonPipeline(name, namespace string, buildConfig *BuildConfig) *t
 						{Name: workspaceNameShared, Workspace: workspaceNameShared},
 						{Name: "manifest-config-workspace", Workspace: "manifest-config-workspace"},
 						{Name: "registry-auth", Workspace: "registry-auth"},
+						{Name: WorkspaceNameSrc, Workspace: WorkspaceNameSrc},
 					},
 					Timeout: &metav1.Duration{Duration: time.Duration(buildConfig.getBuildTimeoutMinutes()) * time.Minute},
 				},

--- a/internal/controller/imagebuild/controller.go
+++ b/internal/controller/imagebuild/controller.go
@@ -1440,15 +1440,6 @@ func (r *ImageBuildReconciler) createBuildTaskRun(
 		})
 	}
 
-	if imageBuild.Spec.WorkspacePVC != "" {
-		pipelineWorkspaces = append(pipelineWorkspaces, tektonv1.WorkspaceBinding{
-			Name: tasks.WorkspaceNameSrc,
-			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-				ClaimName: imageBuild.Spec.WorkspacePVC,
-			},
-		})
-	}
-
 	if imageBuild.Spec.GetS3CredentialsSecret() != "" {
 		pipelineWorkspaces = append(pipelineWorkspaces, tektonv1.WorkspaceBinding{
 			Name: "s3-auth",
@@ -1510,6 +1501,7 @@ func (r *ImageBuildReconciler) createBuildTaskRun(
 	}
 	podTemplate.Volumes = append(podTemplate.Volumes, tasks.OCIVolumes(buildConfig)...)
 	podTemplate.Volumes = append(podTemplate.Volumes, ociRepoVolumes(imageBuild.Spec.GetOCIRepoImages())...)
+	podTemplate.Volumes = append(podTemplate.Volumes, workspaceSrcVolume(imageBuild.Spec.WorkspacePVC))
 	pipelineRunSpec := tektonv1.PipelineRunSpec{
 		Params:     params,
 		Workspaces: pipelineWorkspaces,
@@ -3088,6 +3080,25 @@ func ociRepoVolumes(ociRepoImages []string) []corev1.Volume {
 		}
 	}
 	return []corev1.Volume{vol}
+}
+
+// workspaceSrcVolume returns the workspace-src volume for the PipelineRun PodTemplate.
+// If a PVC name is provided, uses PersistentVolumeClaimVolumeSource; otherwise EmptyDir
+// so the Task's VolumeMount always resolves.
+func workspaceSrcVolume(pvcName string) corev1.Volume {
+	vol := corev1.Volume{Name: tasks.WorkspaceNameSrc}
+	if pvcName != "" {
+		vol.VolumeSource = corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+				ClaimName: pvcName,
+			},
+		}
+	} else {
+		vol.VolumeSource = corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		}
+	}
+	return vol
 }
 
 func decodeAuthEntry(auth string, log logr.Logger) ([]byte, []byte) {

--- a/internal/controller/imagebuild/controller.go
+++ b/internal/controller/imagebuild/controller.go
@@ -1440,6 +1440,15 @@ func (r *ImageBuildReconciler) createBuildTaskRun(
 		})
 	}
 
+	if imageBuild.Spec.WorkspacePVC != "" {
+		pipelineWorkspaces = append(pipelineWorkspaces, tektonv1.WorkspaceBinding{
+			Name: tasks.WorkspaceNameSrc,
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+				ClaimName: imageBuild.Spec.WorkspacePVC,
+			},
+		})
+	}
+
 	if imageBuild.Spec.GetS3CredentialsSecret() != "" {
 		pipelineWorkspaces = append(pipelineWorkspaces, tektonv1.WorkspaceBinding{
 			Name: "s3-auth",

--- a/internal/controller/imagebuild/controller_test.go
+++ b/internal/controller/imagebuild/controller_test.go
@@ -963,6 +963,49 @@ func TestOCIRepoVolumes(t *testing.T) {
 	}
 }
 
+func TestWorkspaceSrcVolume(t *testing.T) {
+	tests := []struct {
+		name    string
+		pvcName string
+		wantPVC bool
+	}{
+		{
+			name:    "no PVC — EmptyDir",
+			pvcName: "",
+			wantPVC: false,
+		},
+		{
+			name:    "with PVC — PersistentVolumeClaim",
+			pvcName: "my-workspace",
+			wantPVC: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vol := workspaceSrcVolume(tt.pvcName)
+			if vol.Name != tasks.WorkspaceNameSrc {
+				t.Errorf("volume name = %q, want %q", vol.Name, tasks.WorkspaceNameSrc)
+			}
+			if tt.wantPVC {
+				if vol.PersistentVolumeClaim == nil {
+					t.Fatal("expected PersistentVolumeClaim, got nil")
+				}
+				if vol.PersistentVolumeClaim.ClaimName != tt.pvcName {
+					t.Errorf("ClaimName = %q, want %q", vol.PersistentVolumeClaim.ClaimName, tt.pvcName)
+				}
+			} else {
+				if vol.EmptyDir == nil {
+					t.Fatal("expected EmptyDir, got nil")
+				}
+				if vol.PersistentVolumeClaim != nil {
+					t.Error("should not have PVC when EmptyDir is set")
+				}
+			}
+		})
+	}
+}
+
 func TestGetOCIRepoImages(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Summary

Mounts the workspace PVC in the build pod so that `file://` paths to workspace-synced content (e.g., local RPM repos) work in AIB manifests.

When `--workspace` is used with `caib image build-dev`, the workspace PVC is now mounted at `/workspace/src` in the build pod via a podTemplate volume (avoids Tekton affinity conflicts with RWO PVCs). The build pod is co-located with the workspace pod using node affinity.

Related issue with full root cause analysis: https://github.com/mickume/automotive-dev-operator/issues/19

**Depends on:** #561

## Changes

| File | Change |
|------|--------|
| `api/v1alpha1/imagebuild_types.go` | Add `WorkspacePVC` field to ImageBuildSpec |
| `config/crd/bases/*.yaml` | CRD regeneration for new field |
| `internal/buildapi/server.go` | Pass workspace PVC name from workspace status to ImageBuild spec |
| `internal/common/tasks/tasks.go` | Add workspace-src volume mount via podTemplate when WorkspacePVC is set |
| `internal/controller/imagebuild/controller.go` | Add node affinity to co-locate build pod with workspace pod |
| `internal/controller/imagebuild/controller_test.go` | Test workspace PVC node affinity logic |
| `internal/common/tasks/pipeline_test.go` | Test workspace-src volume and mount generation |
| `internal/common/tasks/scripts/build_image.sh` | Preserve scratch subPath dirs in cleanup (from #561) |
| `internal/common/tasks/scripts/find_manifest.sh` | Skip scratch dirs in manifest copy (from #561) |
| `internal/common/tasks/scratch_volumes_test.go` | Regression test for scratch dir names (from #561) |

## Test plan

- [ ] Verify `caib image build-dev manifest.aib.yml --workspace <name>` with `file:///workspace/src/...` repo paths succeeds
- [ ] Verify builds without `--workspace` are unaffected (no extra volumes mounted)
- [ ] Verify build pod is scheduled on the same node as the workspace pod
- [ ] Verify existing workspace features (sync, exec, deploy) still work

@coderabbitai ignore
