### PR TITLE
feat(caib): support S3 defaults in config file with CLI overrides

### DIFF
--- a/cmd/caib/README.md
+++ b/cmd/caib/README.md
@@ -670,6 +670,41 @@ Supported locations:
 - `content.add_files[].source_path`
 - `qm.content.add_files[].source_path`
 
+## Configuration File
+
+`caib` reads defaults from `~/.config/caib/cli.json`. The file is created automatically by `caib login`; you can also edit it by hand.
+
+```json
+{
+  "server_url": "https://build-api.example.com",
+  "s3": {
+    "bucket": "my-builds",
+    "prefix": "artifacts/",
+    "endpoint": "https://minio.example.com",
+    "region": "us-east-1",
+    "insecure_skip_tls_verify": false,
+    "credentials_secret": "my-k8s-secret",
+    "access_key_id": "AKIA...",
+    "secret_access_key": "wJa..."
+  }
+}
+```
+
+All `s3` fields are optional. Setting `s3.bucket` causes **every build** to upload artifacts to S3 (equivalent to always passing `--s3-bucket`). Pass `--s3-bucket ""` to disable S3 for a single build when a default bucket is configured.
+
+CLI flags override config values. Explicitly passing an empty flag (e.g. `--s3-region ""`) clears the config default for that field.
+
+**Credential sources** — use exactly one:
+
+| Source | Fields |
+|--------|--------|
+| Kubernetes secret | `credentials_secret` |
+| Inline keys | `access_key_id` + `secret_access_key` (both required) |
+| Environment variables | `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` |
+| IAM / instance profile | Omit all credential fields |
+
+Mixing `credentials_secret` with `access_key_id`/`secret_access_key` in the config file is an error.
+
 ## Environment Variables
 
 | Variable | Description |

--- a/cmd/caib/README.md
+++ b/cmd/caib/README.md
@@ -683,9 +683,7 @@ Supported locations:
     "endpoint": "https://minio.example.com",
     "region": "us-east-1",
     "insecure_skip_tls_verify": false,
-    "credentials_secret": "my-k8s-secret",
-    "access_key_id": "AKIA...",
-    "secret_access_key": "wJa..."
+    "credentials_secret": "my-k8s-secret"
   }
 }
 ```
@@ -696,14 +694,14 @@ CLI flags override config values. Explicitly passing an empty flag (e.g. `--s3-r
 
 **Credential sources** — use exactly one:
 
-| Source | Fields |
-|--------|--------|
-| Kubernetes secret | `credentials_secret` |
-| Inline keys | `access_key_id` + `secret_access_key` (both required) |
+| Source | How to configure |
+|--------|------------------|
+| Kubernetes secret | `credentials_secret` in config file or `--s3-credentials-secret` flag |
+| Inline keys | `--s3-access-key-id` + `--s3-secret-access-key` flags |
 | Environment variables | `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` |
 | IAM / instance profile | Omit all credential fields |
 
-Mixing `credentials_secret` with `access_key_id`/`secret_access_key` in the config file is an error.
+Inline access keys (`access_key_id`/`secret_access_key`) are not supported in the config file to avoid storing long-lived secrets in plaintext on disk. Use `credentials_secret` (a Kubernetes secret reference), CLI flags, or environment variables instead.
 
 ## Environment Variables
 

--- a/cmd/caib/README.md
+++ b/cmd/caib/README.md
@@ -688,7 +688,7 @@ Supported locations:
 }
 ```
 
-All `s3` fields are optional. Setting `s3.bucket` causes **every build** to upload artifacts to S3 (equivalent to always passing `--s3-bucket`). Pass `--s3-bucket ""` to disable S3 for a single build when a default bucket is configured.
+All `s3` fields are optional. Setting `s3.bucket` causes **disk-artifact builds** (`build`, `disk`, `build-dev`) to upload artifacts to S3 (equivalent to always passing `--s3-bucket`). Pass `--s3-bucket ""` to disable S3 for a single build when a default bucket is configured.
 
 CLI flags override config values. Explicitly passing an empty flag (e.g. `--s3-region ""`) clears the config default for that field.
 

--- a/cmd/caib/buildcmd/build.go
+++ b/cmd/caib/buildcmd/build.go
@@ -14,6 +14,7 @@ import (
 	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	common "github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/common"
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/config"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/registryauth"
 	buildapitypes "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi"
 	buildapiclient "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi/client"
@@ -545,28 +546,68 @@ func (h *Handler) applyFlashOptions(req *buildapitypes.BuildRequest, pushRequire
 	return nil
 }
 
-func (h *Handler) applyS3Options(req *buildapitypes.BuildRequest) error {
-	if h.opts.S3Bucket == nil || *h.opts.S3Bucket == "" {
+// s3DefaultsFn is the function used to load S3 defaults from the config file.
+// Overridden in tests.
+var s3DefaultsFn = config.S3Defaults
+
+func (h *Handler) applyS3Options(cmd *cobra.Command, req *buildapitypes.BuildRequest) error {
+	s3Cfg, err := s3DefaultsFn()
+	if err != nil {
+		return err
+	}
+
+	bucket := ptrStr(h.opts.S3Bucket)
+	if !flagChanged(cmd, "s3-bucket") && bucket == "" && s3Cfg != nil {
+		bucket = s3Cfg.Bucket
+	}
+	if bucket == "" {
 		return nil
 	}
+	req.S3Bucket = bucket
 
-	req.S3Bucket = *h.opts.S3Bucket
-	if h.opts.S3Prefix != nil {
-		req.S3Prefix = *h.opts.S3Prefix
-	}
-	if h.opts.S3Endpoint != nil {
-		req.S3Endpoint = *h.opts.S3Endpoint
-	}
-	if h.opts.S3Region != nil {
-		req.S3Region = *h.opts.S3Region
-	}
-	if h.opts.S3Insecure != nil {
-		req.S3InsecureSkipTLSVerify = *h.opts.S3Insecure
+	h.applyS3ConnectionParams(cmd, req, s3Cfg)
+
+	return h.applyS3Credentials(req, s3Cfg)
+}
+
+func (h *Handler) applyS3ConnectionParams(cmd *cobra.Command, req *buildapitypes.BuildRequest, s3Cfg *config.S3Config) {
+	if flagChanged(cmd, "s3-prefix") {
+		req.S3Prefix = ptrStr(h.opts.S3Prefix)
+	} else if v := ptrStr(h.opts.S3Prefix); v != "" {
+		req.S3Prefix = v
+	} else if s3Cfg != nil {
+		req.S3Prefix = s3Cfg.Prefix
 	}
 
-	secretProvided := h.opts.S3CredentialsSecret != nil && *h.opts.S3CredentialsSecret != ""
-	explicitAccess := h.opts.S3AccessKeyID != nil && *h.opts.S3AccessKeyID != ""
-	explicitSecret := h.opts.S3SecretAccessKey != nil && *h.opts.S3SecretAccessKey != ""
+	if flagChanged(cmd, "s3-endpoint") {
+		req.S3Endpoint = ptrStr(h.opts.S3Endpoint)
+	} else if v := ptrStr(h.opts.S3Endpoint); v != "" {
+		req.S3Endpoint = v
+	} else if s3Cfg != nil {
+		req.S3Endpoint = s3Cfg.Endpoint
+	}
+
+	if flagChanged(cmd, "s3-region") {
+		req.S3Region = ptrStr(h.opts.S3Region)
+	} else if v := ptrStr(h.opts.S3Region); v != "" {
+		req.S3Region = v
+	} else if s3Cfg != nil {
+		req.S3Region = s3Cfg.Region
+	}
+
+	if flagChanged(cmd, "s3-insecure") {
+		req.S3InsecureSkipTLSVerify = h.opts.S3Insecure != nil && *h.opts.S3Insecure
+	} else if h.opts.S3Insecure != nil && *h.opts.S3Insecure {
+		req.S3InsecureSkipTLSVerify = true
+	} else if s3Cfg != nil {
+		req.S3InsecureSkipTLSVerify = s3Cfg.InsecureSkipTLSVerify
+	}
+}
+
+func (h *Handler) applyS3Credentials(req *buildapitypes.BuildRequest, s3Cfg *config.S3Config) error {
+	secretProvided := ptrStr(h.opts.S3CredentialsSecret) != ""
+	explicitAccess := ptrStr(h.opts.S3AccessKeyID) != ""
+	explicitSecret := ptrStr(h.opts.S3SecretAccessKey) != ""
 	inlineCredsProvided := explicitAccess || explicitSecret
 	envAccess := os.Getenv("AWS_ACCESS_KEY_ID")
 	envSecret := os.Getenv("AWS_SECRET_ACCESS_KEY")
@@ -610,9 +651,38 @@ func (h *Handler) applyS3Options(req *buildapitypes.BuildRequest) error {
 			AccessKeyID:     envAccess,
 			SecretAccessKey: envSecret,
 		}
+	} else if s3Cfg != nil {
+		if s3Cfg.CredentialsSecret != "" && (s3Cfg.AccessKeyID != "" || s3Cfg.SecretAccessKey != "") {
+			return fmt.Errorf("config file has both s3.credentials_secret and s3.access_key_id/s3.secret_access_key; use only one")
+		}
+		if s3Cfg.CredentialsSecret != "" {
+			req.S3CredentialsSecretName = s3Cfg.CredentialsSecret
+		} else if s3Cfg.AccessKeyID != "" || s3Cfg.SecretAccessKey != "" {
+			if s3Cfg.AccessKeyID == "" {
+				return fmt.Errorf("config file has s3.secret_access_key but s3.access_key_id is missing")
+			}
+			if s3Cfg.SecretAccessKey == "" {
+				return fmt.Errorf("config file has s3.access_key_id but s3.secret_access_key is missing")
+			}
+			req.S3Credentials = &buildapitypes.S3Credentials{
+				AccessKeyID:     s3Cfg.AccessKeyID,
+				SecretAccessKey: s3Cfg.SecretAccessKey,
+			}
+		}
 	}
 
 	return nil
+}
+
+func ptrStr(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}
+
+func flagChanged(cmd *cobra.Command, name string) bool {
+	return cmd != nil && cmd.Flags().Changed(name)
 }
 
 func (h *Handler) displayBuildLogsCommand(buildName string) {
@@ -852,7 +922,7 @@ func (h *Handler) RunBuild(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	if err := h.applyS3Options(&req); err != nil {
+	if err := h.applyS3Options(cmd, &req); err != nil {
 		h.handleError(err)
 		return
 	}
@@ -976,7 +1046,7 @@ func (h *Handler) RunDisk(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	if err := h.applyS3Options(&req); err != nil {
+	if err := h.applyS3Options(cmd, &req); err != nil {
 		h.handleError(err)
 		return
 	}
@@ -1152,7 +1222,7 @@ func (h *Handler) RunBuildDev(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	if err := h.applyS3Options(&req); err != nil {
+	if err := h.applyS3Options(cmd, &req); err != nil {
 		h.handleError(err)
 		return
 	}

--- a/cmd/caib/buildcmd/build.go
+++ b/cmd/caib/buildcmd/build.go
@@ -552,13 +552,9 @@ var s3DefaultsFn = config.S3Defaults
 
 func (h *Handler) applyS3Options(cmd *cobra.Command, req *buildapitypes.BuildRequest) error {
 	bucket := ptrStr(h.opts.S3Bucket)
-	s3Requested := flagChanged(cmd, "s3-bucket") || bucket != ""
 
 	s3Cfg, err := s3DefaultsFn()
 	if err != nil {
-		if !s3Requested {
-			return nil
-		}
 		return err
 	}
 

--- a/cmd/caib/buildcmd/build.go
+++ b/cmd/caib/buildcmd/build.go
@@ -656,24 +656,8 @@ func (h *Handler) applyS3Credentials(req *buildapitypes.BuildRequest, s3Cfg *con
 			AccessKeyID:     envAccess,
 			SecretAccessKey: envSecret,
 		}
-	} else if s3Cfg != nil {
-		if s3Cfg.CredentialsSecret != "" && (s3Cfg.AccessKeyID != "" || s3Cfg.SecretAccessKey != "") {
-			return fmt.Errorf("config file has both s3.credentials_secret and s3.access_key_id/s3.secret_access_key; use only one")
-		}
-		if s3Cfg.CredentialsSecret != "" {
-			req.S3CredentialsSecretName = s3Cfg.CredentialsSecret
-		} else if s3Cfg.AccessKeyID != "" || s3Cfg.SecretAccessKey != "" {
-			if s3Cfg.AccessKeyID == "" {
-				return fmt.Errorf("config file has s3.secret_access_key but s3.access_key_id is missing")
-			}
-			if s3Cfg.SecretAccessKey == "" {
-				return fmt.Errorf("config file has s3.access_key_id but s3.secret_access_key is missing")
-			}
-			req.S3Credentials = &buildapitypes.S3Credentials{
-				AccessKeyID:     s3Cfg.AccessKeyID,
-				SecretAccessKey: s3Cfg.SecretAccessKey,
-			}
-		}
+	} else if s3Cfg != nil && s3Cfg.CredentialsSecret != "" {
+		req.S3CredentialsSecretName = s3Cfg.CredentialsSecret
 	}
 
 	return nil

--- a/cmd/caib/buildcmd/build.go
+++ b/cmd/caib/buildcmd/build.go
@@ -551,12 +551,17 @@ func (h *Handler) applyFlashOptions(req *buildapitypes.BuildRequest, pushRequire
 var s3DefaultsFn = config.S3Defaults
 
 func (h *Handler) applyS3Options(cmd *cobra.Command, req *buildapitypes.BuildRequest) error {
+	bucket := ptrStr(h.opts.S3Bucket)
+	s3Requested := flagChanged(cmd, "s3-bucket") || bucket != ""
+
 	s3Cfg, err := s3DefaultsFn()
 	if err != nil {
+		if !s3Requested {
+			return nil
+		}
 		return err
 	}
 
-	bucket := ptrStr(h.opts.S3Bucket)
 	if !flagChanged(cmd, "s3-bucket") && bucket == "" && s3Cfg != nil {
 		bucket = s3Cfg.Bucket
 	}

--- a/cmd/caib/buildcmd/build_disk_test.go
+++ b/cmd/caib/buildcmd/build_disk_test.go
@@ -55,7 +55,7 @@ func newTestDiskOpts() Options {
 		insecureSkipTLS      bool
 		s3Bucket             string
 		s3Prefix             string
-		s3Region             = "us-east-1"
+		s3Region             string
 		s3Endpoint           string
 		s3AccessKeyID        string
 		s3SecretAccessKey    string

--- a/cmd/caib/buildcmd/build_s3_test.go
+++ b/cmd/caib/buildcmd/build_s3_test.go
@@ -56,6 +56,8 @@ func TestApplyS3Options_InlineCredentials(t *testing.T) {
 	*opts.S3AccessKeyID = testS3AccessKey
 	*opts.S3SecretAccessKey = "SECRET"
 	*opts.S3Insecure = true
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
 	h := newS3TestHandler(opts)
 
 	var req buildapitypes.BuildRequest
@@ -133,6 +135,8 @@ func TestApplyS3Options_SecretName(t *testing.T) {
 	opts := newTestDiskOpts()
 	*opts.S3Bucket = testS3Bucket
 	*opts.S3CredentialsSecret = "shared-s3-creds"
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
 	h := newS3TestHandler(opts)
 
 	var req buildapitypes.BuildRequest
@@ -151,6 +155,8 @@ func TestApplyS3Options_PartialCredentialsError(t *testing.T) {
 	opts := newTestDiskOpts()
 	*opts.S3Bucket = testS3Bucket
 	*opts.S3AccessKeyID = "AKID"
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
 	h := newS3TestHandler(opts)
 
 	var req buildapitypes.BuildRequest
@@ -266,6 +272,8 @@ func TestApplyS3Options_NoCredentialsAllowed(t *testing.T) {
 
 func TestApplyS3Options_ConfigFileDefaults(t *testing.T) {
 	opts := newTestDiskOpts()
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
 	h := newS3TestHandler(opts)
 
 	cfg := &config.S3Config{
@@ -311,6 +319,8 @@ func TestApplyS3Options_CLIFlagsOverrideConfig(t *testing.T) {
 	*opts.S3Region = "ap-southeast-1"
 	*opts.S3CredentialsSecret = "flag-secret"
 	*opts.S3Insecure = true
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
 	h := newS3TestHandler(opts)
 
 	cfg := &config.S3Config{
@@ -352,6 +362,8 @@ func TestApplyS3Options_ExplicitInsecureFalseOverridesConfig(t *testing.T) {
 	opts := newTestDiskOpts()
 	*opts.S3Bucket = "test-bucket"
 	*opts.S3Insecure = false
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
 	h := newS3TestHandler(opts)
 
 	cmd := &cobra.Command{}
@@ -377,6 +389,8 @@ func TestApplyS3Options_ExplicitInsecureFalseOverridesConfig(t *testing.T) {
 func TestApplyS3Options_ConfigBucketWithFlagOverrides(t *testing.T) {
 	opts := newTestDiskOpts()
 	*opts.S3Region = "us-west-2"
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
 	h := newS3TestHandler(opts)
 
 	cfg := &config.S3Config{
@@ -572,6 +586,8 @@ func TestApplyS3Options_ExplicitEmptyConnectionParamsOverrideConfig(t *testing.T
 	*opts.S3Prefix = ""
 	*opts.S3Endpoint = ""
 	*opts.S3Region = ""
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
 	h := newS3TestHandler(opts)
 
 	cmd := &cobra.Command{}

--- a/cmd/caib/buildcmd/build_s3_test.go
+++ b/cmd/caib/buildcmd/build_s3_test.go
@@ -427,9 +427,8 @@ func TestApplyS3Options_EnvVarsOverrideConfigCredentials(t *testing.T) {
 	h := newS3TestHandler(opts)
 
 	cfg := &config.S3Config{
-		Bucket:          "config-bucket",
-		AccessKeyID:     "config-akid",
-		SecretAccessKey: "config-secret",
+		Bucket:            "config-bucket",
+		CredentialsSecret: "config-secret-ref",
 	}
 
 	withS3Defaults(cfg, func() {
@@ -443,54 +442,8 @@ func TestApplyS3Options_EnvVarsOverrideConfigCredentials(t *testing.T) {
 		if req.S3Credentials.AccessKeyID != "ENV_AKID" {
 			t.Errorf("AccessKeyID = %q, want %q (env should override config)", req.S3Credentials.AccessKeyID, "ENV_AKID")
 		}
-	})
-}
-
-func TestApplyS3Options_ConfigInlineCredentials(t *testing.T) {
-	opts := newTestDiskOpts()
-	t.Setenv("AWS_ACCESS_KEY_ID", "")
-	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
-	h := newS3TestHandler(opts)
-
-	cfg := &config.S3Config{
-		Bucket:          "config-bucket",
-		AccessKeyID:     "config-akid",
-		SecretAccessKey: "config-secret",
-	}
-
-	withS3Defaults(cfg, func() {
-		var req buildapitypes.BuildRequest
-		if err := h.applyS3Options(nil, &req); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if req.S3Credentials == nil {
-			t.Fatal("expected S3Credentials from config file")
-		}
-		if req.S3Credentials.AccessKeyID != "config-akid" {
-			t.Errorf("AccessKeyID = %q, want %q", req.S3Credentials.AccessKeyID, "config-akid")
-		}
-		if req.S3Credentials.SecretAccessKey != "config-secret" {
-			t.Errorf("SecretAccessKey = %q, want %q", req.S3Credentials.SecretAccessKey, "config-secret")
-		}
-	})
-}
-
-func TestApplyS3Options_ConfigPartialCredentialsError(t *testing.T) {
-	opts := newTestDiskOpts()
-	t.Setenv("AWS_ACCESS_KEY_ID", "")
-	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
-	h := newS3TestHandler(opts)
-
-	cfg := &config.S3Config{
-		Bucket:      "config-bucket",
-		AccessKeyID: "config-akid",
-	}
-
-	withS3Defaults(cfg, func() {
-		var req buildapitypes.BuildRequest
-		err := h.applyS3Options(nil, &req)
-		if err == nil {
-			t.Fatal("expected error for partial config file credentials")
+		if req.S3CredentialsSecretName != "" {
+			t.Errorf("S3CredentialsSecretName = %q, want empty (env vars take priority over config secret)", req.S3CredentialsSecretName)
 		}
 	})
 }
@@ -527,31 +480,6 @@ func TestApplyS3Options_NoBucketWithConfigNil(t *testing.T) {
 		}
 		if req.S3Bucket != "" {
 			t.Error("expected empty S3Bucket when no flag and no config")
-		}
-	})
-}
-
-func TestApplyS3Options_ConfigMixedCredentialSourcesError(t *testing.T) {
-	opts := newTestDiskOpts()
-	t.Setenv("AWS_ACCESS_KEY_ID", "")
-	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
-	h := newS3TestHandler(opts)
-
-	cfg := &config.S3Config{
-		Bucket:            "config-bucket",
-		CredentialsSecret: "my-k8s-secret",
-		AccessKeyID:       "config-akid",
-		SecretAccessKey:   "config-secret",
-	}
-
-	withS3Defaults(cfg, func() {
-		var req buildapitypes.BuildRequest
-		err := h.applyS3Options(nil, &req)
-		if err == nil {
-			t.Fatal("expected error for mixed credential sources in config file")
-		}
-		if !strings.Contains(err.Error(), "credentials_secret") {
-			t.Errorf("error = %q, want it to mention credentials_secret", err.Error())
 		}
 	})
 }

--- a/cmd/caib/buildcmd/build_s3_test.go
+++ b/cmd/caib/buildcmd/build_s3_test.go
@@ -497,6 +497,7 @@ func TestApplyS3Options_ConfigPartialCredentialsError(t *testing.T) {
 
 func TestApplyS3Options_ConfigReadError(t *testing.T) {
 	opts := newTestDiskOpts()
+	*opts.S3Bucket = testS3Bucket
 	h := newS3TestHandler(opts)
 
 	orig := s3DefaultsFn
@@ -622,4 +623,48 @@ func TestApplyS3Options_ExplicitEmptyConnectionParamsOverrideConfig(t *testing.T
 			t.Errorf("S3Region = %q, want empty (explicit --s3-region '' should override config)", req.S3Region)
 		}
 	})
+}
+
+func TestApplyS3Options_MalformedConfigIgnoredWhenNoS3Flags(t *testing.T) {
+	opts := newTestDiskOpts()
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	h := newS3TestHandler(opts)
+
+	orig := s3DefaultsFn
+	s3DefaultsFn = func() (*config.S3Config, error) {
+		return nil, fmt.Errorf("reading config for S3 defaults: invalid character 'i' looking for beginning of value")
+	}
+	defer func() { s3DefaultsFn = orig }()
+
+	var req buildapitypes.BuildRequest
+	if err := h.applyS3Options(nil, &req); err != nil {
+		t.Fatalf("malformed config should be tolerated when no S3 flags are set, got: %v", err)
+	}
+	if req.S3Bucket != "" {
+		t.Errorf("S3Bucket = %q, want empty", req.S3Bucket)
+	}
+}
+
+func TestApplyS3Options_MalformedConfigErrorsWhenS3FlagSet(t *testing.T) {
+	opts := newTestDiskOpts()
+	*opts.S3Bucket = testS3Bucket
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	h := newS3TestHandler(opts)
+
+	orig := s3DefaultsFn
+	s3DefaultsFn = func() (*config.S3Config, error) {
+		return nil, fmt.Errorf("reading config for S3 defaults: invalid character 'i' looking for beginning of value")
+	}
+	defer func() { s3DefaultsFn = orig }()
+
+	var req buildapitypes.BuildRequest
+	err := h.applyS3Options(nil, &req)
+	if err == nil {
+		t.Fatal("expected error from malformed config when --s3-bucket is set")
+	}
+	if !strings.Contains(err.Error(), "reading config") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "reading config")
+	}
 }

--- a/cmd/caib/buildcmd/build_s3_test.go
+++ b/cmd/caib/buildcmd/build_s3_test.go
@@ -553,7 +553,7 @@ func TestApplyS3Options_ExplicitEmptyConnectionParamsOverrideConfig(t *testing.T
 	})
 }
 
-func TestApplyS3Options_MalformedConfigIgnoredWhenNoS3Flags(t *testing.T) {
+func TestApplyS3Options_MalformedConfigErrorsWhenNoS3Flags(t *testing.T) {
 	opts := newTestDiskOpts()
 	t.Setenv("AWS_ACCESS_KEY_ID", "")
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
@@ -566,11 +566,12 @@ func TestApplyS3Options_MalformedConfigIgnoredWhenNoS3Flags(t *testing.T) {
 	defer func() { s3DefaultsFn = orig }()
 
 	var req buildapitypes.BuildRequest
-	if err := h.applyS3Options(nil, &req); err != nil {
-		t.Fatalf("malformed config should be tolerated when no S3 flags are set, got: %v", err)
+	err := h.applyS3Options(nil, &req)
+	if err == nil {
+		t.Fatal("expected error from malformed config even when no S3 flags are set")
 	}
-	if req.S3Bucket != "" {
-		t.Errorf("S3Bucket = %q, want empty", req.S3Bucket)
+	if !strings.Contains(err.Error(), "reading config") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "reading config")
 	}
 }
 

--- a/cmd/caib/buildcmd/build_s3_test.go
+++ b/cmd/caib/buildcmd/build_s3_test.go
@@ -1,21 +1,34 @@
 package buildcmd
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/config"
 	buildapitypes "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi"
+	"github.com/spf13/cobra"
 )
 
 const (
-	testS3Bucket    = "my-bucket"
-	testS3AccessKey = "AKID"
+	testS3Bucket     = "my-bucket"
+	testS3FlagBucket = "flag-bucket"
+	testS3AccessKey  = "AKID"
 )
 
 func newS3TestHandler(opts Options) *Handler {
 	if opts.HandleError == nil {
 		opts.HandleError = func(_ error) {}
 	}
+	s3DefaultsFn = func() (*config.S3Config, error) { return nil, nil }
 	return NewHandler(opts)
+}
+
+func withS3Defaults(cfg *config.S3Config, fn func()) {
+	orig := s3DefaultsFn
+	s3DefaultsFn = func() (*config.S3Config, error) { return cfg, nil }
+	defer func() { s3DefaultsFn = orig }()
+	fn()
 }
 
 func TestApplyS3Options_NoBucket(t *testing.T) {
@@ -23,7 +36,7 @@ func TestApplyS3Options_NoBucket(t *testing.T) {
 	h := newS3TestHandler(opts)
 
 	var req buildapitypes.BuildRequest
-	if err := h.applyS3Options(&req); err != nil {
+	if err := h.applyS3Options(nil, &req); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if req.S3Bucket != "" {
@@ -46,7 +59,7 @@ func TestApplyS3Options_InlineCredentials(t *testing.T) {
 	h := newS3TestHandler(opts)
 
 	var req buildapitypes.BuildRequest
-	if err := h.applyS3Options(&req); err != nil {
+	if err := h.applyS3Options(nil, &req); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if req.S3Bucket != testS3Bucket {
@@ -86,7 +99,7 @@ func TestApplyS3Options_EnvVarFallback(t *testing.T) {
 	h := newS3TestHandler(opts)
 
 	var req buildapitypes.BuildRequest
-	if err := h.applyS3Options(&req); err != nil {
+	if err := h.applyS3Options(nil, &req); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if req.S3Credentials == nil {
@@ -110,7 +123,7 @@ func TestApplyS3Options_ConflictingCredentialSourcesError(t *testing.T) {
 	h := newS3TestHandler(opts)
 
 	var req buildapitypes.BuildRequest
-	err := h.applyS3Options(&req)
+	err := h.applyS3Options(nil, &req)
 	if err == nil {
 		t.Fatal("expected error when both flags and env vars provide credentials")
 	}
@@ -123,7 +136,7 @@ func TestApplyS3Options_SecretName(t *testing.T) {
 	h := newS3TestHandler(opts)
 
 	var req buildapitypes.BuildRequest
-	if err := h.applyS3Options(&req); err != nil {
+	if err := h.applyS3Options(nil, &req); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if req.S3CredentialsSecretName != "shared-s3-creds" {
@@ -141,7 +154,7 @@ func TestApplyS3Options_PartialCredentialsError(t *testing.T) {
 	h := newS3TestHandler(opts)
 
 	var req buildapitypes.BuildRequest
-	err := h.applyS3Options(&req)
+	err := h.applyS3Options(nil, &req)
 	if err == nil {
 		t.Fatal("expected error for partial credentials")
 	}
@@ -187,7 +200,7 @@ func TestApplyS3Options_ExplicitAccessKeyOnlyError(t *testing.T) {
 	h := newS3TestHandler(opts)
 
 	var req buildapitypes.BuildRequest
-	err := h.applyS3Options(&req)
+	err := h.applyS3Options(nil, &req)
 	if err == nil {
 		t.Fatal("expected error when only --s3-access-key-id is set (should not combine with env)")
 	}
@@ -201,7 +214,7 @@ func TestApplyS3Options_ExplicitSecretKeyOnlyError(t *testing.T) {
 	h := newS3TestHandler(opts)
 
 	var req buildapitypes.BuildRequest
-	err := h.applyS3Options(&req)
+	err := h.applyS3Options(nil, &req)
 	if err == nil {
 		t.Fatal("expected error when only --s3-secret-access-key is set (should not combine with env)")
 	}
@@ -215,7 +228,7 @@ func TestApplyS3Options_AmbientAccessKeyOnlyError(t *testing.T) {
 	h := newS3TestHandler(opts)
 
 	var req buildapitypes.BuildRequest
-	err := h.applyS3Options(&req)
+	err := h.applyS3Options(nil, &req)
 	if err == nil {
 		t.Fatal("expected error when only AWS_ACCESS_KEY_ID is set in env")
 	}
@@ -229,7 +242,7 @@ func TestApplyS3Options_AmbientSecretKeyOnlyError(t *testing.T) {
 	h := newS3TestHandler(opts)
 
 	var req buildapitypes.BuildRequest
-	err := h.applyS3Options(&req)
+	err := h.applyS3Options(nil, &req)
 	if err == nil {
 		t.Fatal("expected error when only AWS_SECRET_ACCESS_KEY is set in env")
 	}
@@ -243,10 +256,354 @@ func TestApplyS3Options_NoCredentialsAllowed(t *testing.T) {
 	h := newS3TestHandler(opts)
 
 	var req buildapitypes.BuildRequest
-	if err := h.applyS3Options(&req); err != nil {
+	if err := h.applyS3Options(nil, &req); err != nil {
 		t.Fatalf("expected no error for IAM-based auth, got: %v", err)
 	}
 	if req.S3Credentials != nil {
 		t.Error("expected nil S3Credentials for IAM-based auth")
 	}
+}
+
+func TestApplyS3Options_ConfigFileDefaults(t *testing.T) {
+	opts := newTestDiskOpts()
+	h := newS3TestHandler(opts)
+
+	cfg := &config.S3Config{
+		Bucket:                "config-bucket",
+		Prefix:                "config-prefix/",
+		Endpoint:              "https://config-minio.local",
+		Region:                "eu-central-1",
+		CredentialsSecret:     "config-s3-creds",
+		InsecureSkipTLSVerify: true,
+	}
+
+	withS3Defaults(cfg, func() {
+		var req buildapitypes.BuildRequest
+		if err := h.applyS3Options(nil, &req); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if req.S3Bucket != "config-bucket" {
+			t.Errorf("S3Bucket = %q, want %q", req.S3Bucket, "config-bucket")
+		}
+		if req.S3Prefix != "config-prefix/" {
+			t.Errorf("S3Prefix = %q, want %q", req.S3Prefix, "config-prefix/")
+		}
+		if req.S3Endpoint != "https://config-minio.local" {
+			t.Errorf("S3Endpoint = %q, want %q", req.S3Endpoint, "https://config-minio.local")
+		}
+		if req.S3Region != "eu-central-1" {
+			t.Errorf("S3Region = %q, want %q", req.S3Region, "eu-central-1")
+		}
+		if req.S3CredentialsSecretName != "config-s3-creds" {
+			t.Errorf("S3CredentialsSecretName = %q, want %q", req.S3CredentialsSecretName, "config-s3-creds")
+		}
+		if !req.S3InsecureSkipTLSVerify {
+			t.Error("expected S3InsecureSkipTLSVerify=true from config")
+		}
+	})
+}
+
+func TestApplyS3Options_CLIFlagsOverrideConfig(t *testing.T) {
+	opts := newTestDiskOpts()
+	*opts.S3Bucket = testS3FlagBucket
+	*opts.S3Prefix = "flag-prefix/"
+	*opts.S3Endpoint = "https://flag-minio.local"
+	*opts.S3Region = "ap-southeast-1"
+	*opts.S3CredentialsSecret = "flag-secret"
+	*opts.S3Insecure = true
+	h := newS3TestHandler(opts)
+
+	cfg := &config.S3Config{
+		Bucket:                "config-bucket",
+		Prefix:                "config-prefix/",
+		Endpoint:              "https://config-minio.local",
+		Region:                "eu-central-1",
+		CredentialsSecret:     "config-s3-creds",
+		InsecureSkipTLSVerify: false,
+	}
+
+	withS3Defaults(cfg, func() {
+		var req buildapitypes.BuildRequest
+		if err := h.applyS3Options(nil, &req); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if req.S3Bucket != testS3FlagBucket {
+			t.Errorf("S3Bucket = %q, want %q", req.S3Bucket, testS3FlagBucket)
+		}
+		if req.S3Prefix != "flag-prefix/" {
+			t.Errorf("S3Prefix = %q, want %q", req.S3Prefix, "flag-prefix/")
+		}
+		if req.S3Endpoint != "https://flag-minio.local" {
+			t.Errorf("S3Endpoint = %q, want %q", req.S3Endpoint, "https://flag-minio.local")
+		}
+		if req.S3Region != "ap-southeast-1" {
+			t.Errorf("S3Region = %q, want %q", req.S3Region, "ap-southeast-1")
+		}
+		if req.S3CredentialsSecretName != "flag-secret" {
+			t.Errorf("S3CredentialsSecretName = %q, want %q", req.S3CredentialsSecretName, "flag-secret")
+		}
+		if !req.S3InsecureSkipTLSVerify {
+			t.Error("expected S3InsecureSkipTLSVerify=true from CLI flag")
+		}
+	})
+}
+
+func TestApplyS3Options_ExplicitInsecureFalseOverridesConfig(t *testing.T) {
+	opts := newTestDiskOpts()
+	*opts.S3Bucket = "test-bucket"
+	*opts.S3Insecure = false
+	h := newS3TestHandler(opts)
+
+	cmd := &cobra.Command{}
+	cmd.Flags().BoolVar(opts.S3Insecure, "s3-insecure", false, "")
+	_ = cmd.Flags().Set("s3-insecure", "false")
+
+	cfg := &config.S3Config{
+		Bucket:                "test-bucket",
+		InsecureSkipTLSVerify: true,
+	}
+
+	withS3Defaults(cfg, func() {
+		var req buildapitypes.BuildRequest
+		if err := h.applyS3Options(cmd, &req); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if req.S3InsecureSkipTLSVerify {
+			t.Error("expected S3InsecureSkipTLSVerify=false when CLI explicitly sets --s3-insecure=false")
+		}
+	})
+}
+
+func TestApplyS3Options_ConfigBucketWithFlagOverrides(t *testing.T) {
+	opts := newTestDiskOpts()
+	*opts.S3Region = "us-west-2"
+	h := newS3TestHandler(opts)
+
+	cfg := &config.S3Config{
+		Bucket:            "config-bucket",
+		Endpoint:          "https://config-minio.local",
+		Region:            "eu-central-1",
+		CredentialsSecret: "config-s3-creds",
+	}
+
+	withS3Defaults(cfg, func() {
+		var req buildapitypes.BuildRequest
+		if err := h.applyS3Options(nil, &req); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if req.S3Bucket != "config-bucket" {
+			t.Errorf("S3Bucket = %q, want %q (from config)", req.S3Bucket, "config-bucket")
+		}
+		if req.S3Endpoint != "https://config-minio.local" {
+			t.Errorf("S3Endpoint = %q, want %q (from config)", req.S3Endpoint, "https://config-minio.local")
+		}
+		if req.S3Region != "us-west-2" {
+			t.Errorf("S3Region = %q, want %q (flag should override config)", req.S3Region, "us-west-2")
+		}
+		if req.S3CredentialsSecretName != "config-s3-creds" {
+			t.Errorf("S3CredentialsSecretName = %q, want %q (from config)", req.S3CredentialsSecretName, "config-s3-creds")
+		}
+	})
+}
+
+func TestApplyS3Options_EnvVarsOverrideConfigCredentials(t *testing.T) {
+	opts := newTestDiskOpts()
+	t.Setenv("AWS_ACCESS_KEY_ID", "ENV_AKID")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "ENV_SECRET")
+	h := newS3TestHandler(opts)
+
+	cfg := &config.S3Config{
+		Bucket:          "config-bucket",
+		AccessKeyID:     "config-akid",
+		SecretAccessKey: "config-secret",
+	}
+
+	withS3Defaults(cfg, func() {
+		var req buildapitypes.BuildRequest
+		if err := h.applyS3Options(nil, &req); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if req.S3Credentials == nil {
+			t.Fatal("expected S3Credentials from env vars")
+		}
+		if req.S3Credentials.AccessKeyID != "ENV_AKID" {
+			t.Errorf("AccessKeyID = %q, want %q (env should override config)", req.S3Credentials.AccessKeyID, "ENV_AKID")
+		}
+	})
+}
+
+func TestApplyS3Options_ConfigInlineCredentials(t *testing.T) {
+	opts := newTestDiskOpts()
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	h := newS3TestHandler(opts)
+
+	cfg := &config.S3Config{
+		Bucket:          "config-bucket",
+		AccessKeyID:     "config-akid",
+		SecretAccessKey: "config-secret",
+	}
+
+	withS3Defaults(cfg, func() {
+		var req buildapitypes.BuildRequest
+		if err := h.applyS3Options(nil, &req); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if req.S3Credentials == nil {
+			t.Fatal("expected S3Credentials from config file")
+		}
+		if req.S3Credentials.AccessKeyID != "config-akid" {
+			t.Errorf("AccessKeyID = %q, want %q", req.S3Credentials.AccessKeyID, "config-akid")
+		}
+		if req.S3Credentials.SecretAccessKey != "config-secret" {
+			t.Errorf("SecretAccessKey = %q, want %q", req.S3Credentials.SecretAccessKey, "config-secret")
+		}
+	})
+}
+
+func TestApplyS3Options_ConfigPartialCredentialsError(t *testing.T) {
+	opts := newTestDiskOpts()
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	h := newS3TestHandler(opts)
+
+	cfg := &config.S3Config{
+		Bucket:      "config-bucket",
+		AccessKeyID: "config-akid",
+	}
+
+	withS3Defaults(cfg, func() {
+		var req buildapitypes.BuildRequest
+		err := h.applyS3Options(nil, &req)
+		if err == nil {
+			t.Fatal("expected error for partial config file credentials")
+		}
+	})
+}
+
+func TestApplyS3Options_ConfigReadError(t *testing.T) {
+	opts := newTestDiskOpts()
+	h := newS3TestHandler(opts)
+
+	orig := s3DefaultsFn
+	s3DefaultsFn = func() (*config.S3Config, error) {
+		return nil, fmt.Errorf("reading config for S3 defaults: invalid character 'i' looking for beginning of value")
+	}
+	defer func() { s3DefaultsFn = orig }()
+
+	var req buildapitypes.BuildRequest
+	err := h.applyS3Options(nil, &req)
+	if err == nil {
+		t.Fatal("expected error from malformed config")
+	}
+	if !strings.Contains(err.Error(), "reading config") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "reading config")
+	}
+}
+
+func TestApplyS3Options_NoBucketWithConfigNil(t *testing.T) {
+	opts := newTestDiskOpts()
+	h := newS3TestHandler(opts)
+
+	withS3Defaults(nil, func() {
+		var req buildapitypes.BuildRequest
+		if err := h.applyS3Options(nil, &req); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if req.S3Bucket != "" {
+			t.Error("expected empty S3Bucket when no flag and no config")
+		}
+	})
+}
+
+func TestApplyS3Options_ConfigMixedCredentialSourcesError(t *testing.T) {
+	opts := newTestDiskOpts()
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	h := newS3TestHandler(opts)
+
+	cfg := &config.S3Config{
+		Bucket:            "config-bucket",
+		CredentialsSecret: "my-k8s-secret",
+		AccessKeyID:       "config-akid",
+		SecretAccessKey:   "config-secret",
+	}
+
+	withS3Defaults(cfg, func() {
+		var req buildapitypes.BuildRequest
+		err := h.applyS3Options(nil, &req)
+		if err == nil {
+			t.Fatal("expected error for mixed credential sources in config file")
+		}
+		if !strings.Contains(err.Error(), "credentials_secret") {
+			t.Errorf("error = %q, want it to mention credentials_secret", err.Error())
+		}
+	})
+}
+
+func TestApplyS3Options_ExplicitEmptyBucketOverridesConfig(t *testing.T) {
+	opts := newTestDiskOpts()
+	*opts.S3Bucket = ""
+	h := newS3TestHandler(opts)
+
+	cmd := &cobra.Command{}
+	cmd.Flags().StringVar(opts.S3Bucket, "s3-bucket", "", "")
+	_ = cmd.Flags().Set("s3-bucket", "")
+
+	cfg := &config.S3Config{
+		Bucket: "config-bucket",
+		Region: "us-east-1",
+	}
+
+	withS3Defaults(cfg, func() {
+		var req buildapitypes.BuildRequest
+		if err := h.applyS3Options(cmd, &req); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if req.S3Bucket != "" {
+			t.Errorf("S3Bucket = %q, want empty (explicit --s3-bucket '' should override config)", req.S3Bucket)
+		}
+	})
+}
+
+func TestApplyS3Options_ExplicitEmptyConnectionParamsOverrideConfig(t *testing.T) {
+	opts := newTestDiskOpts()
+	*opts.S3Bucket = testS3FlagBucket
+	*opts.S3Prefix = ""
+	*opts.S3Endpoint = ""
+	*opts.S3Region = ""
+	h := newS3TestHandler(opts)
+
+	cmd := &cobra.Command{}
+	cmd.Flags().StringVar(opts.S3Bucket, "s3-bucket", "", "")
+	cmd.Flags().StringVar(opts.S3Prefix, "s3-prefix", "", "")
+	cmd.Flags().StringVar(opts.S3Endpoint, "s3-endpoint", "", "")
+	cmd.Flags().StringVar(opts.S3Region, "s3-region", "", "")
+	_ = cmd.Flags().Set("s3-bucket", testS3FlagBucket)
+	_ = cmd.Flags().Set("s3-prefix", "")
+	_ = cmd.Flags().Set("s3-endpoint", "")
+	_ = cmd.Flags().Set("s3-region", "")
+
+	cfg := &config.S3Config{
+		Bucket:   "config-bucket",
+		Prefix:   "config-prefix/",
+		Endpoint: "https://config-minio.local",
+		Region:   "eu-central-1",
+	}
+
+	withS3Defaults(cfg, func() {
+		var req buildapitypes.BuildRequest
+		if err := h.applyS3Options(cmd, &req); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if req.S3Prefix != "" {
+			t.Errorf("S3Prefix = %q, want empty (explicit --s3-prefix '' should override config)", req.S3Prefix)
+		}
+		if req.S3Endpoint != "" {
+			t.Errorf("S3Endpoint = %q, want empty (explicit --s3-endpoint '' should override config)", req.S3Endpoint)
+		}
+		if req.S3Region != "" {
+			t.Errorf("S3Region = %q, want empty (explicit --s3-region '' should override config)", req.S3Region)
+		}
+	})
 }

--- a/cmd/caib/config/config.go
+++ b/cmd/caib/config/config.go
@@ -27,10 +27,23 @@ const (
 // nil means use the default (insecure TLS, 5s timeout). Overridden in tests.
 var healthHTTPClient *http.Client
 
+// S3Config holds default S3 artifact upload settings.
+type S3Config struct {
+	Bucket                string `json:"bucket,omitempty"`
+	Prefix                string `json:"prefix,omitempty"`
+	Endpoint              string `json:"endpoint,omitempty"`
+	Region                string `json:"region,omitempty"`
+	CredentialsSecret     string `json:"credentials_secret,omitempty"`
+	AccessKeyID           string `json:"access_key_id,omitempty"`
+	SecretAccessKey       string `json:"secret_access_key,omitempty"`
+	InsecureSkipTLSVerify bool   `json:"insecure_skip_tls_verify,omitempty"`
+}
+
 // CLIConfig holds saved CLI settings.
 type CLIConfig struct {
-	ServerURL           string `json:"server_url"`
-	DerivedFromEndpoint string `json:"derived_from_endpoint,omitempty"`
+	ServerURL           string    `json:"server_url"`
+	DerivedFromEndpoint string    `json:"derived_from_endpoint,omitempty"`
+	S3                  *S3Config `json:"s3,omitempty"`
 }
 
 // DefaultServer returns the effective default server URL: CAIB_SERVER env, then saved config.
@@ -220,21 +233,49 @@ func Read() (*CLIConfig, error) {
 	return &cfg, nil
 }
 
+// S3Defaults returns the S3 config from the saved config file.
+// Returns (nil, nil) when no config file exists or the S3 section is absent.
+func S3Defaults() (*S3Config, error) {
+	cfg, err := Read()
+	if err != nil {
+		return nil, fmt.Errorf("reading config for S3 defaults: %w", err)
+	}
+	if cfg == nil {
+		return nil, nil
+	}
+	return cfg.S3, nil
+}
+
 // SaveServerURL writes the given server URL to the local config file.
 // This is the manual-set path (e.g. caib login <url>) — clears DerivedFromEndpoint
-// so the URL is never auto-invalidated.
+// so the URL is never auto-invalidated. Preserves other config fields (e.g. S3).
 func SaveServerURL(serverURL string) error {
-	return saveConfig(&CLIConfig{ServerURL: strings.TrimSpace(serverURL)})
+	cfg, err := Read()
+	if err != nil {
+		return fmt.Errorf("reading existing config: %w", err)
+	}
+	if cfg == nil {
+		cfg = &CLIConfig{}
+	}
+	cfg.ServerURL = strings.TrimSpace(serverURL)
+	cfg.DerivedFromEndpoint = ""
+	return saveConfig(cfg)
 }
 
 // saveDerivedServerURL saves a server URL that was auto-derived from a Jumpstarter endpoint.
 // The source endpoint is recorded so the cached URL can be invalidated when the
-// Jumpstarter config changes.
+// Jumpstarter config changes. Preserves other config fields (e.g. S3).
 func saveDerivedServerURL(serverURL, sourceEndpoint string) error {
-	return saveConfig(&CLIConfig{
-		ServerURL:           strings.TrimSpace(serverURL),
-		DerivedFromEndpoint: strings.TrimSpace(sourceEndpoint),
-	})
+	cfg, err := Read()
+	if err != nil {
+		return fmt.Errorf("reading existing config: %w", err)
+	}
+	if cfg == nil {
+		cfg = &CLIConfig{}
+	}
+	cfg.ServerURL = strings.TrimSpace(serverURL)
+	cfg.DerivedFromEndpoint = strings.TrimSpace(sourceEndpoint)
+	return saveConfig(cfg)
 }
 
 func saveConfig(cfg *CLIConfig) error {

--- a/cmd/caib/config/config.go
+++ b/cmd/caib/config/config.go
@@ -28,14 +28,15 @@ const (
 var healthHTTPClient *http.Client
 
 // S3Config holds default S3 artifact upload settings.
+// Inline credentials (access_key_id / secret_access_key) are intentionally
+// not supported here to avoid storing long-lived secrets in plaintext on disk.
+// Use credentials_secret (a Kubernetes secret ref), CLI flags, or env vars.
 type S3Config struct {
 	Bucket                string `json:"bucket,omitempty"`
 	Prefix                string `json:"prefix,omitempty"`
 	Endpoint              string `json:"endpoint,omitempty"`
 	Region                string `json:"region,omitempty"`
 	CredentialsSecret     string `json:"credentials_secret,omitempty"`
-	AccessKeyID           string `json:"access_key_id,omitempty"`
-	SecretAccessKey       string `json:"secret_access_key,omitempty"`
 	InsecureSkipTLSVerify bool   `json:"insecure_skip_tls_verify,omitempty"`
 }
 

--- a/cmd/caib/config/config_test.go
+++ b/cmd/caib/config/config_test.go
@@ -398,6 +398,208 @@ var _ = Describe("DefaultServerWithDerive", func() {
 	})
 })
 
+var _ = Describe("S3Defaults", func() {
+	var tempDir string
+	var origHome, origXDG string
+
+	BeforeEach(func() {
+		var err error
+		tempDir, err = os.MkdirTemp("", "caib-s3-config-test-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		origHome = os.Getenv("HOME")
+		origXDG = os.Getenv("XDG_CONFIG_HOME")
+		Expect(os.Setenv("HOME", tempDir)).To(Succeed())
+		Expect(os.Unsetenv("XDG_CONFIG_HOME")).To(Succeed())
+	})
+
+	AfterEach(func() {
+		_ = os.Setenv("HOME", origHome)
+		if origXDG != "" {
+			_ = os.Setenv("XDG_CONFIG_HOME", origXDG)
+		} else {
+			_ = os.Unsetenv("XDG_CONFIG_HOME")
+		}
+		_ = os.RemoveAll(tempDir)
+	})
+
+	It("returns nil when no config file exists", func() {
+		result, err := S3Defaults()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeNil())
+	})
+
+	It("returns nil when config file has no S3 section", func() {
+		Expect(SaveServerURL("https://example.com")).To(Succeed())
+		result, err := S3Defaults()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeNil())
+	})
+
+	It("returns S3 config when present", func() {
+		cfg := &CLIConfig{
+			ServerURL: "https://example.com",
+			S3: &S3Config{
+				Bucket:            "my-bucket",
+				Prefix:            "builds/",
+				Endpoint:          "https://minio.local",
+				Region:            "eu-west-1",
+				CredentialsSecret: "my-s3-creds",
+			},
+		}
+		Expect(saveConfig(cfg)).To(Succeed())
+
+		result, err := S3Defaults()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).NotTo(BeNil())
+		Expect(result.Bucket).To(Equal("my-bucket"))
+		Expect(result.Prefix).To(Equal("builds/"))
+		Expect(result.Endpoint).To(Equal("https://minio.local"))
+		Expect(result.Region).To(Equal("eu-west-1"))
+		Expect(result.CredentialsSecret).To(Equal("my-s3-creds"))
+	})
+
+	It("returns error when config file contains invalid JSON", func() {
+		configDir := filepath.Join(tempDir, ".config", "caib")
+		Expect(os.MkdirAll(configDir, 0700)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(configDir, "cli.json"), []byte("{invalid"), 0600)).To(Succeed())
+
+		result, err := S3Defaults()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("reading config for S3 defaults"))
+		Expect(result).To(BeNil())
+	})
+})
+
+var _ = Describe("SaveServerURL preserves S3 config", func() {
+	var tempDir string
+	var origHome, origXDG string
+
+	BeforeEach(func() {
+		var err error
+		tempDir, err = os.MkdirTemp("", "caib-preserve-s3-test-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		origHome = os.Getenv("HOME")
+		origXDG = os.Getenv("XDG_CONFIG_HOME")
+		Expect(os.Setenv("HOME", tempDir)).To(Succeed())
+		Expect(os.Unsetenv("XDG_CONFIG_HOME")).To(Succeed())
+	})
+
+	AfterEach(func() {
+		_ = os.Setenv("HOME", origHome)
+		if origXDG != "" {
+			_ = os.Setenv("XDG_CONFIG_HOME", origXDG)
+		} else {
+			_ = os.Unsetenv("XDG_CONFIG_HOME")
+		}
+		_ = os.RemoveAll(tempDir)
+	})
+
+	It("preserves S3 config when saving a new server URL", func() {
+		cfg := &CLIConfig{
+			ServerURL: "https://old-server.com",
+			S3: &S3Config{
+				Bucket:   "my-bucket",
+				Endpoint: "https://minio.local",
+			},
+		}
+		Expect(saveConfig(cfg)).To(Succeed())
+
+		Expect(SaveServerURL("https://new-server.com")).To(Succeed())
+
+		result, err := Read()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.ServerURL).To(Equal("https://new-server.com"))
+		Expect(result.DerivedFromEndpoint).To(BeEmpty())
+		Expect(result.S3).NotTo(BeNil())
+		Expect(result.S3.Bucket).To(Equal("my-bucket"))
+		Expect(result.S3.Endpoint).To(Equal("https://minio.local"))
+	})
+
+	It("preserves S3 config when saving a derived server URL", func() {
+		cfg := &CLIConfig{
+			S3: &S3Config{
+				Bucket:            "my-bucket",
+				CredentialsSecret: "my-creds",
+			},
+		}
+		Expect(saveConfig(cfg)).To(Succeed())
+
+		Expect(saveDerivedServerURL("https://derived.com", "grpc.endpoint:443")).To(Succeed())
+
+		result, err := Read()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.ServerURL).To(Equal("https://derived.com"))
+		Expect(result.DerivedFromEndpoint).To(Equal("grpc.endpoint:443"))
+		Expect(result.S3).NotTo(BeNil())
+		Expect(result.S3.Bucket).To(Equal("my-bucket"))
+		Expect(result.S3.CredentialsSecret).To(Equal("my-creds"))
+	})
+})
+
+var _ = Describe("SaveServerURL with invalid config file", func() {
+	var tempDir string
+	var origHome, origXDG string
+
+	BeforeEach(func() {
+		var err error
+		tempDir, err = os.MkdirTemp("", "caib-invalid-config-test-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		origHome = os.Getenv("HOME")
+		origXDG = os.Getenv("XDG_CONFIG_HOME")
+		Expect(os.Setenv("HOME", tempDir)).To(Succeed())
+		Expect(os.Unsetenv("XDG_CONFIG_HOME")).To(Succeed())
+	})
+
+	AfterEach(func() {
+		_ = os.Setenv("HOME", origHome)
+		if origXDG != "" {
+			_ = os.Setenv("XDG_CONFIG_HOME", origXDG)
+		} else {
+			_ = os.Unsetenv("XDG_CONFIG_HOME")
+		}
+		_ = os.RemoveAll(tempDir)
+	})
+
+	writeInvalidConfig := func() string {
+		configDir := filepath.Join(tempDir, ".config", "caib")
+		ExpectWithOffset(1, os.MkdirAll(configDir, 0700)).To(Succeed())
+		path := filepath.Join(configDir, "cli.json")
+		ExpectWithOffset(1, os.WriteFile(path, []byte("{invalid json"), 0600)).To(Succeed())
+		return path
+	}
+
+	It("returns error from SaveServerURL and leaves file unchanged", func() {
+		path := writeInvalidConfig()
+		original, err := os.ReadFile(path)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = SaveServerURL("https://new.example.com")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("reading existing config"))
+
+		after, err := os.ReadFile(path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(after).To(Equal(original))
+	})
+
+	It("returns error from saveDerivedServerURL and leaves file unchanged", func() {
+		path := writeInvalidConfig()
+		original, err := os.ReadFile(path)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = saveDerivedServerURL("https://derived.example.com", "grpc.endpoint:443")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("reading existing config"))
+
+		after, err := os.ReadFile(path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(after).To(Equal(original))
+	})
+})
+
 var _ = Describe("Read with XDG config override", func() {
 	var tempDir string
 	var origHome, origXDG string

--- a/cmd/caib/image/image.go
+++ b/cmd/caib/image/image.go
@@ -697,7 +697,7 @@ Input, signed artifact, and output can be given as positionals or via --input, -
 func addS3Flags(cmd *cobra.Command, opts Options) {
 	cmd.Flags().StringVar(opts.S3Bucket, "s3-bucket", "", "S3 bucket name for artifact upload")
 	cmd.Flags().StringVar(opts.S3Prefix, "s3-prefix", "", "S3 key prefix (path within bucket)")
-	cmd.Flags().StringVar(opts.S3Region, "s3-region", "", "S3 region (default \"us-east-1\")")
+	cmd.Flags().StringVar(opts.S3Region, "s3-region", "", "S3 region (defaults to us-east-1 if not specified)")
 	cmd.Flags().StringVar(opts.S3Endpoint, "s3-endpoint", "", "Custom S3 endpoint URL (for MinIO/Ceph)")
 	cmd.Flags().StringVar(opts.S3AccessKeyID, "s3-access-key-id", "", "S3 access key ID (env: AWS_ACCESS_KEY_ID)")
 	cmd.Flags().StringVar(opts.S3SecretAccessKey, "s3-secret-access-key", "", "S3 secret access key (env: AWS_SECRET_ACCESS_KEY)")

--- a/cmd/caib/image/image.go
+++ b/cmd/caib/image/image.go
@@ -697,7 +697,7 @@ Input, signed artifact, and output can be given as positionals or via --input, -
 func addS3Flags(cmd *cobra.Command, opts Options) {
 	cmd.Flags().StringVar(opts.S3Bucket, "s3-bucket", "", "S3 bucket name for artifact upload")
 	cmd.Flags().StringVar(opts.S3Prefix, "s3-prefix", "", "S3 key prefix (path within bucket)")
-	cmd.Flags().StringVar(opts.S3Region, "s3-region", "us-east-1", "S3 region")
+	cmd.Flags().StringVar(opts.S3Region, "s3-region", "", "S3 region (default \"us-east-1\")")
 	cmd.Flags().StringVar(opts.S3Endpoint, "s3-endpoint", "", "Custom S3 endpoint URL (for MinIO/Ceph)")
 	cmd.Flags().StringVar(opts.S3AccessKeyID, "s3-access-key-id", "", "S3 access key ID (env: AWS_ACCESS_KEY_ID)")
 	cmd.Flags().StringVar(opts.S3SecretAccessKey, "s3-secret-access-key", "", "S3 secret access key (env: AWS_SECRET_ACCESS_KEY)")


### PR DESCRIPTION
S3 options can now be set in ~/.config/caib/cli.json under an "s3" key, with CLI flags and env vars taking precedence.

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configuration-file support for S3 artifact uploads, including bucket, prefix, endpoint, region, TLS settings, and credential secrets.
  - S3 credentials can be sourced from configured secrets, environment variables, command-line options, or cloud instance profiles.
  - Command-line settings override configured defaults, including explicit empty and disabled values.
  - S3 uploads now default to the `us-east-1` region when unspecified.

- **Bug Fixes**
  - Saving server settings now preserves existing S3 configuration.
  - Improved validation for incomplete, conflicting, unavailable, or malformed credentials and configuration.

- **Documentation**
  - Added guidance for configuring S3 uploads and credential sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->