### PR TITLE
fix: properly report workspace failed status

### DIFF
--- a/api/v1alpha1/workspace_types.go
+++ b/api/v1alpha1/workspace_types.go
@@ -21,6 +21,25 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// WorkspaceStatusReason is a stable explanation of a workspace phase exposed through build-api.
+type WorkspaceStatusReason string
+
+const (
+	WorkspaceReasonAutoPaused            WorkspaceStatusReason = "AutoPaused"
+	WorkspaceReasonContainerConfigError  WorkspaceStatusReason = "ContainerConfigurationError"
+	WorkspaceReasonContainerExited       WorkspaceStatusReason = "ContainerExited"
+	WorkspaceReasonContainerRestarting   WorkspaceStatusReason = "ContainerRestarting"
+	WorkspaceReasonContainerRuntimeError WorkspaceStatusReason = "ContainerRuntimeError"
+	WorkspaceReasonContainerStarting     WorkspaceStatusReason = "ContainerStarting"
+	WorkspaceReasonImageConfigError      WorkspaceStatusReason = "ImageConfigurationError"
+	WorkspaceReasonImagePulling          WorkspaceStatusReason = "ImagePulling"
+	WorkspaceReasonPodCreationError      WorkspaceStatusReason = "PodCreationError"
+	WorkspaceReasonPodExited             WorkspaceStatusReason = "PodExited"
+	WorkspaceReasonPodFailed             WorkspaceStatusReason = "PodFailed"
+	WorkspaceReasonScheduling            WorkspaceStatusReason = "Scheduling"
+	WorkspaceReasonStorageError          WorkspaceStatusReason = "StorageError"
+)
+
 // WorkspaceSpec defines the desired state of a developer workspace.
 type WorkspaceSpec struct {
 	// Architecture is the target architecture (e.g., "arm64", "amd64")
@@ -83,6 +102,10 @@ type WorkspaceStatus struct {
 	// Phase is the current phase of the workspace
 	// +kubebuilder:validation:Enum=Pending;Creating;Running;Failed;Terminating;Stopped
 	Phase string `json:"phase,omitempty"`
+
+	// Reason is a stable, machine-readable explanation of the current phase
+	// +kubebuilder:validation:Enum=AutoPaused;ContainerConfigurationError;ContainerExited;ContainerRestarting;ContainerRuntimeError;ContainerStarting;ImageConfigurationError;ImagePulling;PodCreationError;PodExited;PodFailed;Scheduling;StorageError
+	Reason WorkspaceStatusReason `json:"reason,omitempty"`
 
 	// PodName is the name of the workspace pod
 	PodName string `json:"podName,omitempty"`

--- a/cmd/caib/workspace/workspace.go
+++ b/cmd/caib/workspace/workspace.go
@@ -20,6 +20,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
 	"github.com/gorilla/websocket"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -442,6 +443,12 @@ func printWorkspaceDetails(ws *buildapitypes.WorkspaceResponse) error {
 	fmt.Printf("Name:         %s\n", ws.Name)
 	fmt.Printf("Architecture: %s\n", ws.Arch)
 	fmt.Printf("Phase:        %s\n", ws.Phase)
+	if ws.Reason != "" {
+		fmt.Printf("Reason:       %s\n", ws.Reason)
+	}
+	if ws.Message != "" {
+		fmt.Printf("Message:      %s\n", ws.Message)
+	}
 	fmt.Printf("Pod:          %s\n", ws.PodName)
 	if ws.Lease != "" {
 		fmt.Printf("Lease:        %s\n", ws.Lease)
@@ -916,7 +923,8 @@ func waitForRunning(name string) {
 	defer ticker.Stop()
 
 	isTTY := term.IsTerminal(int(os.Stdout.Fd()))
-	lastPhase := ""
+	lastStatus := ""
+	lastReason := ""
 
 	for {
 		select {
@@ -925,10 +933,11 @@ func waitForRunning(name string) {
 			return
 		case <-timeout:
 			fmt.Println()
-			handleError(caibcommon.NewActionableError(
-				fmt.Errorf("timed out waiting for workspace %q to be running", name),
-				"caib workspace logs "+name,
-			))
+			err := fmt.Errorf("timed out waiting for workspace %q to be running", name)
+			if lastStatus != "" {
+				err = fmt.Errorf("%w (last status: %s)", err, lastStatus)
+			}
+			handleError(workspaceStatusError(err, lastReason))
 		case <-ticker.C:
 			var ws *buildapitypes.WorkspaceResponse
 			err := caibcommon.ExecuteWithReauth(serverURL, &authToken, insecureSkipTLS, func(client *buildapiclient.Client) error {
@@ -944,13 +953,21 @@ func waitForRunning(name string) {
 			}
 
 			showProgress := !clilog.IsQuiet()
-			if ws.Phase != lastPhase {
-				lastPhase = ws.Phase
+			status := ws.Phase
+			lastReason = ws.Reason
+			if ws.Reason != "" {
+				status += " (" + ws.Reason + ")"
+			}
+			if ws.Message != "" {
+				status += ": " + ws.Message
+			}
+			if status != lastStatus {
+				lastStatus = status
 				if showProgress {
 					if isTTY {
-						fmt.Printf("\r  Phase:        %-20s", ws.Phase)
+						fmt.Printf("\r  Phase:        %s\033[K", status)
 					} else {
-						fmt.Printf("  Phase: %s\n", ws.Phase)
+						fmt.Printf("  Phase: %s\n", status)
 					}
 				}
 			}
@@ -973,9 +990,32 @@ func waitForRunning(name string) {
 				if isTTY && showProgress {
 					fmt.Println()
 				}
-				handleError(fmt.Errorf("workspace %q failed", name))
+				handleError(workspaceFailureError(name, ws))
 			}
 		}
+	}
+}
+
+func workspaceFailureError(name string, ws *buildapitypes.WorkspaceResponse) error {
+	err := fmt.Errorf("workspace %q failed", name)
+	if ws.Reason != "" {
+		err = fmt.Errorf("workspace %q failed (%s)", name, ws.Reason)
+	}
+	if ws.Message != "" {
+		err = fmt.Errorf("%w: %s", err, ws.Message)
+	}
+
+	return workspaceStatusError(err, ws.Reason)
+}
+
+func workspaceStatusError(err error, reason string) error {
+	switch reason {
+	case string(automotivev1alpha1.WorkspaceReasonImagePulling):
+		return caibcommon.NewActionableError(err, "verify the workspace image name and registry access")
+	case string(automotivev1alpha1.WorkspaceReasonScheduling):
+		return caibcommon.NewActionableError(err, "contact your service administrator to check cluster capacity for the requested architecture")
+	default:
+		return fmt.Errorf("%w; contact your service administrator with this status", err)
 	}
 }
 

--- a/cmd/caib/workspace/workspace_test.go
+++ b/cmd/caib/workspace/workspace_test.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
 	caibcommon "github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/common"
 	buildapitypes "github.com/centos-automotive-suite/automotive-dev-operator/internal/buildapi"
@@ -163,7 +165,9 @@ func TestRenderFormattedWorkspaceShow(t *testing.T) {
 	ws := &buildapitypes.WorkspaceResponse{
 		Name:             "test-ws",
 		Arch:             "amd64",
-		Phase:            "Running",
+		Phase:            "Failed",
+		Reason:           "ContainerConfigurationError",
+		Message:          "container toolchain: CreateContainerConfigError: invalid configuration",
 		PodName:          "test-ws-pod",
 		Lease:            "lease-123",
 		Age:              "10m",
@@ -204,6 +208,12 @@ func TestRenderFormattedWorkspaceShow(t *testing.T) {
 		}
 		if parsed["lease"] != "lease-123" {
 			t.Errorf("expected lease 'lease-123', got %q", parsed["lease"])
+		}
+		if parsed["reason"] != ws.Reason {
+			t.Errorf("expected reason %q, got %q", ws.Reason, parsed["reason"])
+		}
+		if parsed["message"] != ws.Message {
+			t.Errorf("expected message %q, got %q", ws.Message, parsed["message"])
 		}
 	})
 }
@@ -254,7 +264,9 @@ func TestPrintWorkspaceDetails(t *testing.T) {
 	ws := &buildapitypes.WorkspaceResponse{
 		Name:             "test-ws",
 		Arch:             "amd64",
-		Phase:            "Running",
+		Phase:            "Failed",
+		Reason:           "ContainerConfigurationError",
+		Message:          "container toolchain: CreateContainerConfigError: invalid configuration",
 		PodName:          "test-ws-pod",
 		AutoPauseTimeout: "30m",
 	}
@@ -282,6 +294,12 @@ func TestPrintWorkspaceDetails(t *testing.T) {
 	if !strings.Contains(output, "Architecture: amd64") {
 		t.Error("expected Architecture field in output")
 	}
+	if !strings.Contains(output, "Reason:       ContainerConfigurationError") {
+		t.Error("expected Reason field in output")
+	}
+	if !strings.Contains(output, "Message:      container toolchain: CreateContainerConfigError: invalid configuration") {
+		t.Error("expected failure message in output")
+	}
 	if !strings.Contains(output, "Auto-pause:   30m") {
 		t.Error("expected Auto-pause field in output")
 	}
@@ -291,6 +309,72 @@ func TestPrintWorkspaceDetails(t *testing.T) {
 	}
 	if strings.Contains(output, "Age:") {
 		t.Error("empty Age should not appear in output")
+	}
+}
+
+func TestWorkspaceFailureError(t *testing.T) {
+	t.Run("container exit carries support details", func(t *testing.T) {
+		err := workspaceFailureError("test-ws", &buildapitypes.WorkspaceResponse{
+			Reason:  "ContainerExited",
+			Message: "container toolchain: OOMKilled",
+		})
+		formatted := caibcommon.FormatError(err)
+		if !strings.Contains(formatted, "contact your service administrator with this status") {
+			t.Fatalf("expected administrator guidance, got %q", formatted)
+		}
+		if strings.Contains(formatted, "workspace logs") {
+			t.Fatalf("unexpected nonexistent logs command in %q", formatted)
+		}
+	})
+
+	t.Run("service failure carries support details", func(t *testing.T) {
+		err := workspaceFailureError("test-ws", &buildapitypes.WorkspaceResponse{
+			Reason:  "ContainerConfigurationError",
+			Message: "container toolchain: CreateContainerConfigError: secret not found",
+		})
+		formatted := caibcommon.FormatError(err)
+		if !strings.Contains(formatted, "contact your service administrator with this status") {
+			t.Fatalf("expected administrator guidance, got %q", formatted)
+		}
+		if !strings.Contains(formatted, "CreateContainerConfigError: secret not found") {
+			t.Fatalf("expected support detail, got %q", formatted)
+		}
+	})
+}
+
+func TestWorkspaceStatusError(t *testing.T) {
+	tests := []struct {
+		name   string
+		reason automotivev1alpha1.WorkspaceStatusReason
+		want   string
+	}{
+		{
+			name:   "image pulling",
+			reason: automotivev1alpha1.WorkspaceReasonImagePulling,
+			want:   "Fix:   verify the workspace image name and registry access",
+		},
+		{
+			name:   "scheduling",
+			reason: automotivev1alpha1.WorkspaceReasonScheduling,
+			want:   "Fix:   contact your service administrator to check cluster capacity for the requested architecture",
+		},
+		{
+			name:   "container restarting",
+			reason: automotivev1alpha1.WorkspaceReasonContainerRestarting,
+			want:   "contact your service administrator with this status",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			formatted := caibcommon.FormatError(workspaceStatusError(fmt.Errorf("workspace unavailable"), string(tt.reason)))
+			if !strings.Contains(formatted, tt.want) {
+				t.Fatalf("expected %q, got %q", tt.want, formatted)
+			}
+			if strings.Contains(formatted, "workspace logs") {
+				t.Fatalf("unexpected nonexistent logs command in %q", formatted)
+			}
+		})
 	}
 }
 

--- a/config/crd/bases/automotive.sdv.cloud.redhat.com_workspaces.yaml
+++ b/config/crd/bases/automotive.sdv.cloud.redhat.com_workspaces.yaml
@@ -224,6 +224,24 @@ spec:
               pvcName:
                 description: PVCName is the generated name of the workspace PVC
                 type: string
+              reason:
+                description: Reason is a stable, machine-readable explanation of the
+                  current phase
+                enum:
+                - AutoPaused
+                - ContainerConfigurationError
+                - ContainerExited
+                - ContainerRestarting
+                - ContainerRuntimeError
+                - ContainerStarting
+                - ImageConfigurationError
+                - ImagePulling
+                - PodCreationError
+                - PodExited
+                - PodFailed
+                - Scheduling
+                - StorageError
+                type: string
             type: object
         type: object
     served: true

--- a/internal/buildapi/workspace.go
+++ b/internal/buildapi/workspace.go
@@ -89,6 +89,8 @@ type WorkspaceRequest struct {
 type WorkspaceResponse struct {
 	Name             string `json:"name"`
 	Phase            string `json:"phase"`
+	Reason           string `json:"reason,omitempty"`
+	Message          string `json:"message,omitempty"`
 	Lease            string `json:"lease,omitempty"`
 	Arch             string `json:"architecture"`
 	PodName          string `json:"podName,omitempty"`
@@ -1012,6 +1014,10 @@ func buildWorkspaceResources(cpu, memory string, wsConfig *automotivev1alpha1.Wo
 		if err != nil {
 			return nil, fmt.Errorf("invalid --memory value %q: %v", memory, err)
 		}
+		minMemory := resource.MustParse("6Mi")
+		if q.Cmp(minMemory) < 0 {
+			return nil, fmt.Errorf("invalid --memory value %q: must be at least %s", memory, minMemory.String())
+		}
 		if wsConfig != nil && wsConfig.MaxResources != nil {
 			if maxMem, ok := wsConfig.MaxResources.Limits[corev1.ResourceMemory]; ok && q.Cmp(maxMem) > 0 {
 				return nil, fmt.Errorf("requested memory %s exceeds maximum %s", memory, maxMem.String())
@@ -1026,14 +1032,18 @@ func buildWorkspaceResources(cpu, memory string, wsConfig *automotivev1alpha1.Wo
 
 func workspaceResponseFromCR(ws *automotivev1alpha1.Workspace) WorkspaceResponse {
 	phase := ws.Status.Phase
+	reason := ws.Status.Reason
+	message := ws.Status.Message
 	if phase == "" {
 		phase = "Pending"
 	}
 	// Reflect spec intent when status hasn't caught up yet
 	if ws.Spec.Stopped && phase != "Stopped" {
 		phase = "Stopping"
+		reason, message = "", ""
 	} else if !ws.Spec.Stopped && phase == "Stopped" {
 		phase = "Starting"
+		reason, message = "", ""
 	}
 	age := ""
 	if !ws.CreationTimestamp.IsZero() {
@@ -1062,6 +1072,8 @@ func workspaceResponseFromCR(ws *automotivev1alpha1.Workspace) WorkspaceResponse
 	return WorkspaceResponse{
 		Name:             ws.Name,
 		Phase:            phase,
+		Reason:           string(reason),
+		Message:          message,
 		Lease:            ws.Spec.LeaseID,
 		Arch:             ws.Spec.Architecture,
 		PodName:          ws.Status.PodName,

--- a/internal/buildapi/workspace_test.go
+++ b/internal/buildapi/workspace_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 
+	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
 	"github.com/gin-gonic/gin"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // Dot import is standard for Ginkgo
@@ -63,6 +64,11 @@ var _ = Describe("Workspace API", func() {
 	})
 
 	Context("Create Workspace", func() {
+		It("should reject memory below the container runtime minimum", func() {
+			_, err := buildWorkspaceResources("", "4", nil)
+			Expect(err).To(MatchError(`invalid --memory value "4": must be at least 6Mi`))
+		})
+
 		It("should reject request with missing name", func() {
 			body, _ := json.Marshal(WorkspaceRequest{})
 			req, err := http.NewRequest("POST", "/v1/workspaces", bytes.NewReader(body))
@@ -86,6 +92,42 @@ var _ = Describe("Workspace API", func() {
 
 			Expect(w.Code).To(Equal(http.StatusUnauthorized))
 		})
+	})
+
+	Context("Workspace response", func() {
+		DescribeTable("status mapping",
+			func(stopped bool, status automotivev1alpha1.WorkspaceStatus, wantPhase, wantReason, wantMessage string) {
+				response := workspaceResponseFromCR(&automotivev1alpha1.Workspace{
+					Spec:   automotivev1alpha1.WorkspaceSpec{Stopped: stopped},
+					Status: status,
+				})
+
+				Expect(response.Phase).To(Equal(wantPhase))
+				Expect(response.Reason).To(Equal(wantReason))
+				Expect(response.Message).To(Equal(wantMessage))
+			},
+			Entry("propagates reason and message", false,
+				automotivev1alpha1.WorkspaceStatus{
+					Phase:   "Failed",
+					Reason:  automotivev1alpha1.WorkspaceReasonContainerRuntimeError,
+					Message: "container toolchain: CreateContainerError",
+				},
+				"Failed", string(automotivev1alpha1.WorkspaceReasonContainerRuntimeError), "container toolchain: CreateContainerError"),
+			Entry("clears stale status while stopping", true,
+				automotivev1alpha1.WorkspaceStatus{
+					Phase:   "Failed",
+					Reason:  automotivev1alpha1.WorkspaceReasonContainerRuntimeError,
+					Message: "container toolchain: CreateContainerError",
+				},
+				"Stopping", "", ""),
+			Entry("clears stale status while starting", false,
+				automotivev1alpha1.WorkspaceStatus{
+					Phase:   "Stopped",
+					Reason:  automotivev1alpha1.WorkspaceReasonAutoPaused,
+					Message: "Auto-paused after 30m of inactivity",
+				},
+				"Starting", "", ""),
+		)
 	})
 
 	Context("Exec Workspace", func() {

--- a/internal/controller/workspace/controller.go
+++ b/internal/controller/workspace/controller.go
@@ -41,6 +41,9 @@ const (
 	pvcSuffix                   = "-workspace"
 	leaseAnn                    = "automotive.sdv.cloud.redhat.com/lease-id"
 	workspaceServiceAccountName = "ado-workspace"
+	phaseCreating               = "Creating"
+	phaseFailed                 = "Failed"
+	phaseStopped                = "Stopped"
 )
 
 // Reconciler reconciles a Workspace object.
@@ -81,7 +84,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 
 	// Ensure PVC exists
 	if err := r.ensurePVC(ctx, ws); err != nil {
-		if statusErr := r.setStatus(ctx, ws, "Failed", fmt.Sprintf("PVC error: %v", err)); statusErr != nil {
+		if statusErr := r.setStatus(ctx, ws, "Failed", automotivev1alpha1.WorkspaceReasonStorageError, fmt.Sprintf("PVC error: %v", err)); statusErr != nil {
 			log.Error(statusErr, "failed to update status after PVC error")
 		}
 		return ctrl.Result{}, err
@@ -92,38 +95,25 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 		if err := r.deleteWorkspacePod(ctx, ws, log); err != nil {
 			return ctrl.Result{}, err
 		}
-		// Preserve existing message (e.g., auto-pause reason) if already Stopped
-		msg := ws.Status.Message
-		return ctrl.Result{}, r.setStatus(ctx, ws, "Stopped", msg)
+		var reason automotivev1alpha1.WorkspaceStatusReason
+		msg := ""
+		if ws.Status.Phase == phaseStopped {
+			reason, msg = ws.Status.Reason, ws.Status.Message
+		}
+		return ctrl.Result{}, r.setStatus(ctx, ws, phaseStopped, reason, msg)
 	}
 
 	pod, err := r.ensurePod(ctx, ws, log)
 	if err != nil {
-		if statusErr := r.setStatus(ctx, ws, "Failed", fmt.Sprintf("Pod error: %v", err)); statusErr != nil {
+		if statusErr := r.setStatus(ctx, ws, "Failed", automotivev1alpha1.WorkspaceReasonPodCreationError, fmt.Sprintf("Pod error: %v", err)); statusErr != nil {
 			log.Error(statusErr, "failed to update status after pod error")
 		}
 		return ctrl.Result{}, err
 	}
 
-	// Update status from pod phase
-	phase := "Pending"
-	msg := ""
-	if pod != nil {
-		switch pod.Status.Phase {
-		case corev1.PodRunning:
-			phase = "Running"
-		case corev1.PodFailed:
-			phase = "Failed"
-			msg = "Pod failed"
-		case corev1.PodSucceeded:
-			phase = "Failed"
-			msg = "Pod exited unexpectedly"
-		default:
-			phase = "Creating"
-		}
-	}
+	phase, reason, msg := workspacePodStatus(pod)
 
-	if err := r.setStatus(ctx, ws, phase, msg); err != nil {
+	if err := r.setStatus(ctx, ws, phase, reason, msg); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -133,6 +123,118 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func workspacePodStatus(pod *corev1.Pod) (string, automotivev1alpha1.WorkspaceStatusReason, string) {
+	if pod == nil {
+		return "Pending", "", ""
+	}
+
+	if (pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodSucceeded) &&
+		(pod.Status.Reason != "" || pod.Status.Message != "") {
+		fallback := "Pod failed"
+		if pod.Status.Phase == corev1.PodSucceeded {
+			fallback = "Pod exited unexpectedly"
+		}
+		reason := automotivev1alpha1.WorkspaceReasonPodFailed
+		if pod.Status.Phase == corev1.PodSucceeded {
+			reason = automotivev1alpha1.WorkspaceReasonPodExited
+		}
+		return phaseFailed, reason, statusMessage("pod", pod.Status.Reason, pod.Status.Message, fallback)
+	}
+
+	var creatingReason automotivev1alpha1.WorkspaceStatusReason
+	creatingMessage := ""
+	for _, status := range pod.Status.InitContainerStatuses {
+		failed, reason, message := workspaceContainerStatus(status, true)
+		if failed {
+			return phaseFailed, reason, message
+		}
+		if creatingMessage == "" {
+			creatingReason = reason
+			creatingMessage = message
+		}
+	}
+	for _, status := range pod.Status.ContainerStatuses {
+		failed, reason, message := workspaceContainerStatus(status, false)
+		if failed {
+			return phaseFailed, reason, message
+		}
+		if creatingMessage == "" {
+			creatingReason = reason
+			creatingMessage = message
+		}
+	}
+
+	switch pod.Status.Phase {
+	case corev1.PodFailed:
+		return phaseFailed, automotivev1alpha1.WorkspaceReasonPodFailed, "pod: Pod failed"
+	case corev1.PodSucceeded:
+		return phaseFailed, automotivev1alpha1.WorkspaceReasonPodExited, "pod: Pod exited unexpectedly"
+	}
+
+	if pod.Status.Phase == corev1.PodRunning {
+		if creatingMessage == "" {
+			return "Running", "", ""
+		}
+	}
+
+	if creatingMessage != "" {
+		return phaseCreating, creatingReason, creatingMessage
+	}
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodScheduled && condition.Status == corev1.ConditionFalse {
+			return phaseCreating, automotivev1alpha1.WorkspaceReasonScheduling, statusMessage("pod", condition.Reason, condition.Message, "Waiting to be scheduled")
+		}
+	}
+
+	return phaseCreating, "", ""
+}
+
+func workspaceContainerStatus(status corev1.ContainerStatus, initContainer bool) (bool, automotivev1alpha1.WorkspaceStatusReason, string) {
+	if waiting := status.State.Waiting; waiting != nil {
+		message := statusMessage("container "+status.Name, waiting.Reason, waiting.Message, "Waiting")
+		reason, failed := workspaceWaitingReason(waiting.Reason)
+		return failed, reason, message
+	}
+	if terminated := status.State.Terminated; terminated != nil {
+		if initContainer && terminated.ExitCode == 0 {
+			return false, "", ""
+		}
+		fallback := fmt.Sprintf("Exited with code %d", terminated.ExitCode)
+		return true, automotivev1alpha1.WorkspaceReasonContainerExited, statusMessage("container "+status.Name, terminated.Reason, terminated.Message, fallback)
+	}
+	return false, "", ""
+}
+
+func statusMessage(subject, reason, message, fallback string) string {
+	detail := reason
+	if detail == "" {
+		detail = fallback
+	}
+	result := subject + ": " + detail
+	if message != "" {
+		result += ": " + message
+	}
+	return result
+}
+
+// Kubelet reasons are free-form strings; map them to the stable Workspace API contract here.
+func workspaceWaitingReason(reason string) (automotivev1alpha1.WorkspaceStatusReason, bool) {
+	switch reason {
+	case "CreateContainerConfigError":
+		return automotivev1alpha1.WorkspaceReasonContainerConfigError, true
+	case "CreateContainerError", "RunContainerError":
+		return automotivev1alpha1.WorkspaceReasonContainerRuntimeError, true
+	case "ErrImageNeverPull", "InvalidImageName":
+		return automotivev1alpha1.WorkspaceReasonImageConfigError, true
+	case "ErrImagePull", "ImagePullBackOff":
+		return automotivev1alpha1.WorkspaceReasonImagePulling, false
+	case "CrashLoopBackOff":
+		return automotivev1alpha1.WorkspaceReasonContainerRestarting, false
+	default:
+		return automotivev1alpha1.WorkspaceReasonContainerStarting, false
+	}
 }
 
 func (r *Reconciler) ensurePVC(ctx context.Context, ws *automotivev1alpha1.Workspace) (err error) {
@@ -512,19 +614,26 @@ func (r *Reconciler) deleteWorkspacePod(ctx context.Context, ws *automotivev1alp
 	return client.IgnoreNotFound(err)
 }
 
-func (r *Reconciler) setStatus(ctx context.Context, ws *automotivev1alpha1.Workspace, phase, message string) error {
+func (r *Reconciler) setStatus(
+	ctx context.Context,
+	ws *automotivev1alpha1.Workspace,
+	phase string,
+	reason automotivev1alpha1.WorkspaceStatusReason,
+	message string,
+) error {
 	podName := "workspace-" + ws.Name
-	if phase == "Stopped" {
+	if phase == phaseStopped {
 		podName = ""
 	}
-	if ws.Status.Phase == phase && ws.Status.Message == message && ws.Status.PodName == podName {
+	if ws.Status.Phase == phase && ws.Status.Reason == reason && ws.Status.Message == message && ws.Status.PodName == podName {
 		return nil // no change
 	}
 	patch := client.MergeFrom(ws.DeepCopy())
 	ws.Status.Phase = phase
+	ws.Status.Reason = reason
 	ws.Status.Message = message
 	ws.Status.PodName = podName
-	if phase == "Stopped" || phase == "Pending" || phase == "Creating" {
+	if phase == phaseStopped || phase == "Pending" || phase == phaseCreating {
 		ws.Status.LastActivityTime = nil
 	}
 	return r.Status().Patch(ctx, ws, patch)
@@ -601,7 +710,7 @@ func (r *Reconciler) checkAutoPause(ctx context.Context, ws *automotivev1alpha1.
 		}
 
 		msg := fmt.Sprintf("Auto-paused after %s of inactivity", idleDuration.Truncate(time.Minute))
-		return ctrl.Result{}, r.setStatus(ctx, ws, "Stopped", msg)
+		return ctrl.Result{}, r.setStatus(ctx, ws, phaseStopped, automotivev1alpha1.WorkspaceReasonAutoPaused, msg)
 	}
 
 	remaining := timeout - idleDuration

--- a/internal/controller/workspace/controller_test.go
+++ b/internal/controller/workspace/controller_test.go
@@ -22,7 +22,6 @@ import (
 
 const (
 	phaseRunning = "Running"
-	phaseStopped = "Stopped"
 )
 
 func newTestScheme() *runtime.Scheme {
@@ -274,6 +273,195 @@ func TestReconcile_DeletedWorkspace(t *testing.T) {
 	}
 }
 
+func TestReconcile_ContainerCreationFailure(t *testing.T) {
+	ws, pvc, pod := runningWorkspace("broken", "default")
+	ws.Status.Phase = "Creating"
+	pod.Status.Phase = corev1.PodPending
+	pod.Status.ContainerStatuses = []corev1.ContainerStatus{
+		{
+			Name: containerName,
+			State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
+				Reason:  "CreateContainerError",
+				Message: "set memory limit 4 too low",
+			}},
+		},
+	}
+
+	r, fc := newTestReconciler(ws, pvc, pod)
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: ws.Name, Namespace: ws.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	updated := &automotivev1alpha1.Workspace{}
+	if err := fc.Get(context.Background(), client.ObjectKeyFromObject(ws), updated); err != nil {
+		t.Fatalf("failed to get workspace: %v", err)
+	}
+	if updated.Status.Phase != "Failed" {
+		t.Errorf("expected phase Failed, got %q", updated.Status.Phase)
+	}
+	if updated.Status.Reason != automotivev1alpha1.WorkspaceReasonContainerRuntimeError {
+		t.Errorf("expected reason %q, got %q", automotivev1alpha1.WorkspaceReasonContainerRuntimeError, updated.Status.Reason)
+	}
+	wantMessage := "container toolchain: CreateContainerError: set memory limit 4 too low"
+	if updated.Status.Message != wantMessage {
+		t.Errorf("expected message %q, got %q", wantMessage, updated.Status.Message)
+	}
+}
+
+func TestWorkspacePodStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		pod         *corev1.Pod
+		wantPhase   string
+		wantReason  automotivev1alpha1.WorkspaceStatusReason
+		wantMessage string
+	}{
+		{
+			name: "running",
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name:  containerName,
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+				}},
+			}},
+			wantPhase: "Running",
+		},
+		{
+			name: "transient image pull failure",
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				Phase: corev1.PodPending,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name: containerName,
+					State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
+						Reason:  "ImagePullBackOff",
+						Message: "back-off pulling image",
+					}},
+				}},
+			}},
+			wantPhase:   "Creating",
+			wantReason:  automotivev1alpha1.WorkspaceReasonImagePulling,
+			wantMessage: "container toolchain: ImagePullBackOff: back-off pulling image",
+		},
+		{
+			name: "container configuration failure",
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				Phase: corev1.PodPending,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name: containerName,
+					State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
+						Reason:  "CreateContainerConfigError",
+						Message: "secret not found",
+					}},
+				}},
+			}},
+			wantPhase:   phaseFailed,
+			wantReason:  automotivev1alpha1.WorkspaceReasonContainerConfigError,
+			wantMessage: "container toolchain: CreateContainerConfigError: secret not found",
+		},
+		{
+			name: "crash loop remains retryable",
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name: containerName,
+					State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
+						Reason: "CrashLoopBackOff",
+					}},
+				}},
+			}},
+			wantPhase:   phaseCreating,
+			wantReason:  automotivev1alpha1.WorkspaceReasonContainerRestarting,
+			wantMessage: "container toolchain: CrashLoopBackOff",
+		},
+		{
+			name: "main container terminated",
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name: containerName,
+					State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 137,
+						Reason:   "OOMKilled",
+					}},
+				}},
+			}},
+			wantPhase:   phaseFailed,
+			wantReason:  automotivev1alpha1.WorkspaceReasonContainerExited,
+			wantMessage: "container toolchain: OOMKilled",
+		},
+		{
+			name: "evicted pod uses pod failure details",
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				Phase:   corev1.PodFailed,
+				Reason:  "Evicted",
+				Message: "node was low on memory",
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name: containerName,
+					State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 137,
+						Reason:   "Error",
+					}},
+				}},
+			}},
+			wantPhase:   phaseFailed,
+			wantReason:  automotivev1alpha1.WorkspaceReasonPodFailed,
+			wantMessage: "pod: Evicted: node was low on memory",
+		},
+		{
+			name: "successful init container",
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				InitContainerStatuses: []corev1.ContainerStatus{{
+					Name: "workspace-init",
+					State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 0,
+						Reason:   "Completed",
+					}},
+				}},
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name:  containerName,
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+				}},
+			}},
+			wantPhase: "Running",
+		},
+		{
+			name: "unschedulable",
+			pod: &corev1.Pod{Status: corev1.PodStatus{
+				Phase: corev1.PodPending,
+				Conditions: []corev1.PodCondition{{
+					Type:    corev1.PodScheduled,
+					Status:  corev1.ConditionFalse,
+					Reason:  "Unschedulable",
+					Message: "insufficient cpu",
+				}},
+			}},
+			wantPhase:   "Creating",
+			wantReason:  automotivev1alpha1.WorkspaceReasonScheduling,
+			wantMessage: "pod: Unschedulable: insufficient cpu",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			phase, reason, message := workspacePodStatus(tt.pod)
+			if phase != tt.wantPhase {
+				t.Errorf("workspacePodStatus() phase = %q, want %q", phase, tt.wantPhase)
+			}
+			if reason != tt.wantReason {
+				t.Errorf("workspacePodStatus() reason = %q, want %q", reason, tt.wantReason)
+			}
+			if message != tt.wantMessage {
+				t.Errorf("workspacePodStatus() message = %q, want %q", message, tt.wantMessage)
+			}
+		})
+	}
+}
+
 func TestSetStatus_StoppedClearsPodName(t *testing.T) {
 	ws := &automotivev1alpha1.Workspace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -289,7 +477,7 @@ func TestSetStatus_StoppedClearsPodName(t *testing.T) {
 	r, fc := newTestReconciler(ws)
 	ctx := context.Background()
 
-	err := r.setStatus(ctx, ws, phaseStopped, "")
+	err := r.setStatus(ctx, ws, phaseStopped, "", "")
 	if err != nil {
 		t.Fatalf("setStatus() error = %v", err)
 	}
@@ -321,7 +509,7 @@ func TestSetStatus_RunningSetsPodName(t *testing.T) {
 	r, fc := newTestReconciler(ws)
 	ctx := context.Background()
 
-	err := r.setStatus(ctx, ws, phaseRunning, "")
+	err := r.setStatus(ctx, ws, phaseRunning, "", "")
 	if err != nil {
 		t.Fatalf("setStatus() error = %v", err)
 	}
@@ -355,7 +543,7 @@ func TestSetStatus_NoOpWhenUnchanged(t *testing.T) {
 	ctx := context.Background()
 
 	// Should be a no-op — same phase, same message, same podName
-	err := r.setStatus(ctx, ws, phaseStopped, "")
+	err := r.setStatus(ctx, ws, phaseStopped, "", "")
 	if err != nil {
 		t.Fatalf("setStatus() error = %v", err)
 	}


### PR DESCRIPTION
When the workspace pod fails to start we should report it via CLI and not get stuck on Creating

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace status details now include server-provided reasons and messages.
  * Failed workspaces provide more specific troubleshooting guidance, including log commands for container and pod failures.
  * Timeout messages now include the latest workspace status and recommended next steps.

* **Bug Fixes**
  * Improved detection and reporting of container, pod, scheduling, storage, and image-related failures.
  * Workspace creation now rejects memory requests below 6 Mi with a clear validation error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->