### PR TITLE
fix: append extra_build_repos

### DIFF
--- a/internal/buildapi/extra_repos_test.go
+++ b/internal/buildapi/extra_repos_test.go
@@ -1,0 +1,22 @@
+package buildapi
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAppendWorkspaceRepoCustomDefs(t *testing.T) {
+	req := &BuildRequest{CustomDefs: []string{"existing=value"}}
+	reposJSON := []byte(`[{"id":"workspace-kernel-build","baseurl":"http://10.0.0.1:8080"}]`)
+
+	appendWorkspaceRepoCustomDefs(req, reposJSON)
+
+	want := []string{
+		"existing=value",
+		`extra_repos=[{"id":"workspace-kernel-build","baseurl":"http://10.0.0.1:8080"}]`,
+		`extra_build_repos=[{"id":"workspace-kernel-build","baseurl":"http://10.0.0.1:8080"}]`,
+	}
+	if !reflect.DeepEqual(req.CustomDefs, want) {
+		t.Fatalf("CustomDefs = %#v, want %#v", req.CustomDefs, want)
+	}
+}

--- a/internal/buildapi/server.go
+++ b/internal/buildapi/server.go
@@ -820,7 +820,8 @@ func (a *APIServer) setupInternalRegistryBuild(
 
 // buildExportSpec creates ExportSpec configuration from build request
 // resolveExtraRepos processes --extra-repo flags (workspace:path pairs), starts HTTP
-// servers in the workspace pods, and injects extra_repos into the build's CustomDefs.
+// servers in the workspace pods, and injects the repos into the image and build
+// depsolver CustomDefs.
 func (a *APIServer) resolveExtraRepos(ctx context.Context, k8sClient client.Client, restCfg *rest.Config, req *BuildRequest) error {
 	if len(req.ExtraRepos) == 0 {
 		return nil
@@ -881,8 +882,16 @@ func (a *APIServer) resolveExtraRepos(ctx context.Context, k8sClient client.Clie
 	if err != nil {
 		return fmt.Errorf("marshaling extra_repos: %w", err)
 	}
-	req.CustomDefs = append(req.CustomDefs, fmt.Sprintf("extra_repos=%s", string(reposJSON)))
+	appendWorkspaceRepoCustomDefs(req, reposJSON)
 	return nil
+}
+
+func appendWorkspaceRepoCustomDefs(req *BuildRequest, reposJSON []byte) {
+	repos := string(reposJSON)
+	req.CustomDefs = append(req.CustomDefs,
+		fmt.Sprintf("extra_repos=%s", repos),
+		fmt.Sprintf("extra_build_repos=%s", repos),
+	)
 }
 
 // resolveOCIRepoImages validates the OCI repo image ref and injects a file:// extra_repos


### PR DESCRIPTION
Currently extra_build_repos were not added to the custom definitions so builds were unable to use them via workspaces

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace repository configuration is now included consistently for both image and build dependency resolution.
  * Existing custom build definitions are preserved when workspace repository settings are added.

* **Tests**
  * Added coverage to verify workspace repository definitions are correctly appended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->