### PR TITLE
refactor(compression): remove lz4 support

### DIFF
--- a/api/v1alpha1/imagebuild_types.go
+++ b/api/v1alpha1/imagebuild_types.go
@@ -226,7 +226,7 @@ type ExportSpec struct {
 	Format string `json:"format,omitempty"`
 
 	// Compression specifies the compression algorithm for artifacts
-	// +kubebuilder:validation:Enum=lz4;gzip;xz
+	// +kubebuilder:validation:Enum=gzip;xz
 	// +kubebuilder:default=gzip
 	Compression string `json:"compression,omitempty"`
 

--- a/cmd/caib/README.md
+++ b/cmd/caib/README.md
@@ -121,7 +121,7 @@ caib image build <manifest.aib.yml> [flags]
 | `-a`, `--arch` | (current system) | Architecture (`amd64`, `arm64`) |
 | `--disk` | `false` | Also build a disk image from the container |
 | `--format` | (inferred from `-o`) | Disk image format (`qcow2`, `raw`, `simg`) |
-| `--compress` | `gzip` | Compression algorithm (`gzip`, `lz4`, `xz`) |
+| `--compress` | `gzip` | Compression algorithm (`gzip`, `xz`) |
 | `--push-disk` | | Push disk image as OCI artifact to registry |
 | `-o`, `--output` | | Download disk image to local file (implies `--disk`) |
 | `--builder-image` | | Custom aib-build container |
@@ -203,7 +203,7 @@ caib image disk <container-ref> [flags]
 | `-n`, `--name` | (auto-generated) | Build job name |
 | `-o`, `--output` | | Download disk image to local file |
 | `--format` | (inferred from `-o`) | Disk image format (`qcow2`, `raw`, `simg`) |
-| `--compress` | `gzip` | Compression algorithm (`gzip`, `lz4`, `xz`) |
+| `--compress` | `gzip` | Compression algorithm (`gzip`, `xz`) |
 | `--push` | | Push disk image as OCI artifact to registry |
 | `-d`, `--distro` | `autosd` | Distribution |
 | `-t`, `--target` | `qemu` | Target platform |
@@ -264,7 +264,7 @@ caib image build-dev <manifest.aib.yml> [flags]
 | `-d`, `--distro` | `autosd` | Distribution to build |
 | `-t`, `--target` | `qemu` | Target platform |
 | `-a`, `--arch` | (current system) | Architecture (`amd64`, `arm64`) |
-| `--compress` | `gzip` | Compression algorithm (`gzip`, `lz4`, `xz`) |
+| `--compress` | `gzip` | Compression algorithm (`gzip`, `xz`) |
 | `--push` | | Push disk image as OCI artifact to registry |
 | `-o`, `--output` | | Download artifact to local file |
 | `--aib-image` | `quay.io/.../automotive-image-builder:1.3.4` | AIB container image |

--- a/cmd/caib/common/manifest_artifact_helpers.go
+++ b/cmd/caib/common/manifest_artifact_helpers.go
@@ -317,8 +317,6 @@ func compressionExtension(algo string) string {
 		return ".tar.gz"
 	case "gzip":
 		return ".gz"
-	case "lz4":
-		return ".lz4"
 	case "xz":
 		return ".xz"
 	default:
@@ -331,7 +329,6 @@ func hasCompressionExtension(filename string) bool {
 	lower := strings.ToLower(filename)
 	return strings.HasSuffix(lower, ".tar.gz") ||
 		strings.HasSuffix(lower, ".gz") ||
-		strings.HasSuffix(lower, ".lz4") ||
 		strings.HasSuffix(lower, ".xz")
 }
 
@@ -358,9 +355,6 @@ func detectFileCompression(filePath string) string {
 			return "tar.gz"
 		}
 		return "gzip"
-	}
-	if n >= 4 && header[0] == 0x04 && header[1] == 0x22 && header[2] == 0x4d && header[3] == 0x18 {
-		return "lz4"
 	}
 	if n >= 6 && header[0] == 0xfd && header[1] == 0x37 && header[2] == 0x7a &&
 		header[3] == 0x58 && header[4] == 0x5a && header[5] == 0x00 {

--- a/cmd/caib/image/image.go
+++ b/cmd/caib/image/image.go
@@ -145,7 +145,7 @@ func NewImageCmd(opts Options) *cobra.Command {
 	buildCmd.Flags().StringVar(
 		opts.DiskFormat, "format", "", "disk image format (qcow2, raw, simg); inferred from output filename if not set",
 	)
-	buildCmd.Flags().StringVar(opts.CompressionAlgo, "compress", "gzip", "compression algorithm (gzip, lz4, xz)")
+	buildCmd.Flags().StringVar(opts.CompressionAlgo, "compress", "gzip", "compression algorithm (gzip, xz)")
 	buildCmd.Flags().StringVar(opts.ExportOCI, "push-disk", "", "push disk image as OCI artifact to registry (implies --disk)")
 	buildCmd.Flags().StringVar(
 		opts.RegistryAuthFile,
@@ -214,7 +214,7 @@ func NewImageCmd(opts Options) *cobra.Command {
 	diskCmd.Flags().StringVar(
 		opts.DiskFormat, "format", "", "disk image format (qcow2, raw, simg); inferred from output filename if not set",
 	)
-	diskCmd.Flags().StringVar(opts.CompressionAlgo, "compress", "gzip", "compression algorithm (gzip, lz4, xz)")
+	diskCmd.Flags().StringVar(opts.CompressionAlgo, "compress", "gzip", "compression algorithm (gzip, xz)")
 	diskCmd.Flags().StringVar(opts.ExportOCI, "push", "", "push disk image as OCI artifact to registry")
 	diskCmd.Flags().StringVar(
 		opts.RegistryAuthFile,
@@ -261,7 +261,7 @@ func NewImageCmd(opts Options) *cobra.Command {
 	buildDevCmd.Flags().StringVar(opts.Mode, "mode", "package", "build mode: image (ostree) or package (package-based)")
 	buildDevCmd.Flags().StringVar(opts.ExportFormat, "format", "", "export format: qcow2, raw, simg, etc.")
 	buildDevCmd.Flags().StringVarP(opts.OutputDir, "output", "o", "", "download artifact to file from registry (uses --internal-registry when no --push given)")
-	buildDevCmd.Flags().StringVar(opts.CompressionAlgo, "compress", "gzip", "compression algorithm (gzip, lz4, xz)")
+	buildDevCmd.Flags().StringVar(opts.CompressionAlgo, "compress", "gzip", "compression algorithm (gzip, xz)")
 	buildDevCmd.Flags().StringVar(opts.ExportOCI, "push", "", "push disk image as OCI artifact to registry")
 	buildDevCmd.Flags().StringVar(
 		opts.RegistryAuthFile,

--- a/config/crd/bases/automotive.sdv.cloud.redhat.com_imagebuilds.yaml
+++ b/config/crd/bases/automotive.sdv.cloud.redhat.com_imagebuilds.yaml
@@ -142,7 +142,6 @@ spec:
                     description: Compression specifies the compression algorithm for
                       artifacts
                     enum:
-                    - lz4
                     - gzip
                     - xz
                     type: string

--- a/config/crd/bases/automotive.sdv.cloud.redhat.com_scheduledimagebuilds.yaml
+++ b/config/crd/bases/automotive.sdv.cloud.redhat.com_scheduledimagebuilds.yaml
@@ -206,7 +206,6 @@ spec:
                             description: Compression specifies the compression algorithm
                               for artifacts
                             enum:
-                            - lz4
                             - gzip
                             - xz
                             type: string

--- a/config/samples/automotive_v1_imagebuild.yaml
+++ b/config/samples/automotive_v1_imagebuild.yaml
@@ -34,7 +34,7 @@ spec:
   # ─── Export Configuration ───
   export:
     format: "qcow2"         # raw, qcow2, simg
-    compression: "gzip"     # gzip, lz4, xz
+    compression: "gzip"     # gzip, xz
     buildDiskImage: false   # whether to create disk image
     #container: "quay.io/myorg/my-container:latest"  # bootc container destination
     #disk:                  # disk image export options

--- a/internal/buildapi/build_validation.go
+++ b/internal/buildapi/build_validation.go
@@ -114,7 +114,7 @@ func applyBuildDefaults(req *BuildRequest) error {
 		req.Compression = CompressionGzip
 	}
 	if !req.Compression.IsValid() {
-		return fmt.Errorf("invalid compression %q: must be lz4, gzip, or xz", req.Compression)
+		return fmt.Errorf("invalid compression %q: must be gzip or xz", req.Compression)
 	}
 	if !req.Distro.IsValid() {
 		return fmt.Errorf("distro cannot be empty")

--- a/internal/buildapi/build_validation_test.go
+++ b/internal/buildapi/build_validation_test.go
@@ -128,14 +128,14 @@ var _ = Describe("applyBuildDefaults", func() {
 			Target:       "aws",
 			Architecture: "amd64",
 			Mode:         ModeDisk,
-			Compression:  CompressionLZ4,
+			Compression:  CompressionXZ,
 		}
 		Expect(applyBuildDefaults(req)).To(Succeed())
 		Expect(string(req.Distro)).To(Equal("cs9"))
 		Expect(string(req.Target)).To(Equal("aws"))
 		Expect(string(req.Architecture)).To(Equal("amd64"))
 		Expect(string(req.Mode)).To(Equal("disk"))
-		Expect(string(req.Compression)).To(Equal("lz4"))
+		Expect(string(req.Compression)).To(Equal("xz"))
 	})
 
 	It("normalizes x86_64 to amd64", func() {

--- a/internal/buildapi/internal_registry_test.go
+++ b/internal/buildapi/internal_registry_test.go
@@ -184,11 +184,10 @@ var _ = Describe("Internal Registry", func() {
 				Expect(req.Compression).To(Equal(CompressionGzip))
 			})
 
-			It("should accept lz4 compression", func() {
-				req := &BuildRequest{Compression: CompressionLZ4}
+			It("should reject lz4 compression", func() {
+				req := &BuildRequest{Compression: "lz4"}
 				err := applyBuildDefaults(req)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(req.Compression).To(Equal(CompressionLZ4))
+				Expect(err).To(HaveOccurred())
 			})
 
 			It("should accept xz compression", func() {

--- a/internal/buildapi/types.go
+++ b/internal/buildapi/types.go
@@ -32,7 +32,6 @@ const (
 // Supported compression algorithms for build artifacts.
 const (
 	CompressionGzip Compression = "gzip"
-	CompressionLZ4  Compression = "lz4"
 	CompressionXZ   Compression = "xz"
 )
 
@@ -85,7 +84,7 @@ func (e ExportFormat) IsValid() bool { return IsValid(string(e)) }
 // IsValid returns true if the compression value is a supported algorithm.
 func (c Compression) IsValid() bool {
 	switch c {
-	case CompressionGzip, CompressionLZ4, CompressionXZ:
+	case CompressionGzip, CompressionXZ:
 		return true
 	}
 	return false

--- a/internal/common/oci/spec.json
+++ b/internal/common/oci/spec.json
@@ -41,18 +41,15 @@
     },
     "compressionSuffixes": {
       "gzip": "+gzip",
-      "lz4": "+lz4",
       "xz": "+xz"
     },
     "containerLayers": {
       "base": "application/vnd.oci.image.layer.v1.tar",
       "gzip": "application/vnd.oci.image.layer.v1.tar+gzip",
-      "lz4": "application/vnd.oci.image.layer.v1.tar+lz4",
       "xz": "application/vnd.oci.image.layer.v1.tar+xz"
     },
     "generic": {
       "gzip": "application/gzip",
-      "lz4": "application/x-lz4",
       "xz": "application/x-xz",
       "octetStream": "application/octet-stream"
     }

--- a/internal/common/oci/spec_test.go
+++ b/internal/common/oci/spec_test.go
@@ -99,13 +99,10 @@ func TestMediaTypeComposition(t *testing.T) {
 		want        string
 	}{
 		{"raw", "gzip", "application/vnd.automotive.disk.raw+gzip"},
-		{"raw", "lz4", "application/vnd.automotive.disk.raw+lz4"},
 		{"raw", "xz", "application/vnd.automotive.disk.raw+xz"},
 		{"qcow2", "gzip", "application/vnd.automotive.disk.qcow2+gzip"},
-		{"qcow2", "lz4", "application/vnd.automotive.disk.qcow2+lz4"},
 		{"qcow2", "xz", "application/vnd.automotive.disk.qcow2+xz"},
 		{"simg", "gzip", "application/vnd.automotive.disk.simg+gzip"},
-		{"simg", "lz4", "application/vnd.automotive.disk.simg+lz4"},
 		{"simg", "xz", "application/vnd.automotive.disk.simg+xz"},
 	}
 	for _, tc := range cases {

--- a/internal/common/tasks/scripts/build_image.sh
+++ b/internal/common/tasks/scripts/build_image.sh
@@ -75,8 +75,8 @@ validate_config() {
     *) fail "unknown build mode '$BUILD_MODE'; expected bootc, image, package, or disk" ;;
   esac
   case "$COMPRESSION" in
-    gzip|lz4|xz) ;;
-    *) fail "unknown compression '$COMPRESSION'; expected gzip, lz4, or xz" ;;
+    gzip|xz) ;;
+    *) fail "unknown compression '$COMPRESSION'; expected gzip or xz" ;;
   esac
 
   validate_boolean "build-disk-image" "$BUILD_DISK_IMAGE"
@@ -425,11 +425,6 @@ configure_compressor() {
       EXT_FILE=".gz"
       EXT_DIR=".tar.gz"
       ;;
-    lz4)
-      command -v lz4 >/dev/null 2>&1 || fail "lz4 compression requested but lz4 is not installed in $AIB_IMAGE_REF"
-      EXT_FILE=".lz4"
-      EXT_DIR=".tar.lz4"
-      ;;
     xz)
       command -v xz >/dev/null 2>&1 || fail "xz compression requested but xz is not installed in $AIB_IMAGE_REF"
       EXT_FILE=".xz"
@@ -686,7 +681,6 @@ finish_aib_metadata_capture
 compress_stream() {
   case "$COMPRESSION" in
     gzip) "$GZIP_COMPRESSOR" -c ;;
-    lz4) lz4 -z -f -q ;;
     xz) xz -T0 -c ;;
   esac
 }

--- a/internal/common/tasks/scripts/push_artifact.sh
+++ b/internal/common/tasks/scripts/push_artifact.sh
@@ -7,18 +7,14 @@ install_oras || exit 1
 get_media_type() {
   case "$1" in
     *.tar.gz)         echo "$OCI_MEDIA_LAYER_GZIP" ;;
-    *.tar.lz4)        echo "$OCI_MEDIA_LAYER_LZ4" ;;
     *.tar.xz)         echo "$OCI_MEDIA_LAYER_XZ" ;;
     *.tar)            echo "$OCI_MEDIA_LAYER_BASE" ;;
 
     *.simg.gz)        echo "${OCI_MEDIA_DISK_SIMG}${OCI_COMPRESS_SUFFIX_GZIP}" ;;
-    *.simg.lz4)       echo "${OCI_MEDIA_DISK_SIMG}${OCI_COMPRESS_SUFFIX_LZ4}" ;;
     *.simg.xz)        echo "${OCI_MEDIA_DISK_SIMG}${OCI_COMPRESS_SUFFIX_XZ}" ;;
     *.raw.gz|*.img.gz) echo "${OCI_MEDIA_DISK_RAW}${OCI_COMPRESS_SUFFIX_GZIP}" ;;
-    *.raw.lz4|*.img.lz4) echo "${OCI_MEDIA_DISK_RAW}${OCI_COMPRESS_SUFFIX_LZ4}" ;;
     *.raw.xz|*.img.xz) echo "${OCI_MEDIA_DISK_RAW}${OCI_COMPRESS_SUFFIX_XZ}" ;;
     *.qcow2.gz)       echo "${OCI_MEDIA_DISK_QCOW2}${OCI_COMPRESS_SUFFIX_GZIP}" ;;
-    *.qcow2.lz4)      echo "${OCI_MEDIA_DISK_QCOW2}${OCI_COMPRESS_SUFFIX_LZ4}" ;;
     *.qcow2.xz)       echo "${OCI_MEDIA_DISK_QCOW2}${OCI_COMPRESS_SUFFIX_XZ}" ;;
 
     *.simg)           echo "$OCI_MEDIA_DISK_SIMG" ;;
@@ -26,7 +22,6 @@ get_media_type() {
     *.qcow2)          echo "$OCI_MEDIA_DISK_QCOW2" ;;
 
     *.gz)             echo "$OCI_MEDIA_GZIP" ;;
-    *.lz4)            echo "$OCI_MEDIA_LZ4" ;;
     *.xz)             echo "$OCI_MEDIA_XZ" ;;
 
     *)                echo "$OCI_MEDIA_OCTETSTREAM" ;;
@@ -40,17 +35,17 @@ json_escape() {
 
 get_artifact_type() {
   case "$1" in
-    *.simg.gz|*.simg.lz4|*.simg.xz|*.simg) echo "$OCI_MEDIA_DISK_SIMG" ;;
-    *.qcow2.gz|*.qcow2.lz4|*.qcow2.xz|*.qcow2) echo "$OCI_MEDIA_DISK_QCOW2" ;;
-    *.raw.gz|*.raw.lz4|*.raw.xz|*.raw|*.img.gz|*.img.lz4|*.img.xz|*.img) echo "$OCI_MEDIA_DISK_RAW" ;;
+    *.simg.gz|*.simg.xz|*.simg) echo "$OCI_MEDIA_DISK_SIMG" ;;
+    *.qcow2.gz|*.qcow2.xz|*.qcow2) echo "$OCI_MEDIA_DISK_QCOW2" ;;
+    *.raw.gz|*.raw.xz|*.raw|*.img.gz|*.img.xz|*.img) echo "$OCI_MEDIA_DISK_RAW" ;;
     *) echo "$OCI_MEDIA_OCTETSTREAM" ;;
   esac
 }
 
 get_partition_name() {
-  # Strip base extension (.simg/.raw/.img), optional .tar, and optional compression (.gz/.lz4/.xz)
-  # Examples: boot_a.simg.gz -> boot_a, foo.simg.tar.gz -> foo, system.raw.lz4 -> system
-  basename "$1" | sed -E 's/\.(simg|raw|img)(\.tar)?(\.(gz|lz4|xz))?$//'
+  # Strip base extension (.simg/.raw/.img), optional .tar, and optional compression (.gz/.xz)
+  # Examples: boot_a.simg.gz -> boot_a, foo.simg.tar.gz -> foo, system.raw.xz -> system
+  basename "$1" | sed -E 's/\.(simg|raw|img)(\.tar)?(\.(gz|xz))?$//'
 }
 
 # Remap partition names for specific targets where AIB's logical names

--- a/internal/common/tasks/tasks.go
+++ b/internal/common/tasks/tasks.go
@@ -672,7 +672,7 @@ func GenerateBuildAutomotiveImageTask(namespace string, buildConfig *BuildConfig
 				{
 					Name:        "compression",
 					Type:        tektonv1.ParamTypeString,
-					Description: "Compression algorithm for artifacts (lz4, gzip, xz)",
+					Description: "Compression algorithm for artifacts (gzip, xz)",
 					Default: &tektonv1.ParamValue{
 						Type:      tektonv1.ParamTypeString,
 						StringVal: "gzip",
@@ -1185,9 +1185,9 @@ func GenerateTektonPipeline(name, namespace string, buildConfig *BuildConfig) *t
 					Type: tektonv1.ParamTypeString,
 					Default: &tektonv1.ParamValue{
 						Type:      tektonv1.ParamTypeString,
-						StringVal: "lz4",
+						StringVal: "gzip",
 					},
-					Description: "Compression algorithm for artifacts (lz4, gzip, xz)",
+					Description: "Compression algorithm for artifacts (gzip, xz)",
 				},
 				{
 					Name: "automotive-image-builder",


### PR DESCRIPTION
## Summary

- remove lz4 from build-script compression handling
- reject lz4 in API and CLI build inputs
- update Tekton defaults, CRDs, samples, and tests to gzip/xz
- 
