### PR TITLE
fix: improve progress reporting

### DIFF
--- a/cmd/caib/ui/progress.go
+++ b/cmd/caib/ui/progress.go
@@ -28,6 +28,8 @@ import (
 	"golang.org/x/term"
 )
 
+const completedPhase = "Completed"
+
 // ProgressBar renders build progress. In a TTY it uses \r overwrite with a
 // visual bar; in non-TTY mode it prints one line per status change.
 // Progress is monotonic: once a higher done count is rendered, lower values
@@ -48,27 +50,23 @@ func (pb *ProgressBar) Render(phase string, step *buildapitypes.BuildStep) {
 	if clilog.IsQuiet() {
 		return
 	}
-	// Work on a local copy to avoid mutating the caller's BuildStep
-	var renderStep *buildapitypes.BuildStep
-	if step != nil {
+	// Keep the label and counts together when a request returns stale data.
+	if step != nil && step.Total > 0 {
 		s := *step
-		// Enforce monotonic progress: never go backwards in Done or Total
-		if pb.highStep != nil {
+		s.Done = max(0, min(s.Done, s.Total))
+		if pb.highStep != nil && phase != completedPhase {
+			s.Total = max(s.Total, pb.highStep.Total)
 			if s.Done < pb.highStep.Done {
-				s.Done = pb.highStep.Done
-			}
-			if s.Total < pb.highStep.Total {
-				s.Total = pb.highStep.Total
+				s = *pb.highStep
 			}
 		}
 		pb.highStep = &s
-		renderStep = &s
 	}
 
 	if pb.isTTY {
-		pb.renderTTY(phase, renderStep)
+		pb.renderTTY(phase, pb.highStep)
 	} else {
-		pb.renderPlain(phase, renderStep)
+		pb.renderPlain(phase, pb.highStep)
 	}
 }
 
@@ -77,6 +75,9 @@ func (pb *ProgressBar) renderTTY(phase string, step *buildapitypes.BuildStep) {
 	var line string
 	if step == nil {
 		line = fmt.Sprintf("\r%-10s ⦿ waiting for progress...", phase)
+		if phase == completedPhase {
+			line = "\r" + completedPhase
+		}
 	} else {
 		barWidth := 30
 		filled := 0
@@ -89,6 +90,7 @@ func (pb *ProgressBar) renderTTY(phase string, step *buildapitypes.BuildStep) {
 	if line == pb.lastLine {
 		return
 	}
+	pb.lastLine = line
 	width, _, err := term.GetSize(int(os.Stdout.Fd()))
 	if err != nil || width <= 0 {
 		width = 80
@@ -100,7 +102,6 @@ func (pb *ProgressBar) renderTTY(phase string, step *buildapitypes.BuildStep) {
 		line += strings.Repeat(" ", width-displayWidth)
 	}
 	_, _ = fmt.Fprint(os.Stdout, line)
-	pb.lastLine = line
 }
 
 // renderPlain renders progress as plain text for non-TTY output
@@ -108,6 +109,9 @@ func (pb *ProgressBar) renderPlain(phase string, step *buildapitypes.BuildStep) 
 	var line string
 	if step == nil {
 		line = fmt.Sprintf("%s: waiting for progress...", phase)
+		if phase == completedPhase {
+			line = completedPhase
+		}
 	} else {
 		line = fmt.Sprintf("%s: [%d/%d] %s", phase, step.Done, step.Total, step.Stage)
 	}
@@ -124,16 +128,18 @@ func (pb *ProgressBar) Complete() {
 	if clilog.IsQuiet() || pb.lastLine == "" {
 		return
 	}
-	total := 8
-	if pb.highStep != nil && pb.highStep.Total > 0 {
-		total = pb.highStep.Total
+	var step *buildapitypes.BuildStep
+	if pb.highStep != nil {
+		step = &buildapitypes.BuildStep{
+			Stage: "Complete",
+			Done:  pb.highStep.Total,
+			Total: pb.highStep.Total,
+		}
 	}
-	pb.Render("Completed", &buildapitypes.BuildStep{
-		Stage: "Complete",
-		Done:  total,
-		Total: total,
-	})
-	_, _ = fmt.Fprintln(os.Stdout)
+	pb.Render(completedPhase, step)
+	if pb.isTTY {
+		_, _ = fmt.Fprintln(os.Stdout)
+	}
 	pb.lastLine = ""
 }
 

--- a/cmd/caib/ui/progress.go
+++ b/cmd/caib/ui/progress.go
@@ -63,10 +63,14 @@ func (pb *ProgressBar) Render(phase string, step *buildapitypes.BuildStep) {
 		pb.highStep = &s
 	}
 
+	renderStep := pb.highStep
+	if phase == completedPhase {
+		renderStep = nil
+	}
 	if pb.isTTY {
-		pb.renderTTY(phase, pb.highStep)
+		pb.renderTTY(phase, renderStep)
 	} else {
-		pb.renderPlain(phase, pb.highStep)
+		pb.renderPlain(phase, renderStep)
 	}
 }
 

--- a/cmd/caib/ui/progress_test.go
+++ b/cmd/caib/ui/progress_test.go
@@ -147,3 +147,66 @@ func TestClear_QuietModeSuppressesOutput(t *testing.T) {
 		t.Errorf("Clear() in quiet mode should produce no output, got: %q", out)
 	}
 }
+
+func TestRenderRetainsLastCheckpoint(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		step *buildapitypes.BuildStep
+	}{
+		{"older checkpoint", &buildapitypes.BuildStep{Stage: "Preparing build", Done: 1, Total: 5}},
+		{"missing checkpoint", nil},
+		{"invalid checkpoint", &buildapitypes.BuildStep{Stage: "Preparing build", Done: 0, Total: 0}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			pb := &ProgressBar{}
+			captureStdout(t, func() {
+				pb.Render("Building", &buildapitypes.BuildStep{Stage: "Building image", Done: 2, Total: 5})
+			})
+			out := captureStdout(t, func() { pb.Render("Building", tt.step) })
+			if out != "" || pb.highStep.Stage != "Building image" || pb.highStep.Done != 2 {
+				t.Fatalf("checkpoint regressed: output=%q step=%+v", out, pb.highStep)
+			}
+		})
+	}
+}
+
+func TestRenderTTYDoesNotRewriteUnchangedLine(t *testing.T) {
+	pb := &ProgressBar{isTTY: true}
+	step := &buildapitypes.BuildStep{Stage: "Building image", Done: 2, Total: 5}
+	captureStdout(t, func() { pb.Render("Building", step) })
+	if out := captureStdout(t, func() { pb.Render("Building", step) }); out != "" {
+		t.Fatalf("unchanged line was written again: %q", out)
+	}
+}
+
+func TestRenderClampsInvalidCountsWithoutMutatingInput(t *testing.T) {
+	for _, done := range []int{-1, 9} {
+		pb := &ProgressBar{isTTY: true}
+		step := &buildapitypes.BuildStep{Stage: "Building image", Done: done, Total: 5}
+		captureStdout(t, func() { pb.Render("Building", step) })
+		if pb.highStep.Done < 0 || pb.highStep.Done > 5 || step.Done != done {
+			t.Fatalf("invalid clamping: rendered=%+v input=%+v", pb.highStep, step)
+		}
+	}
+}
+
+func TestCompleteWithoutCheckpointDoesNotInventCounts(t *testing.T) {
+	pb := &ProgressBar{}
+	captureStdout(t, func() { pb.Render("Building", nil) })
+	if out := captureStdout(t, pb.Complete); out != "Completed\n" {
+		t.Fatalf("completion = %q, want a plain completion message", out)
+	}
+}
+
+func TestRenderCompletionAcceptsCorrectedTotal(t *testing.T) {
+	pb := &ProgressBar{}
+	captureStdout(t, func() {
+		pb.Render("Building", &buildapitypes.BuildStep{Stage: "Building image", Done: 2, Total: 6})
+	})
+	out := captureStdout(t, func() {
+		pb.Render("Completed", &buildapitypes.BuildStep{Stage: "Complete", Done: 4, Total: 4})
+	})
+	if !strings.Contains(out, "[4/4] Complete") {
+		t.Fatalf("completion retained the old estimate: %q", out)
+	}
+}

--- a/cmd/caib/ui/progress_test.go
+++ b/cmd/caib/ui/progress_test.go
@@ -2,7 +2,6 @@ package ui
 
 import (
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/centos-automotive-suite/automotive-dev-operator/cmd/caib/clilog"
@@ -33,7 +32,7 @@ func captureStdout(t *testing.T, fn func()) string {
 	return string(buf[:n])
 }
 
-func TestComplete_RendersFullBar(t *testing.T) {
+func TestComplete_RendersCompleted(t *testing.T) {
 	// Use a non-TTY progress bar (isTTY=false) so output goes through renderPlain
 	pb := &ProgressBar{isTTY: false}
 
@@ -44,16 +43,12 @@ func TestComplete_RendersFullBar(t *testing.T) {
 		Total: 8,
 	})
 
-	// Call Complete — this should render a final fully-filled state
 	out := captureStdout(t, func() {
 		pb.Complete()
 	})
 
-	if !strings.Contains(out, "8/8") {
-		t.Errorf("Complete() should render full progress (8/8), got: %q", out)
-	}
-	if !strings.Contains(out, "Complete") {
-		t.Errorf("Complete() should show 'Complete' stage, got: %q", out)
+	if out != "Completed\n" {
+		t.Errorf("Complete() should render completion, got: %q", out)
 	}
 }
 
@@ -71,8 +66,8 @@ func TestComplete_UsesHighStepTotal(t *testing.T) {
 		pb.Complete()
 	})
 
-	if !strings.Contains(out, "6/6") {
-		t.Errorf("Complete() should use the tracked total (6/6), got: %q", out)
+	if out != "Completed\n" || pb.highStep.Done != 6 || pb.highStep.Total != 6 {
+		t.Errorf("Complete() should use the tracked total and render completion, got: %q step=%+v", out, pb.highStep)
 	}
 }
 
@@ -206,7 +201,7 @@ func TestRenderCompletionAcceptsCorrectedTotal(t *testing.T) {
 	out := captureStdout(t, func() {
 		pb.Render("Completed", &buildapitypes.BuildStep{Stage: "Complete", Done: 4, Total: 4})
 	})
-	if !strings.Contains(out, "[4/4] Complete") {
-		t.Fatalf("completion retained the old estimate: %q", out)
+	if out != "Completed\n" || pb.highStep.Done != 4 || pb.highStep.Total != 4 {
+		t.Fatalf("completion retained the old estimate: %q step=%+v", out, pb.highStep)
 	}
 }

--- a/internal/buildapi/progress.go
+++ b/internal/buildapi/progress.go
@@ -24,6 +24,9 @@ const (
 	progressCacheTTL        = 10 * time.Second
 	progressCacheMaxEntries = 256
 	buildImageTask          = "build-image"
+	flashImageTask          = "flash-image"
+	pushDiskArtifactTask    = "push-disk-artifact"
+	pushDiskArtifactS3Task  = "push-disk-artifact-s3"
 )
 
 type progressCacheEntry struct {
@@ -105,11 +108,11 @@ func stageForPipelineTask(taskName string) string {
 	switch taskName {
 	case buildImageTask:
 		return "Starting build"
-	case "push-disk-artifact":
+	case pushDiskArtifactTask:
 		return "Pushing artifact"
-	case "push-disk-artifact-s3":
+	case pushDiskArtifactS3Task:
 		return "Pushing to S3"
-	case "flash-image":
+	case flashImageTask:
 		return "Flashing device"
 	default:
 		return taskName
@@ -262,7 +265,7 @@ func buildProgressStep(
 	var pushReported, s3Reported, flashReported bool
 	for _, tp := range tasks {
 		total := tp.marker.Total
-		if tp.taskName == "build-image" {
+		if tp.taskName == buildImageTask {
 			total = buildTotal
 		} else {
 			combinedTotal += total

--- a/internal/buildapi/progress.go
+++ b/internal/buildapi/progress.go
@@ -23,6 +23,7 @@ import (
 const (
 	progressCacheTTL        = 10 * time.Second
 	progressCacheMaxEntries = 256
+	buildImageTask          = "build-image"
 )
 
 type progressCacheEntry struct {
@@ -75,8 +76,9 @@ type BuildStep struct {
 
 // taskProgress holds the latest marker from a single pipeline task pod.
 type taskProgress struct {
-	taskName string
-	marker   BuildStep
+	taskName  string
+	marker    BuildStep
+	completed bool
 }
 
 // parseProgressAnnotation parses a pod annotation value with the format
@@ -87,11 +89,11 @@ func parseProgressAnnotation(value string) (*BuildStep, bool) {
 		return nil, false
 	}
 	done, err := strconv.Atoi(parts[1])
-	if err != nil {
+	if err != nil || done < 0 {
 		return nil, false
 	}
 	total, err := strconv.Atoi(parts[2])
-	if err != nil {
+	if err != nil || total <= 0 || done > total || strings.TrimSpace(parts[0]) == "" {
 		return nil, false
 	}
 	return &BuildStep{Stage: parts[0], Done: done, Total: total}, true
@@ -101,8 +103,12 @@ func parseProgressAnnotation(value string) (*BuildStep, bool) {
 // that may not have a progress annotation yet.
 func stageForPipelineTask(taskName string) string {
 	switch taskName {
+	case buildImageTask:
+		return "Starting build"
 	case "push-disk-artifact":
 		return "Pushing artifact"
+	case "push-disk-artifact-s3":
+		return "Pushing to S3"
 	case "flash-image":
 		return "Flashing device"
 	default:
@@ -157,22 +163,29 @@ func readTaskProgressFromPods(ctx context.Context, cs *kubernetes.Clientset, pip
 
 		if ann, ok := pod.Annotations[labels.Progress]; ok {
 			if step, parsed := parseProgressAnnotation(ann); parsed {
-				results = append(results, taskProgress{taskName: taskName, marker: *step})
+				results = append(results, taskProgress{taskName: taskName, marker: *step, completed: pod.Status.Phase == corev1.PodSucceeded})
 				continue
 			}
 		}
 
 		// Synthesize a marker for pods that don't have the annotation
 		// yet so the progress bar advances when tasks start running.
+		total := 1
+		if taskName == buildImageTask {
+			// The build contains several checkpoints; use the spec estimate
+			// until its first annotation supplies the actual total.
+			total = 0
+		}
 		switch pod.Status.Phase {
 		case corev1.PodRunning, corev1.PodSucceeded:
 			done := 0
 			if pod.Status.Phase == corev1.PodSucceeded {
-				done = 1
+				done = total
 			}
 			results = append(results, taskProgress{
-				taskName: taskName,
-				marker:   BuildStep{Stage: stageForPipelineTask(taskName), Done: done, Total: 1},
+				taskName:  taskName,
+				marker:    BuildStep{Stage: stageForPipelineTask(taskName), Done: done, Total: total},
+				completed: pod.Status.Phase == corev1.PodSucceeded,
 			})
 		case corev1.PodPending:
 			// Surface image-pull or container-creating status so the
@@ -180,7 +193,7 @@ func readTaskProgressFromPods(ctx context.Context, cs *kubernetes.Clientset, pip
 			if stage := pendingPodStage(&pod); stage != "" {
 				results = append(results, taskProgress{
 					taskName: taskName,
-					marker:   BuildStep{Stage: stage, Done: 0, Total: 1},
+					marker:   BuildStep{Stage: stage, Done: 0, Total: total},
 				})
 			}
 		}
@@ -235,29 +248,44 @@ func buildProgressStep(
 	hasClusterRegistryRoute bool,
 ) *BuildStep {
 	hasPushTask := strings.TrimSpace(build.Spec.GetExportOCI()) != "" && strings.TrimSpace(build.Spec.SecretRef) != ""
+	hasS3Task := strings.TrimSpace(build.Spec.GetS3Bucket()) != ""
 	hasFlashTask := build.Spec.IsFlashEnabled()
 
-	// Sum up totals from all task markers and find the active task.
-	// Also track whether push/flash tasks already reported markers
-	// so we don't double-count them in the pipeline total.
-	var combinedTotal, combinedDone int
-	var activeStage string
-	var pushReported, flashReported bool
+	buildTotal := estimateBuildSteps(build, hasClusterRegistryRoute)
 	for _, tp := range tasks {
-		combinedTotal += tp.marker.Total
-		combinedDone += tp.marker.Done
-		activeStage = tp.marker.Stage
+		if tp.taskName == buildImageTask && tp.marker.Total > 0 {
+			buildTotal = tp.marker.Total
+		}
+	}
+	combinedTotal, combinedDone := buildTotal, 0
+	var activeStage string
+	var pushReported, s3Reported, flashReported bool
+	for _, tp := range tasks {
+		total := tp.marker.Total
+		if tp.taskName == "build-image" {
+			total = buildTotal
+		} else {
+			combinedTotal += total
+		}
+		if tp.completed {
+			combinedDone += total
+		} else {
+			combinedDone += clampDone(tp.marker.Done, total)
+			activeStage = tp.marker.Stage
+		}
 		if tp.taskName == "push-disk-artifact" {
 			pushReported = true
+		}
+		if tp.taskName == "push-disk-artifact-s3" {
+			s3Reported = true
 		}
 		if tp.taskName == "flash-image" {
 			flashReported = true
 		}
 	}
 
-	// Use spec-based estimate when no markers have arrived yet
-	if combinedTotal == 0 {
-		combinedTotal = estimateBuildSteps(build, hasClusterRegistryRoute)
+	if activeStage == "" && len(tasks) > 0 {
+		activeStage = "Finalizing build"
 	}
 
 	// Pipeline total = build task steps + push + flash.
@@ -265,6 +293,9 @@ func buildProgressStep(
 	// their own markers yet (avoids double-counting).
 	pipelineTotal := combinedTotal
 	if hasPushTask && !pushReported {
+		pipelineTotal++
+	}
+	if hasS3Task && !s3Reported {
 		pipelineTotal++
 	}
 	if hasFlashTask && !flashReported {
@@ -369,8 +400,16 @@ func (a *APIServer) handleGetProgress(c *gin.Context) {
 		a.progressCacheMu.Unlock()
 	}
 
-	// Estimate builder-prepare steps only when no task markers exist yet.
-	if len(tasks) == 0 {
+	// Synthetic pod markers have no build total, so they still need the
+	// registry-aware estimate used before the build pod exists.
+	hasBuildTotal := false
+	for _, tp := range tasks {
+		if tp.taskName == "build-image" && tp.marker.Total > 0 {
+			hasBuildTotal = true
+			break
+		}
+	}
+	if !hasBuildTotal {
 		mode := Mode(build.Spec.GetMode())
 		if build.Spec.GetBuilderImage() == "" && (mode == ModeBootc || mode == ModeDisk) {
 			if route, err := getExternalRegistryRoute(ctx, k8sClient, namespace); err == nil && strings.TrimSpace(route) != "" {

--- a/internal/buildapi/progress_test.go
+++ b/internal/buildapi/progress_test.go
@@ -1,9 +1,20 @@
 package buildapi
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	automotivev1alpha1 "github.com/centos-automotive-suite/automotive-dev-operator/api/v1alpha1"
+	"github.com/centos-automotive-suite/automotive-dev-operator/internal/common/labels"
 	. "github.com/onsi/ginkgo/v2" //nolint:revive
 	. "github.com/onsi/gomega"    //nolint:revive
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 var _ = Describe("pendingPodStage", func() {
@@ -70,3 +81,137 @@ var _ = Describe("pendingPodStage", func() {
 		Expect(pendingPodStage(pod)).To(BeEmpty())
 	})
 })
+
+func TestBuildProgressAcrossPodTransitions(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		pods  []*corev1.Pod
+		stage string
+		done  int
+	}{
+		{name: "before pod creation", stage: "Starting build"},
+		{name: "pulling build image", pods: []*corev1.Pod{progressTestPod("build-image", corev1.PodPending, "", 1)}, stage: "Pulling image"},
+		{name: "before first checkpoint", pods: []*corev1.Pod{progressTestPod("build-image", corev1.PodRunning, "", 1)}, stage: "Starting build"},
+		{name: "preparing", pods: []*corev1.Pod{progressTestPod("build-image", corev1.PodRunning, "Preparing build|1|4", 1)}, stage: "Preparing build", done: 1},
+		{name: "building", pods: []*corev1.Pod{progressTestPod("build-image", corev1.PodRunning, "Building image|2|4", 1)}, stage: "Building image", done: 2},
+		{name: "finished pod with stale checkpoint", pods: []*corev1.Pod{progressTestPod("build-image", corev1.PodSucceeded, "Preparing build|1|4", 1)}, stage: "Finalizing build", done: 4},
+		{name: "finished pod without checkpoint", pods: []*corev1.Pod{progressTestPod("build-image", corev1.PodSucceeded, "", 1)}, stage: "Finalizing build", done: 4},
+		{name: "starting push", pods: []*corev1.Pod{
+			progressTestPod("build-image", corev1.PodSucceeded, "Compressing artifacts|3|4", 1),
+			progressTestPod("push-disk-artifact", corev1.PodPending, "", 2),
+		}, stage: "Pulling image", done: 4},
+		{name: "pushing", pods: []*corev1.Pod{
+			progressTestPod("build-image", corev1.PodSucceeded, "Compressing artifacts|3|4", 1),
+			progressTestPod("push-disk-artifact", corev1.PodRunning, "Pushing artifact|0|1", 2),
+		}, stage: "Pushing artifact", done: 4},
+		{name: "push completed without final checkpoint", pods: []*corev1.Pod{
+			progressTestPod("build-image", corev1.PodSucceeded, "Compressing artifacts|3|4", 1),
+			progressTestPod("push-disk-artifact", corev1.PodSucceeded, "Pushing artifact|0|1", 2),
+		}, stage: "Finalizing build", done: 5},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			build := &automotivev1alpha1.ImageBuild{
+				Spec: automotivev1alpha1.ImageBuildSpec{
+					AIB:       &automotivev1alpha1.AIBSpec{Mode: "image"},
+					SecretRef: "registry-auth",
+					Export:    &automotivev1alpha1.ExportSpec{Disk: &automotivev1alpha1.DiskExport{OCI: "registry.example/test"}},
+				},
+				Status: automotivev1alpha1.ImageBuildStatus{Phase: phaseBuilding},
+			}
+			cs := progressTestClient(t, tt.pods...)
+			tasks := readTaskProgressFromPods(t.Context(), cs, "test-run", "test-ns")
+			got := buildProgressStep(build, tasks, false)
+			want := BuildStep{Stage: tt.stage, Done: tt.done, Total: 5}
+			if *got != want {
+				t.Fatalf("progress = %+v, want %+v", *got, want)
+			}
+		})
+	}
+}
+
+func TestBuildProgressIncludesS3BeforeItsPodExists(t *testing.T) {
+	build := &automotivev1alpha1.ImageBuild{
+		Spec: automotivev1alpha1.ImageBuildSpec{
+			AIB: &automotivev1alpha1.AIBSpec{Mode: "image"},
+			Export: &automotivev1alpha1.ExportSpec{Disk: &automotivev1alpha1.DiskExport{
+				S3: &automotivev1alpha1.S3Export{Bucket: "test-bucket"},
+			}},
+		},
+		Status: automotivev1alpha1.ImageBuildStatus{Phase: phaseBuilding},
+	}
+	initial := buildProgressStep(build, nil, false)
+	cs := progressTestClient(t,
+		progressTestPod("build-image", corev1.PodSucceeded, "Preparing build|1|4", 1),
+		progressTestPod("push-disk-artifact-s3", corev1.PodRunning, "", 2),
+	)
+	tasks := readTaskProgressFromPods(t.Context(), cs, "test-run", "test-ns")
+	pushing := buildProgressStep(build, tasks, false)
+	if initial.Total != 5 || pushing.Total != 5 || pushing.Done != 4 || pushing.Stage != "Pushing to S3" {
+		t.Fatalf("incorrect S3 progress: initial=%+v pushing=%+v", initial, pushing)
+	}
+}
+
+func TestBuildProgressEstimatesBuilderStepsBeforeAnnotations(t *testing.T) {
+	build := &automotivev1alpha1.ImageBuild{
+		Spec:   automotivev1alpha1.ImageBuildSpec{AIB: &automotivev1alpha1.AIBSpec{Mode: "bootc"}},
+		Status: automotivev1alpha1.ImageBuildStatus{Phase: phaseBuilding},
+	}
+	cs := progressTestClient(t, progressTestPod("build-image", corev1.PodPending, "", 1))
+	tasks := readTaskProgressFromPods(t.Context(), cs, "test-run", "test-ns")
+	got := buildProgressStep(build, tasks, true)
+	if got.Total != 5 || got.Done != 0 {
+		t.Fatalf("synthetic checkpoint changed the build estimate: %+v", got)
+	}
+}
+
+func TestParseProgressAnnotationValidatesCounts(t *testing.T) {
+	for _, value := range []string{"Building|-1|4", "Building|5|4", "Building|0|0", "Building|0|-1", "|1|4", "Building|one|4"} {
+		if _, ok := parseProgressAnnotation(value); ok {
+			t.Errorf("accepted invalid checkpoint %q", value)
+		}
+	}
+	if got, ok := parseProgressAnnotation("Pushing artifact|0|1"); !ok || got.Done != 0 || got.Total != 1 {
+		t.Fatalf("rejected valid checkpoint: %+v", got)
+	}
+}
+
+func progressTestPod(task string, phase corev1.PodPhase, annotation string, start int64) *corev1.Pod {
+	startTime := metav1.NewTime(time.Unix(start, 0))
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: task, Namespace: "test-ns",
+			Labels: map[string]string{"tekton.dev/pipelineRun": "test-run", "tekton.dev/memberOf": "tasks", "tekton.dev/pipelineTask": task},
+		},
+		Status: corev1.PodStatus{Phase: phase, StartTime: &startTime},
+	}
+	if annotation != "" {
+		pod.Annotations = map[string]string{labels.Progress: annotation}
+	}
+	if phase == corev1.PodPending {
+		pod.Status.ContainerStatuses = []corev1.ContainerStatus{{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ContainerCreating"}}}}
+	}
+	return pod
+}
+
+func progressTestClient(t *testing.T, pods ...*corev1.Pod) *kubernetes.Clientset {
+	t.Helper()
+	list := corev1.PodList{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "PodList"}}
+	for _, pod := range pods {
+		list.Items = append(list.Items, *pod)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/namespaces/test-ns/pods" || r.URL.Query().Get("labelSelector") != "tekton.dev/pipelineRun=test-run,tekton.dev/memberOf=tasks" {
+			t.Errorf("unexpected pod query: %s", r.URL)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(list); err != nil {
+			t.Errorf("encode pods: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	cs, err := kubernetes.NewForConfig(&rest.Config{Host: srv.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cs
+}

--- a/internal/common/tasks/progress_test.go
+++ b/internal/common/tasks/progress_test.go
@@ -1,0 +1,62 @@
+package tasks
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestProgressCheckpointsAreDeliveredInOrder(t *testing.T) {
+	dir := t.TempDir()
+	script := `
+cat() { printf 'test'; }
+curl() {
+  case "$*" in
+    *'Preparing build'*) sleep 0.2; printf 'preparing\n' >> "$PROGRESS_TEST_LOG" ;;
+    *'Building image'*) printf 'building\n' >> "$PROGRESS_TEST_LOG" ;;
+    *'Finalizing build'*) printf 'finalizing\n' >> "$PROGRESS_TEST_LOG" ;;
+  esac
+}
+emit_progress "Preparing build" 1 4
+emit_progress "Building image" 2 4
+emit_progress "Finalizing build" 4 4
+`
+	logPath := filepath.Join(dir, "checkpoints")
+	runProgressScript(t, script, "PROGRESS_TEST_LOG="+logPath)
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "preparing\nbuilding\nfinalizing\n" {
+		t.Fatalf("updates arrived out of order: %q", data)
+	}
+}
+
+func TestProgressFailureWarnsAndAllowsBuildToContinue(t *testing.T) {
+	out := runProgressScript(t, `
+cat() { printf 'test'; }
+curl() { return 22; }
+emit_progress "Building image" 2 4
+printf 'build continues\n'
+`)
+	if !strings.Contains(out, "could not report build progress: Building image") || !strings.Contains(out, "build continues") {
+		t.Fatalf("missing failure warning or build continuation: %q", out)
+	}
+}
+
+func runProgressScript(t *testing.T, body string, env ...string) string {
+	t.Helper()
+	preamble, _, ok := strings.Cut(commonScript, "\nwrite_result()")
+	if !ok {
+		t.Fatal("progress helper missing from common script")
+	}
+	cmd := exec.Command("bash", "-c", preamble+"\n"+body)
+	cmd.Env = append(os.Environ(), env...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("progress script failed: %v\n%s", err, out)
+	}
+	return string(out)
+}

--- a/internal/common/tasks/scripts/common.sh
+++ b/internal/common/tasks/scripts/common.sh
@@ -6,15 +6,19 @@ set -e
 
 emit_progress() {
   local stage="$1" done="$2" total="$3"
-  # Run in background to avoid blocking the build on API server round-trip
-  (curl -s --connect-timeout 3 --max-time 5 \
+  # Serialize checkpoints so a delayed update cannot overwrite a newer stage,
+  # and finish the final update before the task exits. Failure must not fail a build.
+  if ! curl --fail --silent --show-error --connect-timeout 2 --max-time 3 \
+    --retry 2 --retry-delay 1 --retry-max-time 10 --retry-connrefused \
     --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
     -X PATCH \
     -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
     -H "Content-Type: application/merge-patch+json" \
     "https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)/pods/${HOSTNAME}" \
     -d "{\"metadata\":{\"annotations\":{\"automotive.sdv.cloud.redhat.com/progress\":\"${stage}|${done}|${total}\"}}}" \
-    > /dev/null 2>&1 || true) &
+    > /dev/null; then
+    echo "Warning: could not report build progress: $stage" >&2
+  fi
 }
 
 write_result() {


### PR DESCRIPTION
Serialize the patches, instead of keeping them in the background and add missing stages

## Summary
<!-- Brief description of what this PR does -->

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Refactoring

## Testing
- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] Manifests are up to date (`make manifests generate`)
- [ ] Tested on OpenShift cluster (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Progress displays remain accurate across task transitions and retain the latest valid checkpoint.
  * Invalid progress values are safely constrained, and completion totals reflect corrected build information.
  * Completion is clearly shown even when no progress checkpoint is available.
  * Progress includes S3 artifact publishing and provides a finalizing status when no active stage is reported.
  * Progress updates complete reliably, with failures reported as warnings without stopping the build.

* **Tests**
  * Added coverage for progress rendering, validation, task transitions, S3 publishing, and checkpoint delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->