### PR TITLE
fix(caib): avoid reauthentication for forbidden API responses

### DIFF
--- a/cmd/caib/auth/wrapper.go
+++ b/cmd/caib/auth/wrapper.go
@@ -2,23 +2,19 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	buildapiclient "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi/client"
 )
 
-// IsAuthError checks if an error is an authentication error (401/403)
+// IsAuthError checks if an error is an authentication error.
 func IsAuthError(err error) bool {
-	if err == nil {
-		return false
-	}
-	errStr := err.Error()
-	return strings.Contains(errStr, "401") ||
-		strings.Contains(errStr, "403") ||
-		strings.Contains(errStr, "unauthorized") ||
-		strings.Contains(errStr, "forbidden")
+	var statusErr buildapiclient.HTTPError
+	return errors.As(err, &statusErr) && statusErr.HTTPStatusCode() == http.StatusUnauthorized
 }
 
 // GetTokenWithReauth gets a token, triggering OIDC re-auth if needed.

--- a/cmd/caib/auth/wrapper_test.go
+++ b/cmd/caib/auth/wrapper_test.go
@@ -3,6 +3,8 @@ package auth
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -12,6 +14,33 @@ import (
 	. "github.com/onsi/ginkgo/v2" //nolint:revive
 	. "github.com/onsi/gomega"    //nolint:revive
 )
+
+type testHTTPStatusError struct {
+	code int
+}
+
+func (e *testHTTPStatusError) Error() string {
+	return http.StatusText(e.code)
+}
+
+func (e *testHTTPStatusError) HTTPStatusCode() int {
+	return e.code
+}
+
+var _ = Describe("IsAuthError", func() {
+	DescribeTable("classifies only authentication failures for reauthentication",
+		func(err error, expected bool) {
+			Expect(IsAuthError(err)).To(Equal(expected))
+		},
+		Entry("nil error", nil, false),
+		Entry("401 response", &testHTTPStatusError{code: http.StatusUnauthorized}, true),
+		Entry("wrapped 401 response", fmt.Errorf("request failed: %w", &testHTTPStatusError{code: http.StatusUnauthorized}), true),
+		Entry("unstructured unauthorized response", errors.New("request failed: unauthorized"), false),
+		Entry("403 workspace image policy response", &testHTTPStatusError{code: http.StatusForbidden}, false),
+		Entry("forbidden response", errors.New("request failed: forbidden"), false),
+		Entry("unrelated response", errors.New("request failed: 500 Internal Server Error"), false),
+	)
+})
 
 var _ = Describe("CreateClientWithReauth", func() {
 	It("should handle nil authToken pointer safely", func() {

--- a/cmd/caib/common/api_client_test.go
+++ b/cmd/caib/common/api_client_test.go
@@ -1,0 +1,39 @@
+package caibcommon
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	buildapitypes "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi"
+	buildapiclient "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi/client"
+)
+
+func TestExecuteWithReauthPreservesForbiddenResponse(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if r.URL.Path != "/v1/workspaces" {
+			t.Errorf("unexpected request path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"image is not in the allowed images list"}`))
+	}))
+	defer server.Close()
+
+	token := "valid-token"
+	err := ExecuteWithReauth(server.URL, &token, false, func(client *buildapiclient.Client) error {
+		_, createErr := client.CreateWorkspace(context.Background(), buildapitypes.WorkspaceRequest{Name: "test"})
+		return createErr
+	})
+
+	if err == nil || !strings.Contains(err.Error(), "403 Forbidden") || !strings.Contains(err.Error(), "image is not in the allowed images list") {
+		t.Fatalf("expected original forbidden response, got %v", err)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("expected one request without reauthentication, got %d", got)
+	}
+}

--- a/internal/buildapi/client/client.go
+++ b/internal/buildapi/client/client.go
@@ -102,6 +102,49 @@ func WithCACertificate(caCertPath string) Option {
 	}
 }
 
+// statusIn returns a doRequest status predicate that accepts an exact set of status codes.
+func statusIn(codes ...int) func(int) bool {
+	return func(code int) bool {
+		for _, c := range codes {
+			if code == c {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// doRequest performs req and validates the response status against isOK.
+//
+// This is the single point through which every build API call must pass:
+// centralizing the status check here means a failing response is always turned
+// into an HTTPError, so callers like auth.IsAuthError can reliably detect status
+// codes (e.g. 401) without every call site having to remember to wrap its own
+// errors.
+//
+// On success the response is returned with its body open for the caller to read
+// and close. On failure the body is drained (up to 1KB) and closed here, and the
+// failure is returned as an HTTPError describing action, the status, and body.
+func (c *Client) doRequest(req *http.Request, action string, isOK func(statusCode int) bool) (*http.Response, error) {
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if isOK(resp.StatusCode) {
+		return resp, nil
+	}
+	b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+	_ = resp.Body.Close()
+	return nil, newHTTPError(resp.StatusCode, "%s failed: %s: %s", action, resp.Status, string(b))
+}
+
+// closeBody closes resp.Body, logging a warning if closing fails.
+func closeBody(resp *http.Response) {
+	if err := resp.Body.Close(); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", err)
+	}
+}
+
 // CreateBuild submits a new build request to the API server.
 //
 //nolint:dupl // Build and Flash methods are intentionally similar but work with different types
@@ -119,19 +162,11 @@ func (c *Client) CreateBuild(ctx context.Context, req buildapi.BuildRequest) (*b
 	if c.authToken != "" {
 		httpReq.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doRequest(httpReq, "create build", statusIn(http.StatusAccepted, http.StatusOK))
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", err)
-		}
-	}()
-	if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("create build failed: %s: %s", resp.Status, string(b))
-	}
+	defer closeBody(resp)
 	var out buildapi.BuildResponse
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		return nil, err
@@ -149,19 +184,11 @@ func (c *Client) GetBuild(ctx context.Context, name string) (*buildapi.BuildResp
 	if c.authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doRequest(req, "get build", statusIn(http.StatusOK))
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", err)
-		}
-	}()
-	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("get build failed: %s: %s", resp.Status, string(b))
-	}
+	defer closeBody(resp)
 	var out buildapi.BuildResponse
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		return nil, err
@@ -187,15 +214,11 @@ func (c *Client) doBuildAction(ctx context.Context, method, endpoint, action str
 	if c.authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doRequest(req, action, statusIn(http.StatusOK))
 	if err != nil {
 		return err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return fmt.Errorf("%s failed: %s: %s", action, resp.Status, string(b))
-	}
 	return nil
 }
 
@@ -211,19 +234,11 @@ func (c *Client) CreateBuildToken(ctx context.Context, name string) (*buildapi.T
 	if c.authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doRequest(req, "create build token", statusIn(http.StatusOK))
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", err)
-		}
-	}()
-	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("create build token failed: %s: %s", resp.Status, string(b))
-	}
+	defer closeBody(resp)
 	var out buildapi.TokenResponse
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		return nil, err
@@ -242,21 +257,13 @@ func (c *Client) GetBuildProgress(ctx context.Context, name string) (*buildapi.B
 	if c.authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doRequest(req, "get build progress", statusIn(http.StatusOK, http.StatusNotFound))
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", err)
-		}
-	}()
+	defer closeBody(resp)
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, nil
-	}
-	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("get build progress failed: %s: %s", resp.Status, string(b))
 	}
 	var out buildapi.BuildProgress
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
@@ -277,19 +284,11 @@ func (c *Client) GetBuildTemplate(ctx context.Context, name string) (*buildapi.B
 	if c.authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doRequest(req, "get build template", statusIn(http.StatusOK))
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", err)
-		}
-	}()
-	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("get build template failed: %s: %s", resp.Status, string(b))
-	}
+	defer closeBody(resp)
 	var out buildapi.BuildTemplateResponse
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		return nil, err
@@ -334,19 +333,11 @@ func (c *Client) CreateFlash(ctx context.Context, req buildapi.FlashRequest) (*b
 	if c.authToken != "" {
 		httpReq.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doRequest(httpReq, "create flash", statusIn(http.StatusAccepted, http.StatusOK))
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", err)
-		}
-	}()
-	if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("create flash failed: %s: %s", resp.Status, string(b))
-	}
+	defer closeBody(resp)
 	var out buildapi.FlashResponse
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		return nil, err
@@ -364,19 +355,11 @@ func (c *Client) GetFlash(ctx context.Context, name string) (*buildapi.FlashResp
 	if c.authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doRequest(req, "get flash", statusIn(http.StatusOK))
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", err)
-		}
-	}()
-	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("get flash failed: %s: %s", resp.Status, string(b))
-	}
+	defer closeBody(resp)
 	var out buildapi.FlashResponse
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		return nil, err
@@ -394,21 +377,13 @@ func (c *Client) GetCatalogImage(ctx context.Context, name string) (*catalog.Cat
 	if c.authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doRequest(req, "get catalog image", statusIn(http.StatusOK, http.StatusNotFound))
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", err)
-		}
-	}()
+	defer closeBody(resp)
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, fmt.Errorf("catalog image %q not found", name)
-	}
-	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("get catalog image failed: %s: %s", resp.Status, string(b))
 	}
 	var out catalog.CatalogImageResponse
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
@@ -435,19 +410,11 @@ func (c *Client) listJSON(ctx context.Context, endpoint, operation string, out a
 	if c.authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doRequest(req, operation, statusIn(http.StatusOK))
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", err)
-		}
-	}()
-	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return fmt.Errorf("%s failed: %s: %s", operation, resp.Status, string(b))
-	}
+	defer closeBody(resp)
 	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
 		return err
 	}
@@ -472,19 +439,11 @@ func (c *Client) CreateSealed(ctx context.Context, req buildapi.SealedRequest) (
 	if c.authToken != "" {
 		httpReq.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doRequest(httpReq, "create reseal", statusIn(http.StatusAccepted, http.StatusOK))
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", err)
-		}
-	}()
-	if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("create reseal failed: %s: %s", resp.Status, string(b))
-	}
+	defer closeBody(resp)
 	var out buildapi.SealedResponse
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		return nil, err
@@ -503,19 +462,11 @@ func (c *Client) GetSealed(ctx context.Context, op buildapi.SealedOperation, nam
 	if c.authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doRequest(req, "get reseal", statusIn(http.StatusOK))
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", err)
-		}
-	}()
-	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("get reseal failed: %s: %s", resp.Status, string(b))
-	}
+	defer closeBody(resp)
 	var out buildapi.SealedResponse
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		return nil, err
@@ -534,19 +485,11 @@ func (c *Client) ListSealed(ctx context.Context, op buildapi.SealedOperation) ([
 	if c.authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doRequest(req, "list reseal", statusIn(http.StatusOK))
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", err)
-		}
-	}()
-	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("list reseal failed: %s: %s", resp.Status, string(b))
-	}
+	defer closeBody(resp)
 	var out []buildapi.SealedListItem
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		return nil, err
@@ -625,19 +568,11 @@ func (c *Client) UploadFiles(ctx context.Context, name string, files []Upload) e
 	if c.authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doRequest(req, "upload", statusIn(http.StatusOK))
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", err)
-		}
-	}()
-	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return fmt.Errorf("upload failed: %s: %s", resp.Status, string(b))
-	}
+	defer closeBody(resp)
 	return nil
 }
 
@@ -658,19 +593,11 @@ func (c *Client) CreateContainerBuild(ctx context.Context, req buildapi.Containe
 	if c.authToken != "" {
 		httpReq.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doRequest(httpReq, "create container build", statusIn(http.StatusAccepted, http.StatusOK))
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", err)
-		}
-	}()
-	if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("create container build failed: %s: %s", resp.Status, string(b))
-	}
+	defer closeBody(resp)
 	var out buildapi.ContainerBuildResponse
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		return nil, err
@@ -688,19 +615,11 @@ func (c *Client) GetContainerBuild(ctx context.Context, name string) (*buildapi.
 	if c.authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doRequest(req, "get container build", statusIn(http.StatusOK))
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", err)
-		}
-	}()
-	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("get container build failed: %s: %s", resp.Status, string(b))
-	}
+	defer closeBody(resp)
 	var out buildapi.ContainerBuildResponse
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		return nil, err
@@ -728,19 +647,11 @@ func (c *Client) UploadContainerBuildContext(ctx context.Context, name string, t
 	if c.authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doRequest(req, "upload context", statusIn(http.StatusOK))
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", err)
-		}
-	}()
-	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return fmt.Errorf("upload context failed: %s: %s", resp.Status, string(b))
-	}
+	defer closeBody(resp)
 	return nil
 }
 
@@ -754,19 +665,11 @@ func (c *Client) GetOperatorConfig(ctx context.Context) (*buildapi.OperatorConfi
 	if c.authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doRequest(req, "get config", statusIn(http.StatusOK))
 	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+		return nil, err
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", err)
-		}
-	}()
-	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("get config failed: %s: %s", resp.Status, string(b))
-	}
+	defer closeBody(resp)
 	var config buildapi.OperatorConfigResponse
 	if err := json.NewDecoder(resp.Body).Decode(&config); err != nil {
 		return nil, fmt.Errorf("decoding response: %w", err)
@@ -789,15 +692,11 @@ func (c *Client) CreateWorkspace(ctx context.Context, req buildapi.WorkspaceRequ
 	if c.authToken != "" {
 		httpReq.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doRequest(httpReq, "create workspace", statusIn(http.StatusCreated))
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusCreated {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("create workspace failed: %s: %s", resp.Status, string(b))
-	}
 	var ws buildapi.WorkspaceResponse
 	if err := json.NewDecoder(resp.Body).Decode(&ws); err != nil {
 		return nil, fmt.Errorf("decoding response: %w", err)
@@ -815,15 +714,11 @@ func (c *Client) ListWorkspaces(ctx context.Context) ([]buildapi.WorkspaceRespon
 	if c.authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doRequest(req, "list workspaces", statusIn(http.StatusOK))
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("list workspaces failed: %s: %s", resp.Status, string(b))
-	}
 	var workspaces []buildapi.WorkspaceResponse
 	if err := json.NewDecoder(resp.Body).Decode(&workspaces); err != nil {
 		return nil, fmt.Errorf("decoding response: %w", err)
@@ -841,15 +736,11 @@ func (c *Client) GetWorkspace(ctx context.Context, name string) (*buildapi.Works
 	if c.authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doRequest(req, "get workspace", statusIn(http.StatusOK))
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("get workspace failed: %s: %s", resp.Status, string(b))
-	}
 	var ws buildapi.WorkspaceResponse
 	if err := json.NewDecoder(resp.Body).Decode(&ws); err != nil {
 		return nil, fmt.Errorf("decoding response: %w", err)
@@ -879,18 +770,11 @@ func (c *Client) SetWorkspaceLease(ctx context.Context, name, leaseID string) er
 	if c.authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doRequest(req, "set workspace lease", func(code int) bool { return code < http.StatusBadRequest })
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", err)
-		}
-	}()
-	if resp.StatusCode >= 400 {
-		return fmt.Errorf("failed to set workspace lease: %s", resp.Status)
-	}
+	defer closeBody(resp)
 	return nil
 }
 
@@ -904,15 +788,11 @@ func (c *Client) workspaceAction(ctx context.Context, name, action string) (*bui
 	if c.authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doRequest(req, action+" workspace", statusIn(http.StatusOK))
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("%s workspace failed: %s: %s", action, resp.Status, string(b))
-	}
 	var ws buildapi.WorkspaceResponse
 	if err := json.NewDecoder(resp.Body).Decode(&ws); err != nil {
 		return nil, fmt.Errorf("decoding response: %w", err)
@@ -930,15 +810,11 @@ func (c *Client) DeleteWorkspace(ctx context.Context, name string) error {
 	if c.authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doRequest(req, "delete workspace", statusIn(http.StatusOK))
 	if err != nil {
 		return err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return fmt.Errorf("delete workspace failed: %s: %s", resp.Status, string(b))
-	}
 	return nil
 }
 
@@ -957,15 +833,11 @@ func (c *Client) SyncPlan(ctx context.Context, name string, req buildapi.SyncPla
 	if c.authToken != "" {
 		httpReq.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doRequest(httpReq, "sync plan", statusIn(http.StatusOK))
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("sync plan failed: %s: %s", resp.Status, string(b))
-	}
 	var plan buildapi.SyncPlanResponse
 	if err := json.NewDecoder(resp.Body).Decode(&plan); err != nil {
 		return nil, fmt.Errorf("decoding response: %w", err)
@@ -984,15 +856,11 @@ func (c *Client) SyncWorkspace(ctx context.Context, name string, body io.Reader)
 	if c.authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doRequest(req, "sync workspace", statusIn(http.StatusOK))
 	if err != nil {
 		return err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return fmt.Errorf("sync workspace failed: %s: %s", resp.Status, string(b))
-	}
 	return nil
 }
 
@@ -1007,15 +875,11 @@ func (c *Client) SyncWorkspaceClean(ctx context.Context, name string, body io.Re
 	if c.authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.doRequest(req, "sync workspace (clean)", statusIn(http.StatusOK))
 	if err != nil {
 		return err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return fmt.Errorf("sync workspace (clean) failed: %s: %s", resp.Status, string(b))
-	}
 	return nil
 }
 
@@ -1034,15 +898,11 @@ func (c *Client) SyncDelete(ctx context.Context, name string, req buildapi.SyncD
 	if c.authToken != "" {
 		httpReq.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doRequest(httpReq, "sync delete", statusIn(http.StatusOK))
 	if err != nil {
 		return err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return fmt.Errorf("sync delete failed: %s: %s", resp.Status, string(b))
-	}
 	return nil
 }
 
@@ -1061,14 +921,9 @@ func (c *Client) workspaceStreamRequest(ctx context.Context, name, action string
 	if c.authToken != "" {
 		httpReq.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.doRequest(httpReq, action+" workspace", statusIn(http.StatusOK))
 	if err != nil {
 		return nil, err
-	}
-	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		_ = resp.Body.Close()
-		return nil, fmt.Errorf("%s workspace failed: %s: %s", action, resp.Status, string(b))
 	}
 	return resp.Body, nil
 }
@@ -1105,7 +960,7 @@ func (c *Client) ShellWorkspace(ctx context.Context, name string) (*websocket.Co
 		if resp != nil {
 			b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 			_ = resp.Body.Close()
-			return nil, fmt.Errorf("shell websocket failed (%s): %s", resp.Status, string(b))
+			return nil, newHTTPError(resp.StatusCode, "shell websocket failed (%s): %s", resp.Status, string(b))
 		}
 		return nil, fmt.Errorf("shell websocket failed: %w", err)
 	}

--- a/internal/buildapi/client/http_error.go
+++ b/internal/buildapi/client/http_error.go
@@ -1,0 +1,27 @@
+package client
+
+import "fmt"
+
+// HTTPError is implemented by errors returned from build API HTTP calls
+// that carry a response status code.
+type HTTPError interface {
+	error
+	HTTPStatusCode() int
+}
+
+type responseError struct {
+	code    int
+	message string
+}
+
+func (e *responseError) Error() string {
+	return e.message
+}
+
+func (e *responseError) HTTPStatusCode() int {
+	return e.code
+}
+
+func newHTTPError(code int, format string, args ...any) error {
+	return &responseError{code: code, message: fmt.Sprintf(format, args...)}
+}


### PR DESCRIPTION
Represent build API failures as structured HTTP errors and trigger reauthentication only for HTTP 401 responses. This preserves actionable 403 errors such as workspace image policy violations.

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication error detection to rely on the HTTP 401 status.
  * Preserved detailed 403 Forbidden responses, including server-provided error messages.
  * Standardized HTTP error reporting with status codes and response details across API operations.
  * Prevented unnecessary reauthentication attempts for forbidden responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->